### PR TITLE
Improve @Tolerate, so it really works with @EqualsAndHashCode.

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -1099,14 +1099,28 @@ public class EclipseHandlerUtil {
 		
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
+	/**
+	 * Wrapper for {@link #methodExists(String, EclipseNode, boolean, int, boolean)} with {@code caseSensitive} = {@code true} and {@code honorTolerate} = {@code false}.
+	 */
+	public static MemberExistsResult methodReallyExists(String methodName, EclipseNode node, int params) {
+		return methodExists(methodName, node, true, params, false);
+	}
+
 	/**
 	 * Wrapper for {@link #methodExists(String, EclipseNode, boolean, int)} with {@code caseSensitive} = {@code true}.
 	 */
 	public static MemberExistsResult methodExists(String methodName, EclipseNode node, int params) {
 		return methodExists(methodName, node, true, params);
 	}
-	
+
+	/**
+	 * Wrapper for {@link #methodExists(String, EclipseNode, boolean, int, boolean)} with {@code honorTolerate} = {@code true}.
+	 */
+	public static MemberExistsResult methodExists(String methodName, EclipseNode node, boolean caseSensitive, int params) {
+		return methodExists(methodName, node, caseSensitive, params, true);
+	}
+
 	/**
 	 * Checks if there is a method with the provided name. In case of multiple methods (overloading), only
 	 * the first method decides if EXISTS_BY_USER or EXISTS_BY_LOMBOK is returned.
@@ -1115,8 +1129,9 @@ public class EclipseHandlerUtil {
 	 * @param node Any node that represents the Type (TypeDeclaration) to look in, or any child node thereof.
 	 * @param caseSensitive If the search should be case sensitive.
 	 * @param params The number of parameters the method should have; varargs count as 0-*. Set to -1 to find any method with the appropriate name regardless of parameter count.
+	 * @param honorTolerate If true, then methods annotated with {@code Tolerate} will be ignored.
 	 */
-	public static MemberExistsResult methodExists(String methodName, EclipseNode node, boolean caseSensitive, int params) {
+	private static MemberExistsResult methodExists(String methodName, EclipseNode node, boolean caseSensitive, int params, boolean honorTolerate) {
 		while (node != null && !(node.get() instanceof TypeDeclaration)) {
 			node = node.up();
 		}
@@ -1146,7 +1161,7 @@ public class EclipseHandlerUtil {
 						}
 						
 						if (def.annotations != null) for (Annotation anno : def.annotations) {
-							if (typeMatches(Tolerate.class, node, anno.type)) continue top;
+							if (honorTolerate && typeMatches(Tolerate.class, node, anno.type)) continue top;
 						}
 						
 						return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;

--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -238,9 +238,11 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 			//fallthrough
 		}
 		
-		MethodDeclaration equalsMethod = createEquals(typeNode, nodesForEquality, callSuper, errorNode.get(), fieldAccess, needsCanEqual, onParam);
-		equalsMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
-		injectMethod(typeNode, equalsMethod);
+		if (methodReallyExists("equals", typeNode, 1) == MemberExistsResult.NOT_EXISTS) {
+			MethodDeclaration equalsMethod = createEquals(typeNode, nodesForEquality, callSuper, errorNode.get(), fieldAccess, needsCanEqual, onParam);
+			equalsMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
+			injectMethod(typeNode, equalsMethod);
+		}
 		
 		if (needsCanEqual && canEqualExists == MemberExistsResult.NOT_EXISTS) {
 			MethodDeclaration canEqualMethod = createCanEqual(typeNode, errorNode.get(), onParam);
@@ -248,9 +250,11 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 			injectMethod(typeNode, canEqualMethod);
 		}
 		
-		MethodDeclaration hashCodeMethod = createHashCode(typeNode, nodesForEquality, callSuper, errorNode.get(), fieldAccess);
-		hashCodeMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
-		injectMethod(typeNode, hashCodeMethod);
+		if (methodReallyExists("hashCode", typeNode, 0) == MemberExistsResult.NOT_EXISTS) {
+			MethodDeclaration hashCodeMethod = createHashCode(typeNode, nodesForEquality, callSuper, errorNode.get(), fieldAccess);
+			hashCodeMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
+			injectMethod(typeNode, hashCodeMethod);
+		}
 	}
 	
 	public MethodDeclaration createHashCode(EclipseNode type, Collection<EclipseNode> fields, boolean callSuper, ASTNode source, FieldAccess fieldAccess) {

--- a/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
@@ -212,16 +212,20 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 			//fallthrough
 		}
 		
-		JCMethodDecl equalsMethod = createEquals(typeNode, nodesForEquality.toList(), callSuper, fieldAccess, needsCanEqual, source.get(), onParam);
-		injectMethod(typeNode, equalsMethod);
+		if (methodReallyExists("equals", typeNode, 1) == MemberExistsResult.NOT_EXISTS) {
+			JCMethodDecl equalsMethod = createEquals(typeNode, nodesForEquality.toList(), callSuper, fieldAccess, needsCanEqual, source.get(), onParam);
+			injectMethod(typeNode, equalsMethod);
+		}
 		
 		if (needsCanEqual && canEqualExists == MemberExistsResult.NOT_EXISTS) {
 			JCMethodDecl canEqualMethod = createCanEqual(typeNode, source.get(), onParam);
 			injectMethod(typeNode, canEqualMethod);
 		}
 		
-		JCMethodDecl hashCodeMethod = createHashCode(typeNode, nodesForEquality.toList(), callSuper, fieldAccess, source.get());
-		injectMethod(typeNode, hashCodeMethod);
+		if (methodReallyExists("hashCode", typeNode, 0) == MemberExistsResult.NOT_EXISTS) {
+			JCMethodDecl hashCodeMethod = createHashCode(typeNode, nodesForEquality.toList(), callSuper, fieldAccess, source.get());
+			injectMethod(typeNode, hashCodeMethod);
+		}
 	}
 	
 	public JCMethodDecl createHashCode(JavacNode typeNode, List<JavacNode> fields, boolean callSuper, FieldAccess fieldAccess, JCTree source) {

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -550,9 +550,17 @@ public class JavacHandlerUtil {
 		
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
+	public static MemberExistsResult methodReallyExists(String methodName, JavacNode node, int params) {
+		return methodExists(methodName, node, true, params, false);
+	}
+
 	public static MemberExistsResult methodExists(String methodName, JavacNode node, int params) {
 		return methodExists(methodName, node, true, params);
+	}
+	
+	public static MemberExistsResult methodExists(String methodName, JavacNode node, boolean caseSensitive, int params) {
+		return methodExists(methodName, node, caseSensitive, params, true);
 	}
 	
 	/**
@@ -563,8 +571,9 @@ public class JavacHandlerUtil {
 	 * @param node Any node that represents the Type (JCClassDecl) to look in, or any child node thereof.
 	 * @param caseSensitive If the search should be case sensitive.
 	 * @param params The number of parameters the method should have; varargs count as 0-*. Set to -1 to find any method with the appropriate name regardless of parameter count.
+	 * @param honorTolerate If true, then methods annotated with {@code Tolerate} will be ignored.
 	 */
-	public static MemberExistsResult methodExists(String methodName, JavacNode node, boolean caseSensitive, int params) {
+	private static MemberExistsResult methodExists(String methodName, JavacNode node, boolean caseSensitive, int params, boolean honorTolerate) {
 		node = upToTypeNode(node);
 		
 		if (node != null && node.get() instanceof JCClassDecl) {
@@ -593,7 +602,7 @@ public class JavacHandlerUtil {
 						
 						List<JCAnnotation> annotations = md.getModifiers().getAnnotations();
 						if (annotations != null) for (JCAnnotation anno : annotations) {
-							if (typeMatches(Tolerate.class, node, anno.getAnnotationType())) continue top;
+							if (honorTolerate && typeMatches(Tolerate.class, node, anno.getAnnotationType())) continue top;
 						}
 						
 						return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;

--- a/test/transform/resource/after-delombok/Tolerate.java
+++ b/test/transform/resource/after-delombok/Tolerate.java
@@ -47,3 +47,34 @@ class Tolerate2 {
 		this.pattern = pattern;
 	}
 }
+final class Tolerate3 {
+	private final java.math.RoundingMode mode;
+	
+	@lombok.experimental.Tolerate
+	public int hashCode() {
+		return 123456789 * mode.ordinal();
+	}
+	
+	@java.lang.SuppressWarnings("all")
+	public java.math.RoundingMode getMode() {
+		return this.mode;
+	}
+	
+	@java.beans.ConstructorProperties({"mode"})
+	@java.lang.SuppressWarnings("all")
+	public Tolerate3(final java.math.RoundingMode mode) {
+		this.mode = mode;
+	}
+	
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public boolean equals(final java.lang.Object o) {
+		if (o == this) return true;
+		if (!(o instanceof Tolerate3)) return false;
+		final Tolerate3 other = (Tolerate3)o;
+		final java.lang.Object this$mode = this.getMode();
+		final java.lang.Object other$mode = other.getMode();
+		if (this$mode == null ? other$mode != null : !this$mode.equals(other$mode)) return false;
+		return true;
+	}
+}

--- a/test/transform/resource/after-ecj/Tolerate.java
+++ b/test/transform/resource/after-ecj/Tolerate.java
@@ -33,3 +33,28 @@ import java.util.regex.Pattern;
     this.pattern = pattern;
   }
 }
+final @lombok.Getter @lombok.AllArgsConstructor @lombok.EqualsAndHashCode class Tolerate3 {
+  private final java.math.RoundingMode mode;
+  public @lombok.experimental.Tolerate int hashCode() {
+    return (123456789 * mode.ordinal());
+  }
+  public @java.lang.SuppressWarnings("all") java.math.RoundingMode getMode() {
+    return this.mode;
+  }
+  public @java.beans.ConstructorProperties({"mode"}) @java.lang.SuppressWarnings("all") Tolerate3(final java.math.RoundingMode mode) {
+    super();
+    this.mode = mode;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") boolean equals(final java.lang.Object o) {
+    if ((o == this))
+        return true;
+    if ((! (o instanceof Tolerate3)))
+        return false;
+    final @java.lang.SuppressWarnings("all") Tolerate3 other = (Tolerate3) o;
+    final java.lang.Object this$mode = this.getMode();
+    final java.lang.Object other$mode = other.getMode();
+    if (((this$mode == null) ? (other$mode != null) : (! this$mode.equals(other$mode))))
+        return false;
+    return true;
+  }
+}

--- a/test/transform/resource/before/Tolerate.java
+++ b/test/transform/resource/before/Tolerate.java
@@ -21,3 +21,12 @@ class Tolerate2 {
 		return withPattern(nameGlob.replace("*", ".*") + "\\." + extensionGlob.replace("*", ".*"));
 	}
 }
+
+@lombok.Getter @lombok.AllArgsConstructor @lombok.EqualsAndHashCode
+final class Tolerate3 {
+	private final java.math.RoundingMode mode;
+
+	@lombok.experimental.Tolerate public int hashCode() {
+		return 123456789 * mode.ordinal();
+	}
+}


### PR DESCRIPTION
It was possible to e.g. let Lombok ignore a preexisting `hashCode` using `@Tolerate`, but then both `equals` and `hashCode` were generated.

That's totally wrong. Generating the missing method only makes sense and there are two good use cases:
1. For perfect reproducibility, I need a deterministic `hashCode` (so that my HashSet gets always iterated in the same order), but there are some fields of type `Enum` or `Class`. When I compute the `hashCode` manually I can easily handle such fields specially. The generated `equals` has no such problem, so I want to use it.
2. With a value object, I precompute and store the `hashCode` for speed. Again, the generated `equals` fits perfectly. This is something Lombok could do itself, but for now there's just this workaround.
