### PR TITLE
Adding annotation for creating Utility Classes easily

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Lombok contributors in alphabetical order:
 
 Christian Sterzl <christian.sterzl@gmail.com>
 Jappe van der Hel <jappe.vanderhel@gmail.com>
+Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>
 Philipp Eichhorn <peichhor@web.de>
 Reinier Zwitserloot <reinier@zwitserloot.com>
@@ -9,6 +10,5 @@ Robbert Jan Grootjans <grootjans@gmail.com>
 Roel Spilker <r.spilker@gmail.com>
 Sander Koning <askoning@gmail.com>
 Taiki Sugawara <buzz.taiki@gmail.com>
-
 
 By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok, and you certify that you have the right to do so for all commits you add to Project Lombok.

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -376,6 +376,14 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> WITHER_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.wither.flagUsage", "Emit a warning or error if @Wither is used.") {};
 	
+	// ----- UtilityClass -----
+	
+	/**
+	 * lombok configuration: {@code lombok.utilityClass.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 * 
+	 * If set, <em>any</em> usage of {@code @UtilityClass} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> UTLITY_CLASS_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.utilityClass.flagUsage", "Emit a warning or error if @UtilityClass is used.") {};
 	
 	// ----- Configuration System -----
 	

--- a/src/core/lombok/experimental/UtilityClass.java
+++ b/src/core/lombok/experimental/UtilityClass.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2012-2013 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.experimental;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A helper to create utilities classes.
+ * <p>
+ * It makes the class final, makes all its methods static, creates a private default constructor that throws a RuntimeException when called and yields an error when other constructors are defined.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+public @interface UtilityClass {
+}

--- a/src/core/lombok/javac/handlers/HandleUtilityClass.java
+++ b/src/core/lombok/javac/handlers/HandleUtilityClass.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2012-2014 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import static lombok.core.handlers.HandlerUtil.handleExperimentalFlagUsage;
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+import lombok.ConfigurationKeys;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.experimental.UtilityClass;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+
+import org.mangosdk.spi.ProviderFor;
+
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCModifiers;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+
+/**
+ * Handles the {@code lombok.experimental.UtilityClass} annotation for javac.
+ */
+@ProviderFor(JavacAnnotationHandler.class) public class HandleUtilityClass extends JavacAnnotationHandler<UtilityClass> {
+
+	@Override public void handle(AnnotationValues<UtilityClass> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.UTLITY_CLASS_FLAG_USAGE, "@UtilityClass");
+		deleteAnnotationIfNeccessary(annotationNode, UtilityClass.class);
+
+		parse(annotationNode.up(), annotationNode);
+	}
+
+	private JCClassDecl getClassDecl(JavacNode typeNode) {
+		JCClassDecl typeDecl = null;
+		if (typeNode.get() instanceof JCClassDecl) {
+			typeDecl = (JCClassDecl) typeNode.get();
+		}
+
+		long modifiers = typeDecl == null ? 0 : typeDecl.mods.flags;
+		boolean notAClass = (modifiers & (Flags.INTERFACE | Flags.ANNOTATION | Flags.ENUM)) != 0;
+		return notAClass ? null : typeDecl;
+	}
+
+	public void parse(JavacNode typeNode, JavacNode errorNode) {
+		JCClassDecl classDecl = getClassDecl(typeNode);
+		if (classDecl == null) {
+			errorNode.addError("@UtilityClass is only supported on a class (can't be interface, enum or annotation).");
+			return;
+		}
+
+		if (!is(classDecl.getModifiers(), Flags.FINAL)) {
+			classDecl.mods.flags |= Flags.FINAL;
+		}
+
+		for (JavacNode element : typeNode.down()) {
+			if (element.getKind() == Kind.FIELD) {
+				JCVariableDecl fieldDecl = (JCVariableDecl) element.get();
+				if (!is(fieldDecl.mods, Flags.STATIC)) {
+					fieldDecl.mods.flags |= Flags.STATIC;
+				}
+			} else if (element.getKind() == Kind.METHOD) {
+				JCMethodDecl methodDecl = (JCMethodDecl) element.get();
+				if (methodDecl.name.contentEquals("<init>")) {
+					if (!is(methodDecl.mods, Flags.GENERATEDCONSTR)) {
+						errorNode.addError("@UtilityClasses cannot have declared constructors.");
+						continue;
+					}
+				} else if (!is(methodDecl.mods, Flags.STATIC)) {
+					methodDecl.mods.flags |= Flags.STATIC;
+				}
+			} else if (element.getKind() == Kind.TYPE) {
+				JCClassDecl innerClassDecl = (JCClassDecl) typeNode.get();
+				if (!is(innerClassDecl.mods, Flags.STATIC)) {
+					innerClassDecl.mods.flags |= Flags.STATIC;
+				}
+			}
+		}
+
+		createPrivateDefaultConstructor(typeNode);
+	}
+
+	private static boolean is(JCModifiers mods, long f) {
+		return (mods.flags & f) != 0;
+	}
+
+	private void createPrivateDefaultConstructor(JavacNode typeNode) {
+		JavacTreeMaker maker = typeNode.getTreeMaker();
+		JCModifiers mods = maker.Modifiers(Flags.PRIVATE, List.<JCAnnotation>nil());
+		
+		Name name = typeNode.toName("<init>");
+		JCBlock block = maker.Block(0L, createThrowStatement(typeNode, maker));
+		JCMethodDecl methodDef = maker.MethodDef(mods, name, null, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), block, null);
+		JCMethodDecl constructor = recursiveSetGeneratedBy(methodDef, typeNode.get(), typeNode.getContext());
+		JavacHandlerUtil.injectMethod(typeNode, constructor);
+	}
+	
+	private List<JCStatement> createThrowStatement(JavacNode typeNode, JavacTreeMaker maker) {
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+		JCExpression exceptionType = genTypeRef(typeNode, "java.lang.RuntimeException");
+		JCExpression exceptionInstance = maker.NewClass(null, List.<JCExpression>nil(), exceptionType, List.<JCExpression>of(maker.Literal("Should not be instanciated!")), null);
+		JCStatement throwStatement = maker.Throw(exceptionInstance);
+		statements.add(throwStatement);
+		return statements.toList();
+	}
+}


### PR DESCRIPTION
Hello! I'd like to say first that I love your project. It is amazing what it opens up with Java, and serves mainly just to show how powerful and extensible this amazing language is.  
This is a feature I am missing very much in the pack for a while now. When we make Utility Classes, i.e., classes only with static methods, we should define a private default constructor, to override the public one that is created if none is presented, and avoid misuse of the class. The best practices would even ask for it to throw and exception when called, to avoid it being used internally or via reflection.  
This class level annotation creates that for you, checks if no other constructors are defined, and also makes all fields, methods and inner classes static, as well as marking the class final for documentation purposes (even though it could not be subclassed already due to lack of constructors). Simple as that.  
I am attaching a pull request, but it is more of a proof of concept. I did it for javac and it works fine. I noticed that I need to add a handler for eclipse as well, which is very odd (doesn't it use javac in the end as well?), but I had no luck in making it work on eclipse (there is a similar but different API, and I can't seem to get any grasp of it). I'll add here any news on that. There is also no documentation (website and whatnot). I did create a ConfigurationKey, because I inspired in the other annotations, yet I don't quite understand what that is for, apart from being some sort of custom switch or something.  
Anyway, what do you guys think of this idea? Of course the name of the annotation and other details can be easily changed, e.g., it can yield an error if you create a non-static member, instead of defaulting them.