### PR TITLE
Add callSuper to @Data and @Value

### DIFF
--- a/src/core/lombok/Data.java
+++ b/src/core/lombok/Data.java
@@ -56,4 +56,11 @@ public @interface Data {
 	 * Default: No static constructor, instead the normal constructor is public.
 	 */
 	String staticConstructor() default "";
+
+	/**
+	 * Call on the superclass's implementations of {@code toString}, {@code equals} and {@code hashCode}
+	 * before calculating for the fields in this class.
+	 * <strong>default: false</strong>
+	 */
+	boolean callSuper() default false;
 }

--- a/src/core/lombok/Value.java
+++ b/src/core/lombok/Value.java
@@ -55,4 +55,11 @@ public @interface Value {
 	 * Default: No static constructor, instead the normal constructor is public.
 	 */
 	String staticConstructor() default "";
+
+	/**
+	 * Call on the superclass's implementations of {@code toString}, {@code equals} and {@code hashCode}
+	 * before calculating for the fields in this class.
+	 * <strong>default: false</strong>
+	 */
+	boolean callSuper() default false;
 }

--- a/src/core/lombok/eclipse/handlers/HandleData.java
+++ b/src/core/lombok/eclipse/handlers/HandleData.java
@@ -59,7 +59,10 @@ public class HandleData extends EclipseAnnotationHandler<Data> {
 			annotationNode.addError("@Data is only supported on a class.");
 			return;
 		}
-		
+
+		Boolean callSuper = ann.callSuper();
+		if (!annotation.isExplicit("callSuper")) callSuper = null;
+
 		//Careful: Generate the public static constructor (if there is one) LAST, so that any attempt to
 		//'find callers' on the annotation node will find callers of the constructor, which is by far the
 		//most useful of the many methods built by @Data. This trick won't work for the non-static constructor,
@@ -68,8 +71,8 @@ public class HandleData extends EclipseAnnotationHandler<Data> {
 		
 		new HandleGetter().generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
 		new HandleSetter().generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
-		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode);
-		new HandleToString().generateToStringForType(typeNode, annotationNode);
+		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode, callSuper);
+		new HandleToString().generateToStringForType(typeNode, annotationNode, callSuper);
 		new HandleConstructor().generateRequiredArgsConstructor(
 				typeNode, AccessLevel.PUBLIC, ann.staticConstructor(), SkipIfConstructorExists.YES,
 				Collections.<Annotation>emptyList(), annotationNode);

--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -110,13 +110,13 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 		}
 	}
 	
-	public void generateEqualsAndHashCodeForType(EclipseNode typeNode, EclipseNode errorNode) {
+	public void generateEqualsAndHashCodeForType(EclipseNode typeNode, EclipseNode errorNode, Boolean callSuper) {
 		if (hasAnnotation(EqualsAndHashCode.class, typeNode)) {
 			//The annotation will make it happen, so we can skip it.
 			return;
 		}
 		
-		generateMethods(typeNode, errorNode, null, null, null, false, FieldAccess.GETTER, new ArrayList<Annotation>());
+		generateMethods(typeNode, errorNode, null, null, callSuper, false, FieldAccess.GETTER, new ArrayList<Annotation>());
 	}
 	
 	@Override public void handle(AnnotationValues<EqualsAndHashCode> annotation, Annotation ast, EclipseNode annotationNode) {

--- a/src/core/lombok/eclipse/handlers/HandleToString.java
+++ b/src/core/lombok/eclipse/handlers/HandleToString.java
@@ -83,7 +83,7 @@ public class HandleToString extends EclipseAnnotationHandler<ToString> {
 		}
 	}
 	
-	public void generateToStringForType(EclipseNode typeNode, EclipseNode errorNode) {
+	public void generateToStringForType(EclipseNode typeNode, EclipseNode errorNode, Boolean callSuper) {
 		if (hasAnnotation(ToString.class, typeNode)) {
 			//The annotation will make it happen, so we can skip it.
 			return;
@@ -94,7 +94,7 @@ public class HandleToString extends EclipseAnnotationHandler<ToString> {
 			Boolean configuration = typeNode.getAst().readConfiguration(ConfigurationKeys.TO_STRING_INCLUDE_FIELD_NAMES);
 			includeFieldNames = configuration != null ? configuration : ((Boolean)ToString.class.getMethod("includeFieldNames").getDefaultValue()).booleanValue();
 		} catch (Exception ignore) {}
-		generateToString(typeNode, errorNode, null, null, includeFieldNames, null, false, FieldAccess.GETTER);
+		generateToString(typeNode, errorNode, null, null, includeFieldNames, callSuper, false, FieldAccess.GETTER);
 	}
 	
 	public void handle(AnnotationValues<ToString> annotation, Annotation ast, EclipseNode annotationNode) {

--- a/src/core/lombok/eclipse/handlers/HandleValue.java
+++ b/src/core/lombok/eclipse/handlers/HandleValue.java
@@ -73,7 +73,10 @@ public class HandleValue extends EclipseAnnotationHandler<Value> {
 		}
 		
 		new HandleFieldDefaults().generateFieldDefaultsForType(typeNode, annotationNode, AccessLevel.PRIVATE, true, true);
-		
+
+		Boolean callSuper = ann.callSuper();
+		if (!annotation.isExplicit("callSuper")) callSuper = null;
+
 		//Careful: Generate the public static constructor (if there is one) LAST, so that any attempt to
 		//'find callers' on the annotation node will find callers of the constructor, which is by far the
 		//most useful of the many methods built by @Value. This trick won't work for the non-static constructor,
@@ -81,8 +84,8 @@ public class HandleValue extends EclipseAnnotationHandler<Value> {
 		//and hitting 'find callers'.
 		
 		new HandleGetter().generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
-		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode);
-		new HandleToString().generateToStringForType(typeNode, annotationNode);
+		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode, callSuper);
+		new HandleToString().generateToStringForType(typeNode, annotationNode, callSuper);
 		new HandleConstructor().generateAllArgsConstructor(typeNode, AccessLevel.PUBLIC, ann.staticConstructor(), SkipIfConstructorExists.YES,
 				Collections.<Annotation>emptyList(), annotationNode);
 	}

--- a/src/core/lombok/javac/handlers/HandleData.java
+++ b/src/core/lombok/javac/handlers/HandleData.java
@@ -51,14 +51,17 @@ public class HandleData extends JavacAnnotationHandler<Data> {
 			annotationNode.addError("@Data is only supported on a class.");
 			return;
 		}
-		
-		String staticConstructorName = annotation.getInstance().staticConstructor();
-		
+
+		Data ann = annotation.getInstance();
+		String staticConstructorName = ann.staticConstructor();
+		Boolean callSuper = ann.callSuper();
+		if (!annotation.isExplicit("callSuper")) callSuper = null;
+
 		// TODO move this to the end OR move it to the top in eclipse.
 		new HandleConstructor().generateRequiredArgsConstructor(typeNode, AccessLevel.PUBLIC, staticConstructorName, SkipIfConstructorExists.YES, annotationNode);
 		new HandleGetter().generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
 		new HandleSetter().generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
-		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode);
-		new HandleToString().generateToStringForType(typeNode, annotationNode);
+		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode, callSuper);
+		new HandleToString().generateToStringForType(typeNode, annotationNode, callSuper);
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
@@ -114,13 +114,13 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 		generateMethods(typeNode, annotationNode, excludes, includes, callSuper, true, fieldAccess, onParam);
 	}
 	
-	public void generateEqualsAndHashCodeForType(JavacNode typeNode, JavacNode source) {
+	public void generateEqualsAndHashCodeForType(JavacNode typeNode, JavacNode source, Boolean callSuper) {
 		if (hasAnnotation(EqualsAndHashCode.class, typeNode)) {
 			//The annotation will make it happen, so we can skip it.
 			return;
 		}
 		
-		generateMethods(typeNode, source, null, null, null, false, FieldAccess.GETTER, List.<JCAnnotation>nil());
+		generateMethods(typeNode, source, null, null, callSuper, false, FieldAccess.GETTER, List.<JCAnnotation>nil());
 	}
 	
 	public void generateMethods(JavacNode typeNode, JavacNode source, List<String> excludes, List<String> includes,

--- a/src/core/lombok/javac/handlers/HandleToString.java
+++ b/src/core/lombok/javac/handlers/HandleToString.java
@@ -105,7 +105,7 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 		generateToString(typeNode, annotationNode, excludes, includes, includeFieldNames, callSuper, true, fieldAccess);
 	}
 	
-	public void generateToStringForType(JavacNode typeNode, JavacNode errorNode) {
+	public void generateToStringForType(JavacNode typeNode, JavacNode errorNode, Boolean callSuper) {
 		if (hasAnnotation(ToString.class, typeNode)) {
 			//The annotation will make it happen, so we can skip it.
 			return;
@@ -117,7 +117,7 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 			Boolean configuration = typeNode.getAst().readConfiguration(ConfigurationKeys.TO_STRING_INCLUDE_FIELD_NAMES);
 			includeFieldNames = configuration != null ? configuration : ((Boolean)ToString.class.getMethod("includeFieldNames").getDefaultValue()).booleanValue();
 		} catch (Exception ignore) {}
-		generateToString(typeNode, errorNode, null, null, includeFieldNames, null, false, FieldAccess.GETTER);
+		generateToString(typeNode, errorNode, null, null, includeFieldNames, callSuper, false, FieldAccess.GETTER);
 	}
 	
 	public void generateToString(JavacNode typeNode, JavacNode source, List<String> excludes, List<String> includes,

--- a/src/core/lombok/javac/handlers/HandleValue.java
+++ b/src/core/lombok/javac/handlers/HandleValue.java
@@ -63,9 +63,12 @@ public class HandleValue extends JavacAnnotationHandler<Value> {
 			annotationNode.addError("@Value is only supported on a class.");
 			return;
 		}
-		
-		String staticConstructorName = annotation.getInstance().staticConstructor();
-		
+
+		Value ann = annotation.getInstance();
+		String staticConstructorName = ann.staticConstructor();
+		Boolean callSuper = ann.callSuper();
+		if (!annotation.isExplicit("callSuper")) callSuper = null;
+
 		if (!hasAnnotationAndDeleteIfNeccessary(NonFinal.class, typeNode)) {
 			JCModifiers jcm = ((JCClassDecl) typeNode.get()).mods;
 			if ((jcm.flags & Flags.FINAL) == 0) {
@@ -78,7 +81,7 @@ public class HandleValue extends JavacAnnotationHandler<Value> {
 		// TODO move this to the end OR move it to the top in eclipse.
 		new HandleConstructor().generateAllArgsConstructor(typeNode, AccessLevel.PUBLIC, staticConstructorName, SkipIfConstructorExists.YES, annotationNode);
 		new HandleGetter().generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
-		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode);
-		new HandleToString().generateToStringForType(typeNode, annotationNode);
+		new HandleEqualsAndHashCode().generateEqualsAndHashCodeForType(typeNode, annotationNode, callSuper);
+		new HandleToString().generateToStringForType(typeNode, annotationNode, callSuper);
 	}
 }

--- a/test/transform/resource/after-delombok/DataPlain.java
+++ b/test/transform/resource/after-delombok/DataPlain.java
@@ -284,3 +284,39 @@ final class Data6 {
 		return "Data6()";
 	}
 }
+final class Data7 extends Data1 {
+	public Data7(int x) {
+		super(x);
+	}
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	public boolean equals(final java.lang.Object o) {
+		if (o == this) return true;
+		if (!(o instanceof Data7)) return false;
+		final Data7 other = (Data7)o;
+		if (!other.canEqual((java.lang.Object)this)) return false;
+		if (!super.equals(o)) return false;
+		return true;
+	}
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	protected boolean canEqual(final java.lang.Object other) {
+		return other instanceof Data7;
+	}
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	public int hashCode() {
+		final int PRIME = 59;
+		int result = 1;
+		result = result * PRIME + super.hashCode();
+		return result;
+	}
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	public java.lang.String toString() {
+		return "Data7(super=" + super.toString() + ")";
+	}
+}

--- a/test/transform/resource/after-ecj/DataPlain.java
+++ b/test/transform/resource/after-ecj/DataPlain.java
@@ -218,3 +218,32 @@ final @Data class Data6 {
     super();
   }
 }
+final @Data(callSuper = true) class Data7 extends Data1 {
+  public Data7(int x) {
+    super(x);
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @javax.annotation.Generated("lombok") boolean equals(final java.lang.Object o) {
+    if ((o == this))
+        return true;
+    if ((! (o instanceof Data7)))
+        return false;
+    final Data7 other = (Data7) o;
+    if ((! other.canEqual((java.lang.Object) this)))
+        return false;
+    if ((! super.equals(o)))
+        return false;
+    return true;
+  }
+  protected @java.lang.SuppressWarnings("all") @javax.annotation.Generated("lombok") boolean canEqual(final java.lang.Object other) {
+    return (other instanceof Data7);
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @javax.annotation.Generated("lombok") int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = ((result * PRIME) + super.hashCode());
+    return result;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @javax.annotation.Generated("lombok") java.lang.String toString() {
+    return (("Data7(super=" + super.toString()) + ")");
+  }
+}

--- a/test/transform/resource/before/DataPlain.java
+++ b/test/transform/resource/before/DataPlain.java
@@ -25,3 +25,9 @@ class Data5 {
 @Data
 final class Data6 {
 }
+@Data(callSuper = true)
+final class Data7 extends Data1 {
+	public Data7(int x) {
+		super(x);
+	}
+}


### PR DESCRIPTION
With this patch, `@Data(callSuper = true)` becomes an equivalent for additional `@ToString(callSuper = true)` and `@EqualsAndHashCode(callSuper = true)`, because Lombok is about avoiding boilerplate, right?
