### PR TITLE
implemented support for annotation arrays as annotation attributes in javac

### DIFF
--- a/src/core/lombok/core/AnnotationValues.java
+++ b/src/core/lombok/core/AnnotationValues.java
@@ -298,6 +298,10 @@ public class AnnotationValues<A extends Annotation> {
 			}
 		}
 		
+		if (guess instanceof AnnotationValues) {
+			return ((AnnotationValues) guess).getInstance();
+		}
+		
 		throw new AnnotationValueDecodeFail(v,
 				"Can't translate a " + guess.getClass() + " to the expected " + expected, pos);
 	}


### PR DESCRIPTION
I'm writing my custom annotations (and handlers) and need to process an annotation in the form

``` java
@MyAnnotation(
    a="a",
    attr={
        @MyAttribute(name="test"),
        @MyAttribute(name="test2")
    })
```

This is not possible in lombok 1.16.4, but with this small changes I got it working. I tested it only using lombok 1.16.4 and javac, as I do not use eclipse.
