### PR TITLE
Updated @Value Java doc to @AllArgsConstructor 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,5 +12,6 @@ Robbert Jan Grootjans <grootjans@gmail.com>
 Roel Spilker <r.spilker@gmail.com>
 Sander Koning <askoning@gmail.com>
 Taiki Sugawara <buzz.taiki@gmail.com>
+Yun Zhi Lin <yun@yunspace.com>
 
 By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok, and you certify that you have the right to do so for all commits you add to Project Lombok.

--- a/src/core/lombok/Value.java
+++ b/src/core/lombok/Value.java
@@ -29,13 +29,13 @@ import java.lang.annotation.Target;
 /**
  * Generates a lot of code which fits with a class that is a representation of an immutable entity.
  * <p>
- * Equivalent to {@code @Getter @FieldDefaults(makeFinal=true, level=AccessLevel.PRIVATE) @RequiredArgsConstructor @ToString @EqualsAndHashCode}.
+ * Equivalent to {@code @Getter @FieldDefaults(makeFinal=true, level=AccessLevel.PRIVATE) @AllArgsConstructor @ToString @EqualsAndHashCode}.
  * <p>
  * Complete documentation is found at <a href="https://projectlombok.org/features/experimental/Value.html">the project lombok features page for &#64;Value</a>.
  * 
  * @see lombok.Getter
  * @see lombok.experimental.FieldDefaults
- * @see lombok.RequiredArgsConstructor
+ * @see lombok.AllArgsConstructor
  * @see lombok.ToString
  * @see lombok.EqualsAndHashCode
  * @see lombok.Data


### PR DESCRIPTION
Current `@Value` java doc incorrectly refers to @RequiredArgsConstructor. This was quite misleading for me when viewing the java doc on the fly within the IDE.