### PR TITLE
Modify createEclipseLaunchForTestEnvironment to generate a launch file

### DIFF
--- a/buildScripts/eclipse-run-tests.template
+++ b/buildScripts/eclipse-run-tests.template
@@ -26,5 +26,5 @@
 	<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.@JAVA_VERSION@"/>
 	<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="lombok.RunAllTests"/>
 	<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="lombok"/>
-	<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-javaagent:dist/lombok.jar -Ddelombok.bootclasspath=@RT_LOCATION@"/>
+	<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-javaagent:dist/lombok.jar -Ddelombok.bootclasspath=@RT_LOCATION@ -Dshadow.override.lombok=true"/>
 </launchConfiguration>


### PR DESCRIPTION
that also out-of-the-box can run the ecj tests