### PR TITLE
JUnit: Runner should not invoke fireTestFinished if test was ignored.

### DIFF
--- a/test/core/src/lombok/AbstractRunTests.java
+++ b/test/core/src/lombok/AbstractRunTests.java
@@ -49,23 +49,49 @@ import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
 
 public abstract class AbstractRunTests {
 	private final File dumpActualFilesHere;
-	
-	public AbstractRunTests() {
+	private final boolean ignore;
+	private final LombokTestSource sourceDirectives;
+	private final LombokTestSource expected;
+	private final DirectoryRunner.TestParams params;
+	private final File file;
+
+	public AbstractRunTests(DirectoryRunner.TestParams params, File file) throws Throwable {
+		this.params = params;
+		this.file = file;
 		this.dumpActualFilesHere = findPlaceToDumpActualFiles();
-	}
-	
-	public boolean compareFile(DirectoryRunner.TestParams params, File file) throws Throwable {
 		ConfigurationKeysLoader.LoaderLoader.loadAllConfigurationKeys();
-		final LombokTestSource sourceDirectives = LombokTestSource.readDirectives(file);
-		if (sourceDirectives.isIgnore()) return false;
-		if (!sourceDirectives.versionWithinLimit(params.getVersion())) return false;
-		if (!sourceDirectives.versionWithinLimit(getClasspathVersion())) return false;
-		
-		String fileName = file.getName();
-		LombokTestSource expected = LombokTestSource.read(params.getAfterDirectory(), params.getMessagesDirectory(), fileName);
-		
-		if (expected.isIgnore()) return false;
-		if (!expected.versionWithinLimit(params.getVersion())) return false;
+		sourceDirectives = LombokTestSource.readDirectives(file);
+		boolean ignore = false;
+		if (sourceDirectives.isIgnore()) {
+			ignore = true;
+		} else if (!sourceDirectives.versionWithinLimit(params.getVersion())) {
+			ignore = true;
+		} else if (!sourceDirectives.versionWithinLimit(getClasspathVersion())) {
+			ignore = true;
+		}
+
+		if (!ignore) {
+			String fileName = file.getName();
+			expected = LombokTestSource.read(params.getAfterDirectory(), params.getMessagesDirectory(), fileName);
+
+			if (expected.isIgnore()) {
+				ignore = true;
+			} else if (!expected.versionWithinLimit(params.getVersion())) {
+				ignore = true;
+			}
+		} else {
+			expected = null;
+		}
+
+		this.ignore = ignore;
+	}
+
+	public boolean isIgnore() {
+		return ignore;
+	}
+
+	public void compareFile() throws Throwable {
+
 		
 		LinkedHashSet<CompilerMessage> messages = new LinkedHashSet<CompilerMessage>();
 		StringWriter writer = new StringWriter();
@@ -79,7 +105,6 @@ public abstract class AbstractRunTests {
 		transformCode(messages, writer, file, sourceDirectives.getSpecifiedEncoding(), sourceDirectives.getFormatPreferences());
 		
 		compare(file.getName(), expected, writer.toString(), messages, params.printErrors(), sourceDirectives.isSkipCompareContent() || expected.isSkipCompareContent());
-		return true;
 	}
 	
 	private static int getClasspathVersion() {

--- a/test/core/src/lombok/DirectoryRunner.java
+++ b/test/core/src/lombok/DirectoryRunner.java
@@ -126,6 +126,7 @@ public class DirectoryRunner extends Runner {
 			try {
 				if (!runTest(entry.getKey())) {
 					notifier.fireTestIgnored(testDescription);
+					continue;
 				}
 			} catch (Throwable t) {
 				notifier.fireTestFailure(new Failure(testDescription, t));

--- a/test/core/src/lombok/RunTestsViaDelombok.java
+++ b/test/core/src/lombok/RunTestsViaDelombok.java
@@ -33,7 +33,11 @@ import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
 
 public class RunTestsViaDelombok extends AbstractRunTests {
 	private Delombok delombok = new Delombok();
-	
+
+	public RunTestsViaDelombok(DirectoryRunner.TestParams params, File file) throws Throwable {
+		super(params, file);
+	}
+
 	@Override
 	public void transformCode(Collection<CompilerMessage> messages, StringWriter result, final File file, String encoding, Map<String, String> formatPreferences) throws Throwable {
 		delombok.setVerbose(false);

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -49,6 +49,10 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 
 public class RunTestsViaEcj extends AbstractRunTests {
+	public RunTestsViaEcj(DirectoryRunner.TestParams params, File file) throws Throwable {
+		super(params, file);
+	}
+
 	protected CompilerOptions ecjCompilerOptions() {
 		CompilerOptions options = new CompilerOptions();
 		options.complianceLevel = Eclipse.getLatestEcjCompilerVersionConstant();


### PR DESCRIPTION
As done in `org.junit.runners.BlockJUnit4ClassRunner.runIgnored` if test is ignored, `Runner` should not invoke `fireTestStarted` and `fireTestFinished`. 
This issue leads to problems when running tests in IntelliJ Idea (see https://youtrack.jetbrains.com/issue/IDEA-142279)

Correct alghorithm:
1. Read LombokTestSources
2. If test should be ignored - invoke fireTestIgnored
3. Otherwice: invoke fireTestStarted, run test, invoke fireTestFinished