### PR TITLE
Lazy annotation for making lazy methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Lombok contributors in alphabetical order:
 
 Christian Sterzl <christian.sterzl@gmail.com>
+Georgy Vlasov <wlasowegor@gmail.com>
 Jappe van der Hel <jappe.vanderhel@gmail.com>
 Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>

--- a/src/core/lombok/Lazy.java
+++ b/src/core/lombok/Lazy.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2013-2015 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package lombok;
 
 import java.lang.annotation.ElementType;

--- a/src/core/lombok/Lazy.java
+++ b/src/core/lombok/Lazy.java
@@ -1,0 +1,11 @@
+package lombok;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Lazy {
+}

--- a/src/core/lombok/javac/handlers/HandleLazy.java
+++ b/src/core/lombok/javac/handlers/HandleLazy.java
@@ -1,0 +1,184 @@
+package lombok.javac.handlers;
+
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Name;
+import lombok.Lazy;
+import lombok.core.AnnotationValues;
+import lombok.javac.Javac;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import org.mangosdk.spi.ProviderFor;
+
+import java.lang.reflect.Modifier;
+
+@ProviderFor(JavacAnnotationHandler.class)
+@SuppressWarnings("restriction")
+public final class HandleLazy extends JavacAnnotationHandler<Lazy> {
+    @Override
+    public void handle(
+            AnnotationValues<Lazy> annotation,
+            JCTree.JCAnnotation ast,
+            JavacNode annotationNode
+    ) {
+        new AnnotatedMethod(annotationNode).addLaziness();
+    }
+
+    private class AnnotatedMethod {
+        private final JavacNode annotationNode;
+        private final Name originalMethodName;
+        private final JCTree.JCMethodDecl renamedBehaviorMethod;
+        private StorageField storageField;
+
+        public AnnotatedMethod(
+                JavacNode annotationNode
+        ) {
+
+            this.annotationNode = annotationNode;
+            this.renamedBehaviorMethod = ((JCTree.JCMethodDecl) annotationNode.up().get());
+            this.originalMethodName = renamedBehaviorMethod.name;
+            this.storageField = new StorageField(annotationNode);
+        }
+
+        public void addLaziness() {
+            addField();
+            renameOriginalMethod();
+            addLazyMethodInPlaceOfOriginal();
+        }
+
+        private void addLazyMethodInPlaceOfOriginal() {
+            JavacHandlerUtil.injectMethod(
+                    getClassNode(),
+                    new LazyMethod(
+                            this,
+                            storageField
+                    )
+            );
+        }
+
+        private JavacTreeMaker treeMaker() {
+            return annotationNode.getTreeMaker();
+        }
+
+        private void renameOriginalMethod() {
+            renamedBehaviorMethod.name = movedBehaviorMethodName();
+        }
+
+        private void addField() {
+            JavacHandlerUtil.injectField(
+                    getClassNode(),
+                    storageField
+            );
+        }
+
+        private JavacNode getClassNode() {
+            return annotationNode.up().up();
+        }
+
+        private Name movedBehaviorMethodName() {
+            return Name.fromString(originalMethodName.table, "$behavior$").append(originalMethodName);
+        }
+    }
+
+    private static class StorageField extends JCTree.JCVariableDecl {
+        public StorageField(JavacNode annotationNode) {
+            super(
+                    mods(annotationNode),
+                    name(annotationNode),
+                    vartype(annotationNode),
+                    init(annotationNode),
+                    sym(annotationNode)
+            );
+        }
+
+        private static JCModifiers mods(JavacNode annotationNode) {
+            return annotationNode.getTreeMaker().Modifiers(Modifier.PRIVATE);
+        }
+
+        private static Name name(JavacNode annotationNode) {
+            return annotationNode.toName("$lazy$" + annotationNode.up().getName());
+        }
+
+        private static JCExpression vartype(JavacNode annotationNode) {
+            return annotationNode.getTreeMaker().Type(
+                    annotationNode.up().get().type
+            );
+        }
+
+        private static JCExpression init(JavacNode annotationNode) {
+            return annotationNode.getTreeMaker().Literal(null);
+        }
+
+        private static Symbol.VarSymbol sym(JavacNode annotationNode) {
+            // TODO: What should I create here?
+            return null;
+        }
+    }
+
+    private static class LazyMethod extends JCTree.JCMethodDecl {
+
+        LazyMethod(
+                AnnotatedMethod originalMethod,
+                StorageField storageField
+        ) {
+            super(
+                    originalMethod.renamedBehaviorMethod.mods,
+                    originalMethod.originalMethodName,
+                    originalMethod.renamedBehaviorMethod.restype,
+                    originalMethod.renamedBehaviorMethod.typarams,
+                    originalMethod.renamedBehaviorMethod.params,
+                    originalMethod.renamedBehaviorMethod.thrown,
+                    body(originalMethod, storageField),
+                    originalMethod.renamedBehaviorMethod.defaultValue,
+                    originalMethod.renamedBehaviorMethod.sym
+            );
+        }
+
+        private static JCBlock body(AnnotatedMethod originalMethod, StorageField storageField) {
+            JavacTreeMaker maker = originalMethod.treeMaker();
+            JCIdent storageFieldIdent = maker.Ident(storageField.name);
+            return maker.Block(
+                    0,
+                    List.of(
+                            maker.If(
+                                    maker.Binary(
+                                            Javac.CTC_EQUAL,
+                                            storageFieldIdent,
+                                            maker.Literal(
+                                                    Javac.CTC_BOT,
+                                                    null
+                                            )
+                                    ),
+                                    maker.Call(
+                                            maker.Assign(
+                                                    storageFieldIdent,
+                                                    createMethodApplication(originalMethod)
+                                            )
+                                    ),
+                                    null
+                            ),
+                            maker.Return(storageFieldIdent)
+                    )
+            );
+        }
+
+        private static JCExpression createMethodApplication(AnnotatedMethod originalMethod) {
+            JavacTreeMaker maker = originalMethod.treeMaker();
+            return maker.App(
+                    maker.Select(
+                            maker.Ident(
+                                    getLangThisName(originalMethod)
+                            ),
+                            originalMethod.renamedBehaviorMethod.name
+                    )
+            );
+        }
+
+        private static Name getLangThisName(AnnotatedMethod originalMethod) {
+            return originalMethod.renamedBehaviorMethod.getName().table._this;
+        }
+    }
+
+}

--- a/src/core/lombok/javac/handlers/HandleLazy.java
+++ b/src/core/lombok/javac/handlers/HandleLazy.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2013-2015 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package lombok.javac.handlers;
 
 import com.sun.tools.javac.tree.JCTree;

--- a/test/transform/resource/after-delombok/LazyMultipleMethods.java
+++ b/test/transform/resource/after-delombok/LazyMultipleMethods.java
@@ -1,30 +1,33 @@
+import java.lang.Deprecated;
+
 class LazyMultipleMethods {
+    @java.lang.SuppressWarnings("all")
+    @javax.annotation.Generated("lombok")
+    private LazyMultipleMethods $lazy$thisObject;
+    @java.lang.SuppressWarnings("all")
+    @javax.annotation.Generated("lombok")
     private String $lazy$myFavouriteDrummer;
 
-    private LazyMultipleMethods $lazy$thisObject;
-
-
-    @lombok.Lazy
     String myFavouriteDrummer() {
-        if (this.$lazy$myFavouriteDrummer == null) {
-            this.$lazy$myFavouriteDrummer = $behavior$myFavouriteDrummer();
-        }
-        return this.$lazy$myFavouriteDrummer;
+        if ($lazy$myFavouriteDrummer == null) $lazy$myFavouriteDrummer = $behavior$myFavouriteDrummer();
+        return $lazy$myFavouriteDrummer;
     }
 
-    String $behavior$myFavouriteDrummer() {
+    @Deprecated
+    public LazyMultipleMethods thisObject() {
+        if ($lazy$thisObject == null) $lazy$thisObject = $behavior$thisObject();
+        return $lazy$thisObject;
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @javax.annotation.Generated("lombok")
+    private String $behavior$myFavouriteDrummer() {
         return "Christian Vander";
     }
 
-    @lombok.Lazy
-    LazyMultipleMethods thisObject() {
-        if (this.$lazy$thisObject == null) {
-            this.$lazy$thisObject = $behavior$thisObject();
-        }
-        return this.$lazy$thisObject;
-    }
-
-    LazyMultipleMethods $behavior$thisObject() {
+    @java.lang.SuppressWarnings("all")
+    @javax.annotation.Generated("lombok")
+    private LazyMultipleMethods $behavior$thisObject() {
         return new LazyMultipleMethods();
     }
 }

--- a/test/transform/resource/after-delombok/LazyMultipleMethods.java
+++ b/test/transform/resource/after-delombok/LazyMultipleMethods.java
@@ -1,0 +1,30 @@
+class LazyMultipleMethods {
+    private String $lazy$myFavouriteDrummer;
+
+    private LazyMultipleMethods $lazy$thisObject;
+
+
+    @lombok.Lazy
+    String myFavouriteDrummer() {
+        if (this.$lazy$myFavouriteDrummer == null) {
+            this.$lazy$myFavouriteDrummer = $behavior$myFavouriteDrummer();
+        }
+        return this.$lazy$myFavouriteDrummer;
+    }
+
+    String $behavior$myFavouriteDrummer() {
+        return "Christian Vander";
+    }
+
+    @lombok.Lazy
+    LazyMultipleMethods thisObject() {
+        if (this.$lazy$thisObject == null) {
+            this.$lazy$thisObject = $behavior$thisObject();
+        }
+        return this.$lazy$thisObject;
+    }
+
+    LazyMultipleMethods $behavior$thisObject() {
+        return new LazyMultipleMethods();
+    }
+}

--- a/test/transform/resource/after-ecj/LazyMultipleMethods.java
+++ b/test/transform/resource/after-ecj/LazyMultipleMethods.java
@@ -1,0 +1,12 @@
+class LazyMultipleMethods {
+
+    @lombok.Lazy
+    String myFavouriteDrummer() {
+        return "Christian" + " " + "Vander";
+    }
+
+    @lombok.Lazy
+    LazyMultipleMethods thisObject() {
+        return new LazyMultipleMethods();
+    }
+}

--- a/test/transform/resource/after-ecj/LazyMultipleMethods.java
+++ b/test/transform/resource/after-ecj/LazyMultipleMethods.java
@@ -1,3 +1,5 @@
+import java.lang.Deprecated;
+
 class LazyMultipleMethods {
 
     @lombok.Lazy
@@ -6,7 +8,8 @@ class LazyMultipleMethods {
     }
 
     @lombok.Lazy
-    LazyMultipleMethods thisObject() {
+    @Deprecated
+    public LazyMultipleMethods thisObject() {
         return new LazyMultipleMethods();
     }
 }

--- a/test/transform/resource/before/LazyMultipleMethods.java
+++ b/test/transform/resource/before/LazyMultipleMethods.java
@@ -1,0 +1,12 @@
+class LazyMultipleMethods {
+
+    @lombok.Lazy
+    String myFavouriteDrummer() {
+        return "Christian" + " " + "Vander";
+    }
+
+    @lombok.Lazy
+    LazyMultipleMethods thisObject() {
+        return new LazyMultipleMethods();
+    }
+}

--- a/test/transform/resource/before/LazyMultipleMethods.java
+++ b/test/transform/resource/before/LazyMultipleMethods.java
@@ -1,3 +1,5 @@
+import java.lang.Deprecated;
+
 class LazyMultipleMethods {
 
     @lombok.Lazy
@@ -6,7 +8,8 @@ class LazyMultipleMethods {
     }
 
     @lombok.Lazy
-    LazyMultipleMethods thisObject() {
+    @Deprecated
+    public LazyMultipleMethods thisObject() {
         return new LazyMultipleMethods();
     }
 }


### PR DESCRIPTION
Added a handler for Lazy annotation. 

This annotation can be applied to methods so their result is computed only once and stored in a generated private field.

The idea behind this annotation is to emphasise object's behavior over the details about how and where the computed data is stored.

Lombok code:

```
public final class Triangle implements Bounded {
  @Lazy 
  @Override
  public Rectangle boundingRectangle() {
    return // compute bounding rectangle for a triangle
  }
}
```

Equivalent Java code:

```
public final class Triangle implements Bounded {
  private Rectangle boundingRectangle;

  @Override
  public Rectangle boundingRectangle() {
    if (boundingRectangle == null) {
      boundingRectangle = // compute bounding rectangle
    }
    return boundingRectangle;
  } 
}
```

Currently the annotation has the following deficiencies:
- Doesn't work on methods that return primitives;
- Doesn't have the Eclipse compiler implementation.
