### PR TITLE
Added a default value of 'log' for all logger annotations.

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -48,7 +48,7 @@ public class HandleLog {
 		throw new UnsupportedOperationException();
 	}
 	
-	public static void processAnnotation(LoggingFramework framework, AnnotationValues<? extends java.lang.annotation.Annotation> annotation, Annotation source, EclipseNode annotationNode) {
+	public static void processAnnotation(LoggingFramework framework, AnnotationValues<? extends java.lang.annotation.Annotation> annotation, Annotation source, EclipseNode annotationNode, String fieldName) {
 		EclipseNode owner = annotationNode.up();
 		switch (owner.getKind()) {
 		case TYPE:
@@ -64,14 +64,14 @@ public class HandleLog {
 				return;
 			}
 			
-			if (fieldExists("log", owner) != MemberExistsResult.NOT_EXISTS) {
-				annotationNode.addWarning("Field 'log' already exists.");
+			if (fieldExists(fieldName, owner) != MemberExistsResult.NOT_EXISTS) {
+				annotationNode.addWarning(String.format("Field '%s' already exists.", fieldName));
 				return;
 			}
 			
 			ClassLiteralAccess loggingType = selfType(owner, source);
 			
-			FieldDeclaration fieldDeclaration = createField(framework, source, loggingType);
+			FieldDeclaration fieldDeclaration = createField(framework, source, loggingType, fieldName);
 			fieldDeclaration.traverse(new SetGeneratedByVisitor(source), typeDecl.staticInitializerScope);
 			// TODO temporary workaround for issue 217. http://code.google.com/p/projectlombok/issues/detail?id=217
 			// injectFieldSuppressWarnings(owner, fieldDeclaration);
@@ -97,13 +97,13 @@ public class HandleLog {
 		return result;
 	}
 	
-	public static FieldDeclaration createField(LoggingFramework framework, Annotation source, ClassLiteralAccess loggingType) {
+	public static FieldDeclaration createField(LoggingFramework framework, Annotation source, ClassLiteralAccess loggingType, String fieldName) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long)pS << 32 | pE;
 		
 		// 	private static final <loggerType> log = <factoryMethod>(<parameter>);
 
-		FieldDeclaration fieldDecl = new FieldDeclaration("log".toCharArray(), 0, -1);
+		FieldDeclaration fieldDecl = new FieldDeclaration(fieldName.toCharArray(), 0, -1);
 		setGeneratedBy(fieldDecl, source);
 		fieldDecl.declarationSourceEnd = -1;
 		fieldDecl.modifiers = Modifier.PRIVATE | Modifier.STATIC | Modifier.FINAL;
@@ -155,7 +155,7 @@ public class HandleLog {
 	@ProviderFor(EclipseAnnotationHandler.class)
 	public static class HandleCommonsLog extends EclipseAnnotationHandler<lombok.extern.apachecommons.CommonsLog> {
 		@Override public void handle(AnnotationValues<lombok.extern.apachecommons.CommonsLog> annotation, Annotation source, EclipseNode annotationNode) {
-			processAnnotation(LoggingFramework.COMMONS, annotation, source, annotationNode);
+			processAnnotation(LoggingFramework.COMMONS, annotation, source, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -165,7 +165,7 @@ public class HandleLog {
 	@ProviderFor(EclipseAnnotationHandler.class)
 	public static class HandleJulLog extends EclipseAnnotationHandler<lombok.extern.java.Log> {
 		@Override public void handle(AnnotationValues<lombok.extern.java.Log> annotation, Annotation source, EclipseNode annotationNode) {
-			processAnnotation(LoggingFramework.JUL, annotation, source, annotationNode);
+			processAnnotation(LoggingFramework.JUL, annotation, source, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -175,7 +175,7 @@ public class HandleLog {
 	@ProviderFor(EclipseAnnotationHandler.class)
 	public static class HandleLog4jLog extends EclipseAnnotationHandler<lombok.extern.log4j.Log4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.log4j.Log4j> annotation, Annotation source, EclipseNode annotationNode) {
-			processAnnotation(LoggingFramework.LOG4J, annotation, source, annotationNode);
+			processAnnotation(LoggingFramework.LOG4J, annotation, source, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -185,7 +185,7 @@ public class HandleLog {
 	@ProviderFor(EclipseAnnotationHandler.class)
 	public static class HandleLog4j2Log extends EclipseAnnotationHandler<lombok.extern.log4j.Log4j2> {
 		@Override public void handle(AnnotationValues<lombok.extern.log4j.Log4j2> annotation, Annotation source, EclipseNode annotationNode) {
-			processAnnotation(LoggingFramework.LOG4J2, annotation, source, annotationNode);
+			processAnnotation(LoggingFramework.LOG4J2, annotation, source, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -195,7 +195,7 @@ public class HandleLog {
 	@ProviderFor(EclipseAnnotationHandler.class)
 	public static class HandleSlf4jLog extends EclipseAnnotationHandler<lombok.extern.slf4j.Slf4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.slf4j.Slf4j> annotation, Annotation source, EclipseNode annotationNode) {
-			processAnnotation(LoggingFramework.SLF4J, annotation, source, annotationNode);
+			processAnnotation(LoggingFramework.SLF4J, annotation, source, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -205,7 +205,7 @@ public class HandleLog {
 	@ProviderFor(EclipseAnnotationHandler.class)
 	public static class HandleXSlf4jLog extends EclipseAnnotationHandler<lombok.extern.slf4j.XSlf4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.slf4j.XSlf4j> annotation, Annotation source, EclipseNode annotationNode) {
-			processAnnotation(LoggingFramework.XSLF4J, annotation, source, annotationNode);
+			processAnnotation(LoggingFramework.XSLF4J, annotation, source, annotationNode, annotation.getInstance().value());
 		}
 	}
 	

--- a/src/core/lombok/extern/apachecommons/CommonsLog.java
+++ b/src/core/lombok/extern/apachecommons/CommonsLog.java
@@ -59,4 +59,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface CommonsLog {
+	String value() default "log";
 }

--- a/src/core/lombok/extern/java/Log.java
+++ b/src/core/lombok/extern/java/Log.java
@@ -58,4 +58,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Log {
+	String value() default "log";
 }

--- a/src/core/lombok/extern/log4j/Log4j.java
+++ b/src/core/lombok/extern/log4j/Log4j.java
@@ -59,4 +59,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Log4j {
+	String value() default "log";
 }

--- a/src/core/lombok/extern/log4j/Log4j2.java
+++ b/src/core/lombok/extern/log4j/Log4j2.java
@@ -59,4 +59,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Log4j2 {
+	String value() default "log";
 }

--- a/src/core/lombok/extern/slf4j/Slf4j.java
+++ b/src/core/lombok/extern/slf4j/Slf4j.java
@@ -56,4 +56,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Slf4j {
+	String value() default "log";
 }

--- a/src/core/lombok/extern/slf4j/XSlf4j.java
+++ b/src/core/lombok/extern/slf4j/XSlf4j.java
@@ -57,4 +57,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface XSlf4j {
+	String value() default "log";
 }

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -48,7 +48,7 @@ public class HandleLog {
 		throw new UnsupportedOperationException();
 	}
 	
-	public static void processAnnotation(LoggingFramework framework, AnnotationValues<?> annotation, JavacNode annotationNode) {
+	public static void processAnnotation(LoggingFramework framework, AnnotationValues<?> annotation, JavacNode annotationNode, String fieldName) {
 		deleteAnnotationIfNeccessary(annotationNode, framework.getAnnotationClass());
 		
 		JavacNode typeNode = annotationNode.up();
@@ -59,13 +59,13 @@ public class HandleLog {
 				return;
 			}
 			
-			if (fieldExists("log", typeNode)!= MemberExistsResult.NOT_EXISTS) {
-				annotationNode.addWarning("Field 'log' already exists.");
+			if (fieldExists(fieldName, typeNode)!= MemberExistsResult.NOT_EXISTS) {
+				annotationNode.addWarning(String.format("Field '%s' already exists.", fieldName));
 				return;
 			}
 			
 			JCFieldAccess loggingType = selfType(typeNode);
-			createField(framework, typeNode, loggingType, annotationNode.get());
+			createField(framework, typeNode, loggingType, annotationNode.get(), fieldName);
 			break;
 		default:
 			annotationNode.addError("@Log is legal only on types.");
@@ -79,7 +79,7 @@ public class HandleLog {
 		return maker.Select(maker.Ident(name), typeNode.toName("class"));
 	}
 	
-	public static boolean createField(LoggingFramework framework, JavacNode typeNode, JCFieldAccess loggingType, JCTree source) {
+	public static boolean createField(LoggingFramework framework, JavacNode typeNode, JCFieldAccess loggingType, JCTree source, String fieldName) {
 		JavacTreeMaker maker = typeNode.getTreeMaker();
 		
 		// private static final <loggerType> log = <factoryMethod>(<parameter>);
@@ -91,7 +91,7 @@ public class HandleLog {
 		
 		JCVariableDecl fieldDecl = recursiveSetGeneratedBy(maker.VarDef(
 				maker.Modifiers(Flags.PRIVATE | Flags.FINAL | Flags.STATIC),
-				typeNode.toName("log"), loggerType, factoryMethodCall), source, typeNode.getContext());
+				typeNode.toName(fieldName), loggerType, factoryMethodCall), source, typeNode.getContext());
 		
 		injectFieldSuppressWarnings(typeNode, fieldDecl);
 		return true;
@@ -103,7 +103,7 @@ public class HandleLog {
 	@ProviderFor(JavacAnnotationHandler.class)
 	public static class HandleCommonsLog extends JavacAnnotationHandler<lombok.extern.apachecommons.CommonsLog> {
 		@Override public void handle(AnnotationValues<lombok.extern.apachecommons.CommonsLog> annotation, JCAnnotation ast, JavacNode annotationNode) {
-			processAnnotation(LoggingFramework.COMMONS, annotation, annotationNode);
+			processAnnotation(LoggingFramework.COMMONS, annotation, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -113,7 +113,7 @@ public class HandleLog {
 	@ProviderFor(JavacAnnotationHandler.class)
 	public static class HandleJulLog extends JavacAnnotationHandler<lombok.extern.java.Log> {
 		@Override public void handle(AnnotationValues<lombok.extern.java.Log> annotation, JCAnnotation ast, JavacNode annotationNode) {
-			processAnnotation(LoggingFramework.JUL, annotation, annotationNode);
+			processAnnotation(LoggingFramework.JUL, annotation, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -123,7 +123,7 @@ public class HandleLog {
 	@ProviderFor(JavacAnnotationHandler.class)
 	public static class HandleLog4jLog extends JavacAnnotationHandler<lombok.extern.log4j.Log4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.log4j.Log4j> annotation, JCAnnotation ast, JavacNode annotationNode) {
-			processAnnotation(LoggingFramework.LOG4J, annotation, annotationNode);
+			processAnnotation(LoggingFramework.LOG4J, annotation, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -133,7 +133,7 @@ public class HandleLog {
 	@ProviderFor(JavacAnnotationHandler.class)
 	public static class HandleLog4j2Log extends JavacAnnotationHandler<lombok.extern.log4j.Log4j2> {
 		@Override public void handle(AnnotationValues<lombok.extern.log4j.Log4j2> annotation, JCAnnotation ast, JavacNode annotationNode) {
-			processAnnotation(LoggingFramework.LOG4J2, annotation, annotationNode);
+			processAnnotation(LoggingFramework.LOG4J2, annotation, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -143,7 +143,7 @@ public class HandleLog {
 	@ProviderFor(JavacAnnotationHandler.class)
 	public static class HandleSlf4jLog extends JavacAnnotationHandler<lombok.extern.slf4j.Slf4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.slf4j.Slf4j> annotation, JCAnnotation ast, JavacNode annotationNode) {
-			processAnnotation(LoggingFramework.SLF4J, annotation, annotationNode);
+			processAnnotation(LoggingFramework.SLF4J, annotation, annotationNode, annotation.getInstance().value());
 		}
 	}
 	
@@ -153,7 +153,7 @@ public class HandleLog {
 	@ProviderFor(JavacAnnotationHandler.class)
 	public static class HandleXSlf4jLog extends JavacAnnotationHandler<lombok.extern.slf4j.XSlf4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.slf4j.XSlf4j> annotation, JCAnnotation ast, JavacNode annotationNode) {
-			processAnnotation(LoggingFramework.XSLF4J, annotation, annotationNode);
+			processAnnotation(LoggingFramework.XSLF4J, annotation, annotationNode, annotation.getInstance().value());
 		}
 	}
 	


### PR DESCRIPTION
All log annotations generate a field named "log". 
In order to override this name, I added the following to each annotation :
```java
String value() default "log";
```
I then used this value instead of the hardcoded "log".
The default value should make this compatible with existing code.