### PR TITLE
Minor, put installer window on correct location

### DIFF
--- a/src/installer/lombok/installer/InstallerGUI.java
+++ b/src/installer/lombok/installer/InstallerGUI.java
@@ -101,6 +101,7 @@ public class InstallerGUI {
 	public InstallerGUI() {
 		appWindow = new JFrame(String.format("Project Lombok v%s - Installer", Version.getVersion()));
 		
+		appWindow.setLocationByPlatform(true);
 		appWindow.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		appWindow.setResizable(false);
 		appWindow.setIconImage(Toolkit.getDefaultToolkit().getImage(Installer.class.getResource("lombokIcon.png")));


### PR DESCRIPTION
When installer window is opened, it would be much better if it would be in a correct location specified by OS instead being at most top left.