### PR TITLE
@Singleton support for javac and Eclipse

### DIFF
--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -446,6 +446,13 @@ public class ConfigurationKeys {
 	// ----- Singleton -----
 	
 	/**
+	 * lombok configuration: {@code lombok.singleton.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 * 
+	 * If set, <em>any</em> usage of {@code @Singleton} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> SINGLETON_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.singleton.flagUsage", "Emit a warning or error if @Singleton is used.") {};
+	
+	/**
    * lombok configuration: {@code lombok.singleton.staticGetterName} = &lt;String: aJavaIdentifier&gt; (Default: {@code getInstance}).
    * 
    * If set the various singleton annotations (which make an instance field) will use the stated identifier instead of {@code getInstance} as the getter name.
@@ -465,13 +472,6 @@ public class ConfigurationKeys {
    * If set the various singleton annotations (which make an instance field) will use the stated identifier instead of {@code SingletonHolder} as the holder class name.
    */
   public static final ConfigurationKey<String> SINGLETON_HOLDER_CLASS_NAME = new ConfigurationKey<String>("lombok.singleton.holderClassName", "Use this name for the generated logger fields (default: 'log').") {};
-  
-  /**
-   * lombok configuration: {@code lombok.singleton.flagUsage} = {@code WARNING} | {@code ERROR}.
-   * 
-   * If set, <em>any</em> usage of {@code @Singleton} results in a warning / error.
-   */
-  public static final ConfigurationKey<FlagUsageType> SINGLETON_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.singleton.flagUsage", "Emit a warning or error if @Singleton is used.") {};
   
 	// ----- Configuration System -----
 	

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -443,6 +443,36 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> WITHER_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.wither.flagUsage", "Emit a warning or error if @Wither is used.") {};
 	
+	// ----- Singleton -----
+	
+	/**
+   * lombok configuration: {@code lombok.singleton.staticGetterName} = &lt;String: aJavaIdentifier&gt; (Default: {@code getInstance}).
+   * 
+   * If set the various singleton annotations (which make an instance field) will use the stated identifier instead of {@code getInstance} as the getter name.
+   */
+  public static final ConfigurationKey<String> SINGLETON_STATIC_GETTER_NAME = new ConfigurationKey<String>("lombok.singleton.staticGetterName", "Use this name for the generated logger fields (default: 'log').") {};
+	
+  /**
+   * lombok configuration: {@code lombok.singleton.instanceFieldName} = &lt;String: aJavaIdentifier&gt; (Default: {@code INSTANCE}).
+   * 
+   * If set the various singleton annotations (which make an instance field) will use the stated identifier instead of {@code INSTANCE} as the field name.
+   */
+  public static final ConfigurationKey<String> SINGLETON_INSTANCE_FIELD_NAME = new ConfigurationKey<String>("lombok.singleton.instanceFieldName", "Use this name for the generated logger fields (default: 'log').") {};
+  
+  /**
+   * lombok configuration: {@code lombok.singleton.holderClassName} = &lt;String: aJavaIdentifier&gt; (Default: {@code SingletonHolder}).
+   * 
+   * If set the various singleton annotations (which make an instance field) will use the stated identifier instead of {@code SingletonHolder} as the holder class name.
+   */
+  public static final ConfigurationKey<String> SINGLETON_HOLDER_CLASS_NAME = new ConfigurationKey<String>("lombok.singleton.holderClassName", "Use this name for the generated logger fields (default: 'log').") {};
+  
+  /**
+   * lombok configuration: {@code lombok.singleton.flagUsage} = {@code WARNING} | {@code ERROR}.
+   * 
+   * If set, <em>any</em> usage of {@code @Singleton} results in a warning / error.
+   */
+  public static final ConfigurationKey<FlagUsageType> SINGLETON_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.singleton.flagUsage", "Emit a warning or error if @Singleton is used.") {};
+  
 	// ----- Configuration System -----
 	
 	/**

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -37,6 +37,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.Singleton;
 import lombok.ToString;
 import lombok.Value;
 import lombok.core.AST;
@@ -163,7 +164,8 @@ public class HandlerUtil {
 			Arrays.<Class<? extends java.lang.annotation.Annotation>>asList(
 			Getter.class, Setter.class, Wither.class, ToString.class, EqualsAndHashCode.class, 
 			RequiredArgsConstructor.class, AllArgsConstructor.class, NoArgsConstructor.class, 
-			Data.class, Value.class, lombok.experimental.Value.class, FieldDefaults.class));
+			Data.class, Value.class, lombok.experimental.Value.class, FieldDefaults.class,
+			Singleton.class));
 	
 	/**
 	 * Given the name of a field, return the 'base name' of that field. For example, {@code fFoobar} becomes {@code foobar} if {@code f} is in the prefix list.

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.ConfigurationKeys;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -166,6 +167,14 @@ public class HandlerUtil {
 			RequiredArgsConstructor.class, AllArgsConstructor.class, NoArgsConstructor.class, 
 			Data.class, Value.class, lombok.experimental.Value.class, FieldDefaults.class,
 			Singleton.class));
+	
+	@SuppressWarnings({"all", "unchecked", "deprecation"})
+  public static final List<Class<? extends java.lang.annotation.Annotation>> INVALID_ON_SINGLETONS = Collections.unmodifiableList(
+      Arrays.<Class<? extends java.lang.annotation.Annotation>>asList(
+      Wither.class, ToString.class, EqualsAndHashCode.class, 
+      RequiredArgsConstructor.class, AllArgsConstructor.class, NoArgsConstructor.class, 
+      Data.class, Value.class, lombok.experimental.Value.class, FieldDefaults.class,
+      Builder.class, lombok.experimental.Builder.class));
 	
 	/**
 	 * Given the name of a field, return the 'base name' of that field. For example, {@code fFoobar} becomes {@code foobar} if {@code f} is in the prefix list.

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -37,7 +37,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import lombok.Singleton;
+import lombok.experimental.Singleton;
 import lombok.ToString;
 import lombok.Value;
 import lombok.core.AST;

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -223,6 +223,46 @@ public class EclipseHandlerUtil {
 		errorNode.addError(out.append(" are not allowed on builder classes.").toString());
 	}
 	
+	/**
+	 * Performs a sanity check for the annotations on a {@code 'X'} type of class.
+	 * 
+	 * <p>
+	 * Adds an appropriate error message to the <tt>errorNode</tt> if any unsupported annotation(s)
+	 * was used in combination with the class type annotation: {@code X}.
+	 * 
+	 * @param typeNode  the type the annotation is used on
+	 * @param errorNode  the node the errors (if any) should be displayed on; usually the annotation node
+	 * @param classX  the type of the class; like {@code Builder}, {@code Singleton} etc. This will be used
+	 * as such in the error/warning messages in case sanity check failed
+	 * @param unsupportedAnnotations  a collection of all the unsupported annotations for the annotation in question
+	 * @return the result of the sanity check; {@code true} if the validation passed; {@code false} otherwise
+	 */
+	public static boolean sanityCheckForMethodGeneratingAnnotationsOnXClass(EclipseNode typeNode, EclipseNode errorNode, String classX,
+	    List<Class<? extends java.lang.annotation.Annotation>> unsupportedAnnotations) {
+    List<String> disallowed = null;
+    for (EclipseNode child : typeNode.down()) {
+      if (child.getKind() != Kind.ANNOTATION) continue;
+      for (Class<? extends java.lang.annotation.Annotation> annType : unsupportedAnnotations) {
+        if (annotationTypeMatches(annType, child)) {
+          if (disallowed == null) disallowed = new ArrayList<String>();
+          disallowed.add(annType.getSimpleName());
+        }
+      }
+    }
+    
+    int size = disallowed == null ? 0 : disallowed.size();
+    if (size == 0) return true;
+    if (size == 1) {
+      errorNode.addError("@" + disallowed.get(0) + " is not allowed on " + classX + " classes.");
+      return false;
+    }
+    StringBuilder out = new StringBuilder();
+    for (String a : disallowed) out.append("@").append(a).append(", ");
+    out.setLength(out.length() - 2);
+    errorNode.addError(out.append(" are not allowed on " + classX + " classes.").toString());
+    return false;
+  }
+	
 	public static Annotation copyAnnotation(Annotation annotation, ASTNode source) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		

--- a/src/core/lombok/eclipse/handlers/HandleSingleton.java
+++ b/src/core/lombok/eclipse/handlers/HandleSingleton.java
@@ -79,6 +79,7 @@ public class HandleSingleton extends EclipseAnnotationHandler<Singleton> {
 		if (typeNode.get() instanceof TypeDeclaration) type = (TypeDeclaration) typeNode.get();
 		boolean isUsedOnClass = isAnnotationUsedOnClass(type, annotationNode);
 		if (! isUsedOnClass) return;
+		sanityCheckForMethodGeneratingAnnotationsOnXClass(typeNode, annotationNode, "singleton", INVALID_ON_SINGLETONS);
 		
 		if (nullaryConstructorExists(typeNode, annotationNode) == MemberExistsResult.NOT_EXISTS) {
 		  HandleConstructor constrHandler = new HandleConstructor();

--- a/src/core/lombok/eclipse/handlers/HandleSingleton.java
+++ b/src/core/lombok/eclipse/handlers/HandleSingleton.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright (C) 2012-2014 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.eclipse.handlers;
+
+import static lombok.eclipse.Eclipse.*;
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+
+import lombok.AccessLevel;
+import lombok.ConfigurationKeys;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.core.AST.Kind;
+import lombok.eclipse.EclipseAnnotationHandler;
+import lombok.eclipse.EclipseNode;
+import lombok.eclipse.handlers.EclipseHandlerUtil.MemberExistsResult;
+import lombok.experimental.Singleton;
+import lombok.experimental.Tolerate;
+import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;
+
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.AllocationExpression;
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.FieldReference;
+import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.ReturnStatement;
+import org.eclipse.jdt.internal.compiler.ast.Statement;
+import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
+import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import org.mangosdk.spi.ProviderFor;
+
+/**
+ * Handles the {@code lombok.Singleton} annotation for eclipse.
+ */
+@ProviderFor(EclipseAnnotationHandler.class)
+public class HandleSingleton extends EclipseAnnotationHandler<Singleton> {
+  @Override
+	public void handle(AnnotationValues<Singleton> annotation, Annotation ast, EclipseNode annotationNode) {
+		handleFlagUsage(annotationNode, ConfigurationKeys.VALUE_FLAG_USAGE, "@Singleton");
+		
+		EclipseNode typeNode = annotationNode.up();
+		
+		TypeDeclaration type = null;
+		if (typeNode.get() instanceof TypeDeclaration) type = (TypeDeclaration) typeNode.get();
+		boolean isUsedOnClass = isUsedOnClass(type, annotationNode);
+		if (! isUsedOnClass) return;
+		
+		if (nonDefaultConstructorExists(typeNode) != MemberExistsResult.NOT_EXISTS) {
+      annotationNode.addWarning("A non-default constructor exists. Consider removing it for the default constructor." + nonDefaultConstructorExists(typeNode));
+    }
+		
+		if (defaultConstructorExists(typeNode, annotationNode) == MemberExistsResult.NOT_EXISTS) {
+      annotationNode.addError("A default constructor does not exist. Consider removing any non-default constructor for the default one.");
+      return;
+    }
+		
+		String staticGetterName = annotationNode.getAst().readConfiguration(ConfigurationKeys.SINGLETON_STATIC_GETTER_NAME);
+		if (staticGetterName == null) staticGetterName = "getInstance";
+		boolean getterExists = getterExists(typeNode, annotationNode, staticGetterName);
+		if (getterExists) return;
+		
+		Singleton singleton = annotation.getInstance();
+		Singleton.Style style = singleton.style();
+		switch (style) {
+    case EAGER:
+      handleEagerInstantiation(ast, typeNode, annotationNode, type, staticGetterName);
+      break;
+    case LAZY:
+      handleLazyInstantiation(ast, typeNode, annotationNode, type, staticGetterName);
+      break;
+    default:
+      annotationNode.addWarning("Invalid instantiation style: '" + staticGetterName + "'.");
+      return;
+    }
+	}
+
+  /**
+   * Checks if a getter method with the given name already exists.
+   * 
+   * <p>
+   * Also adds an error to the annotation node if it exists already.
+   * 
+   * @param typeNode  the type the annotation is used on
+   * @param annotationNode  the annotation node
+   * @param staticGetterName  the name of the getter method
+   * @return {@code true} if a getter method with the given name: <tt>staticGetterName</tt>
+   * already exists; {@code false} otherwise
+   */
+  private boolean getterExists(EclipseNode typeNode, EclipseNode annotationNode, String staticGetterName) {
+    MemberExistsResult getterExistsResult = methodExists(staticGetterName, typeNode, true, 0);
+		if (getterExistsResult != MemberExistsResult.NOT_EXISTS) {
+		  annotationNode.addWarning("The static instance getter method: '" + staticGetterName + "' already exists.");
+		  return true;
+		} else {
+		  return false;
+		}
+  }
+
+  /**
+   * Checks if the given type declaration corresponds to that of a class.
+   * 
+   * <p>
+   * Also adds an error message to the given annotation node if the type declaration
+   * is not that of a class.
+   * 
+   * @param type  the type declaration to check
+   * @param annotationNode  the annotation node to add an error message to if the
+   * given type declaration does not correspond to that of a class
+   * @return  {@code true} if the given type declaration is that of a class; {@code false}
+   * otherwise
+   */
+  private boolean isUsedOnClass(TypeDeclaration type, EclipseNode annotationNode) {
+    int modifiers = type == null ? 0 : type.modifiers;
+		boolean notAClass = (modifiers &
+				(ClassFileConstants.AccInterface | ClassFileConstants.AccAnnotation | ClassFileConstants.AccEnum)) != 0;
+		
+		if (type == null || notAClass) {
+			annotationNode.addError("@Singleton is only supported on a class.");
+			return false;
+		} else {
+		  return true;
+		}
+  }
+
+  /**
+   * Handles a request to eagerly instantiate the Singleton class by creating
+   * a field and assigning it an object by calling the nullary constructor.
+   * 
+   * @param source  the {@code AST} setup
+   * @param typeNode  the declaring type
+   * @param annotationNode  the annotation node to declare warnings on
+   * @param type  the enclosing type declaration
+   * @param staticGetterName  the getter of the instance
+   */
+  private void handleEagerInstantiation(Annotation source, EclipseNode typeNode, EclipseNode annotationNode,
+      TypeDeclaration type, String staticGetterName) {
+    String instanceFieldName = annotationNode.getAst().readConfiguration(ConfigurationKeys.SINGLETON_INSTANCE_FIELD_NAME);
+    if (instanceFieldName == null) instanceFieldName = "INSTANCE";
+    if (!instanceFieldName.isEmpty()) {
+      if (!checkName("instanceFieldName", instanceFieldName, annotationNode)) return;
+    }
+    
+    MemberExistsResult instanceFieldExists = fieldExists(instanceFieldName, typeNode);
+    if (instanceFieldExists != MemberExistsResult.NOT_EXISTS) {
+      annotationNode.addWarning("The instance field '" + instanceFieldName + "' already exists.");
+      return;
+    }
+    
+    FieldDeclaration fieldDeclaration = createField(source, instanceFieldName, typeNode);
+    fieldDeclaration.traverse(new SetGeneratedByVisitor(source), type.staticInitializerScope);
+    // TODO temporary workaround for issue 217. http://code.google.com/p/projectlombok/issues/detail?id=217
+    // injectFieldSuppressWarnings(owner, fieldDeclaration);
+    EclipseNode instanceField = injectField(typeNode, fieldDeclaration);
+    
+    MethodDeclaration md = generateGetterMethod(staticGetterName, typeNode, type.typeParameters, source, null, instanceField);
+    injectMethod(typeNode, md);
+    
+    typeNode.rebuild();
+  }
+	
+	/**
+	 * Creates the instance field with the given name by calling the nullary constructor.
+	 * 
+	 * @param source  the {@code AST} setup
+	 * @param instanceName  the instance field name
+	 * @param typeNode  the enclosing type node
+	 * @return  the created field
+	 */
+	private static FieldDeclaration createField(Annotation source, String instanceName, EclipseNode typeNode) {
+    int pS = source.sourceStart, pE = source.sourceEnd;
+    long p = (long)pS << 32 | pE;
+    
+    FieldDeclaration fieldDecl = new FieldDeclaration(instanceName.toCharArray(), 0, -1);
+    setGeneratedBy(fieldDecl, source);
+    fieldDecl.declarationSourceEnd = -1;
+    fieldDecl.modifiers = Modifier.PRIVATE | Modifier.STATIC | Modifier.FINAL;
+    fieldDecl.type = createTypeReference(typeNode.getName(), source);
+    
+    AllocationExpression init = new AllocationExpression();
+    /*init.sourceStart = fieldDecl.initialization.sourceStart; fieldDecl.sourceEnd = init.statementEnd = fieldDecl.initialization.sourceEnd;*/
+    init.type = new SingleTypeReference(typeNode.getName().toCharArray(), 0L);
+    
+    fieldDecl.initialization = init;
+    
+    return fieldDecl;
+  }
+
+	/**
+   * Handles a request to lazily instantiate the Singleton class by creating
+   * a static inner Holder class to hold the Singleton instance.
+   * 
+   * @param source  the {@code AST} setup
+   * @param typeNode  the declaring type
+   * @param annotationNode  the annotation node to declare warnings on
+   * @param type  the enclosing type declaration
+   * @param staticGetterName  the getter of the instance
+   */
+  private void handleLazyInstantiation(Annotation source, EclipseNode typeNode, EclipseNode annotationNode,
+      TypeDeclaration type, String staticGetterName) {
+    String holderClassName = annotationNode.getAst().readConfiguration(ConfigurationKeys.SINGLETON_HOLDER_CLASS_NAME);
+		if (holderClassName == null) holderClassName = "SingletonHolder";
+		if (!holderClassName.isEmpty()) {
+      if (!checkName("holderClassName", holderClassName, annotationNode)) return;
+    }
+		
+		EclipseNode holderType = findInnerClass(typeNode, holderClassName);
+    if (holderType == null) {
+      holderType = makeHolderClass(source, typeNode, holderClassName);
+      FieldDeclaration holderInstanceField = createField(source, "INSTANCE", typeNode);
+      EclipseNode heldInstance = injectField(holderType, holderInstanceField);
+      
+      MethodDeclaration md = generateGetterMethod(staticGetterName, typeNode, type.typeParameters, source, holderClassName, heldInstance);
+      injectMethod(typeNode, md);
+      typeNode.rebuild();
+    } else {
+      annotationNode.addWarning("The Singleton holder inner class '" + holderClassName + "' already exists.");
+      return;
+    }
+  }
+	
+	/**
+	 * Finds an inner class with the given name.
+	 * 
+	 * @param parent  the enclosing node
+	 * @param name  the name of the inner class
+	 * @return  the inner class with the given name; {@code null}
+	 * if none was found
+	 */
+	private EclipseNode findInnerClass(EclipseNode parent, String name) {
+    char[] c = name.toCharArray();
+    for (EclipseNode child : parent.down()) {
+      if (child.getKind() != Kind.TYPE) continue;
+      TypeDeclaration td = (TypeDeclaration) child.get();
+      if (Arrays.equals(td.name, c)) return child;
+    }
+    return null;
+  }
+	
+	/**
+   * Finds a field with the given name.
+   * 
+   * @param parent  the enclosing node
+   * @param name  the name of the field
+   * @return  the inner class with the given field; {@code null}
+   * if none was found
+   */
+	private EclipseNode findField(EclipseNode parent, String name) {
+    char[] c = name.toCharArray();
+    for (EclipseNode child : parent.down()) {
+      if (child.getKind() != Kind.FIELD) continue;
+      FieldDeclaration td = (FieldDeclaration) child.get();
+      if (Arrays.equals(td.name, c)) return child;
+    }
+    return null;
+  }
+	
+	/**
+	 * Creates a type reference given the type name.
+	 * 
+	 * @param typeName  the reference type name
+	 * @param source  the {@code AST} setup
+	 * @return a type reference given the type name
+	 */
+	private static TypeReference createTypeReference(String typeName, Annotation source) {
+    int pS = source.sourceStart, pE = source.sourceEnd;
+    long p = (long)pS << 32 | pE;
+    
+    TypeReference typeReference = new SingleTypeReference(typeName.toCharArray(), 0L);
+    
+    setGeneratedBy(typeReference, source);
+    return typeReference;
+  }
+	
+	private MethodDeclaration generateGetterMethod(String staticGetterName, EclipseNode type, TypeParameter[] typeParams, ASTNode source,
+	    String holderClassName, EclipseNode heldInstance) {
+    int pS = source.sourceStart, pE = source.sourceEnd;
+    long p = (long) pS << 32 | pE;
+    
+    MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) type.top().get()).compilationResult);
+    out.selector = staticGetterName.toCharArray();
+    out.modifiers = ClassFileConstants.AccPublic;
+    out.modifiers |= ClassFileConstants.AccStatic;
+    out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+    out.returnType = namePlusTypeParamsToTypeReference(type.getName().toCharArray(), typeParams, p);
+    out.typeParameters = copyTypeParams(typeParams, source);
+    
+    FieldDeclaration fieldDecl = (FieldDeclaration)heldInstance.get();
+    FieldReference ref = new FieldReference(fieldDecl.name, p);
+    EclipseNode containerNode = heldInstance.up();
+    ref.receiver = new SingleNameReference(((TypeDeclaration) containerNode.get()).name, p);
+    setGeneratedBy(ref, source);
+    setGeneratedBy(ref.receiver, source);
+    out.statements = new Statement[] {new ReturnStatement(ref, ref.sourceStart, ref.sourceEnd)};
+    out.traverse(new SetGeneratedByVisitor(source), ((TypeDeclaration) type.get()).scope);
+    
+    return out;
+  }
+	
+	/**
+	 * Makes a new holder (a static, final, inner) class to hold the Singleton
+	 * reference.
+	 * 
+	 * @param ast  the {@code AST} setup
+	 * @param parent  the enclosing node
+	 * @param holderClassName  the holder class name
+	 * @return a new holder (a static, final, inner) class to hold the Singleton
+   * reference
+	 */
+	private EclipseNode makeHolderClass(Annotation ast, EclipseNode parent, String holderClassName) {
+    TypeDeclaration parentTypeDecl = (TypeDeclaration) parent.get();
+    TypeDeclaration holder = new TypeDeclaration(parentTypeDecl.compilationResult);
+    holder.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+    holder.modifiers |= ClassFileConstants.AccPublic;
+    holder.modifiers |= ClassFileConstants.AccStatic;
+    holder.modifiers |= ClassFileConstants.AccFinal;
+    holder.name = holderClassName.toCharArray();
+    holder.traverse(new SetGeneratedByVisitor(ast), (ClassScope) null);
+    
+    return injectType(parent, holder);
+  }
+	
+	/**
+   * Checks if there is a default constructor.
+   * 
+   * <p>
+   * Also adds a warning if the default constructor is not {@code private}.
+   * 
+   * @param typeNode  the type node the annotation is declared on
+   * @param annotationNode  the annotation node
+   */
+  private static MemberExistsResult defaultConstructorExists(EclipseNode typeNode, EclipseNode annotationNode) {
+    while (typeNode != null && !(typeNode.get() instanceof TypeDeclaration)) {
+      typeNode = typeNode.up();
+    }
+    
+    if (typeNode != null && typeNode.get() instanceof TypeDeclaration) {
+      TypeDeclaration typeDecl = (TypeDeclaration)typeNode.get();
+      if (typeDecl.methods != null) for (AbstractMethodDeclaration def : typeDecl.methods) {
+        if (def instanceof ConstructorDeclaration) {
+          if ((def.bits & ASTNode.IsDefaultConstructor) == 0) continue;
+          
+          boolean isDefaultConstrPrivate = ((typeDecl.modifiers & Modifier.PRIVATE) != 0) ? true : false;
+          if (! isDefaultConstrPrivate) {
+            annotationNode.addWarning("The default constructor is not private! Considering marking it private.");
+          }
+          return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;
+        }
+      }
+    }
+    
+    return MemberExistsResult.NOT_EXISTS;
+  }
+  
+  /**
+   * Checks if there is a non-default constructor.
+   * 
+   * @param typeNode  the type node the annotation is declared on
+   */
+  private static MemberExistsResult nonDefaultConstructorExists(EclipseNode typeNode) {
+    while (typeNode != null && !(typeNode.get() instanceof TypeDeclaration)) {
+      typeNode = typeNode.up();
+    }
+    
+    if (typeNode != null && typeNode.get() instanceof TypeDeclaration) {
+      TypeDeclaration typeDecl = (TypeDeclaration)typeNode.get();
+      if (typeDecl.methods != null) for (AbstractMethodDeclaration def : typeDecl.methods) {
+        if (def instanceof ConstructorDeclaration) {
+          System.out
+              .println("Checking: " + def);
+          if ((def.bits & ASTNode.IsDefaultConstructor) != 0) continue;
+          
+          return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;
+        }
+      }
+    }
+    
+    return MemberExistsResult.NOT_EXISTS;
+  }
+}

--- a/src/core/lombok/experimental/Singleton.java
+++ b/src/core/lombok/experimental/Singleton.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.experimental;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation that can be used to create {@code Singleton} types that
+ * ensure only one instance of themselves are created.
+ * 
+ * <p>
+ * The implementation comes in two flavors depending on the need for the type
+ * to be instantiated:
+ * <ul>
+ *   <li>eagerly (default)</li>
+ *   <li>lazily (on-demand)</li>
+ * </ul>
+ * 
+ * @author mystarrocks
+ */
+@Target(TYPE)
+@Retention(SOURCE)
+public @interface Singleton {
+  /** 
+   * The instantiation style to use.
+   * 
+   * <p>
+   * Defaults to {@code EAGER}.
+   */
+  Style style() default Style.EAGER;
+
+  /**
+   * The instantiation style for the Singleton type.
+   * 
+   * @author mystarrocks
+   */
+  public static enum Style {
+    /**
+     * <pre>
+     * public class MySingletonClass {
+     *  private static final MySingletonClass INSTANCE = new MySingletonClass();
+     * 
+     *  public static MySingletonClass getInstance() {
+     *    return INSTANCE;
+     *  }
+     * }
+     * </pre>
+     */
+    EAGER,
+    
+    /**
+     * <pre>
+     * public class MySingletonClass {
+     * 
+     *  private static class MySingletonClassHolder {
+     *    private static final MySingletonClass INSTANCE = new MySingletonClass();
+     *  }
+     * 
+     *  public static MySingletonClass getInstance() {
+     *    return MySingletonClassHolder.INSTANCE;
+     *  }
+     * }
+     * </pre>
+     */
+    LAZY;
+  }
+}

--- a/src/core/lombok/javac/handlers/HandleSingleton.java
+++ b/src/core/lombok/javac/handlers/HandleSingleton.java
@@ -84,6 +84,9 @@ public class HandleSingleton extends JavacAnnotationHandler<Singleton> {
 		  return;
 		}
 		
+		boolean sanityCheckResult = sanityCheckForMethodGeneratingAnnotationsOnXClass(typeNode, annotationNode, "singleton", INVALID_ON_SINGLETONS);
+		if (! sanityCheckResult) return;
+		
 		JCClassDecl type = null;
 		if (typeNode.get() instanceof JCClassDecl) type = (JCClassDecl) typeNode.get();
 		boolean isUsedOnClass = isAnnotationUsedOnClass(type, annotationNode);

--- a/src/core/lombok/javac/handlers/HandleSingleton.java
+++ b/src/core/lombok/javac/handlers/HandleSingleton.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2015 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.javac.handlers.JavacHandlerUtil.injectField;
+import static lombok.javac.handlers.JavacHandlerUtil.injectMethod;
+import static lombok.javac.handlers.JavacHandlerUtil.injectType;
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.mangosdk.spi.ProviderFor;
+
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.TreeVisitor;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+
+import lombok.ConfigurationKeys;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.experimental.Singleton;
+import lombok.experimental.Tolerate;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import lombok.javac.handlers.HandleLog.LoggingFramework;
+import lombok.javac.handlers.JavacHandlerUtil.FieldAccess;
+import lombok.javac.handlers.JavacHandlerUtil.MemberExistsResult;
+
+@ProviderFor(JavacAnnotationHandler.class)
+public class HandleSingleton extends JavacAnnotationHandler<Singleton> {
+	@Override public void handle(AnnotationValues<Singleton> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.SINGLETON_FLAG_USAGE, "@Singleton");
+		
+		deleteAnnotationIfNeccessary(annotationNode, Singleton.class);
+		deleteImportFromCompilationUnit(annotationNode, "lombok.Singleton.Style");
+		
+		JavacNode typeNode = annotationNode.up();
+		if (typeNode == null) return;
+		if (typeNode.getKind() != Kind.TYPE) {
+		  annotationNode.addError("@Singleton is legal only on classes.");
+		  return;
+		}
+		
+		JCClassDecl type = null;
+		if (typeNode.get() instanceof JCClassDecl) type = (JCClassDecl) typeNode.get();
+		long modifiers = type == null ? 0 : type.mods.flags;
+		boolean notAClass = (modifiers & (Flags.INTERFACE | Flags.ANNOTATION | Flags.ENUM)) != 0;
+		
+		if (type == null || notAClass) {
+		  annotationNode.addError("@Singleton is only supported on a class.");
+		  return;
+		}
+		
+		String staticGetterName = annotationNode.getAst().readConfiguration(ConfigurationKeys.SINGLETON_STATIC_GETTER_NAME);
+    if (staticGetterName == null) staticGetterName = "getInstance";
+    MemberExistsResult getterExistsResult = methodExists(staticGetterName, typeNode, true, 0);
+    if (getterExistsResult != MemberExistsResult.NOT_EXISTS) {
+      annotationNode.addWarning("The static instance getter method: '" + staticGetterName + "' already exists.");
+      return;
+    }
+		
+    Singleton singleton = annotation.getInstance();
+    Singleton.Style style = singleton.style();
+    
+		switch (style) {
+		case EAGER:
+		  handleEagerInstantiation(ast, typeNode, annotationNode, type, staticGetterName);
+		  break;
+		case LAZY:
+		  handleLazyInstantiation(ast, typeNode, annotationNode, type, staticGetterName);
+		  break;
+		}
+	}
+	
+	/**
+   * Handles a request to eagerly instantiate the Singleton class by creating
+   * a field and assigning it an object by calling the nullary constructor.
+   * 
+   * @param source  the {@code AST} setup
+   * @param typeNode  the declaring type
+   * @param annotationNode  the annotation node to declare warnings on
+   * @param type  the enclosing type declaration
+   * @param staticGetterName  the getter of the instance
+   */
+  private void handleEagerInstantiation(JCAnnotation source, JavacNode typeNode, JavacNode annotationNode,
+      JCClassDecl type, String staticGetterName) {
+    String instanceFieldName = annotationNode.getAst().readConfiguration(ConfigurationKeys.SINGLETON_INSTANCE_FIELD_NAME);
+    if (instanceFieldName == null) instanceFieldName = "INSTANCE";
+    if (!instanceFieldName.isEmpty()) {
+      if (!checkName("instanceFieldName", instanceFieldName, annotationNode)) return;
+    }
+    
+    MemberExistsResult instanceFieldExists = fieldExists(instanceFieldName, typeNode);
+    if (instanceFieldExists != MemberExistsResult.NOT_EXISTS) {
+      annotationNode.addWarning("The instance field '" + instanceFieldName + "' already exists.");
+      return;
+    }
+    
+    JCTree tree = annotationNode.get();
+    JCVariableDecl fieldDecl = createField(typeNode, tree, type, instanceFieldName);
+    JavacNode fieldNode = injectFieldAndMarkGenerated(typeNode, fieldDecl);
+    
+    JCMethodDecl getterMethodDeclaration = generateGetterMethod(type, staticGetterName, fieldNode.getTreeMaker(), tree, fieldNode);
+    injectMethod(fieldNode.up(), getterMethodDeclaration);
+  }
+  
+  private static JCVariableDecl createField(JavacNode typeNode, JCTree source, JCClassDecl type, String instanceFieldName) {
+    JavacTreeMaker treeMaker = typeNode.getTreeMaker();
+    
+    JCExpression init = treeMaker.NewClass(null, List.<JCExpression>nil(), treeMaker.Ident(type.name), List.<JCExpression>nil(), null);
+    JCExpression varType = treeMaker.Ident(type.name);
+    JCVariableDecl fieldDecl = treeMaker.VarDef(treeMaker.Modifiers(Flags.PRIVATE | Flags.FINAL | Flags.STATIC),
+        typeNode.toName(instanceFieldName),
+        varType,
+        init);
+    return fieldDecl;
+  }
+
+  private JCMethodDecl generateGetterMethod(JCClassDecl type, String staticGetterName, JavacTreeMaker treeMaker, JCTree source,
+      JavacNode fieldNode) {
+    long getterAccess = Flags.PUBLIC | Flags.STATIC;
+    List<JCStatement> returnStatement = List.<JCStatement>of(treeMaker.Return(createFieldAccessor(treeMaker, fieldNode, FieldAccess.ALWAYS_FIELD)));
+    JCBlock methodBody = treeMaker.Block(0, returnStatement);
+    List<JCTypeParameter> methodGenericParams = List.nil();
+    List<JCVariableDecl> parameters = List.nil();
+    List<JCExpression> throwsClauses = List.nil();
+    JCExpression annotationMethodDefaultValue = null;
+    Name getterMethodName = fieldNode.toName(staticGetterName);
+    JCExpression methodType = treeMaker.Ident(type.name);
+    JCMethodDecl getterMethodDeclaration = recursiveSetGeneratedBy(treeMaker.MethodDef(treeMaker.Modifiers(getterAccess), getterMethodName, methodType,
+        methodGenericParams, parameters, throwsClauses, methodBody, annotationMethodDefaultValue), source, fieldNode.getContext());
+    return getterMethodDeclaration;
+  }
+  
+  private void handleLazyInstantiation(JCAnnotation source, JavacNode typeNode, JavacNode annotationNode,
+      JCClassDecl type, String staticGetterName) {
+    /*String holderClassName = annotationNode.getAst().readConfiguration(ConfigurationKeys.SINGLETON_HOLDER_CLASS_NAME);
+    if (holderClassName == null) holderClassName = "SingletonHolder";
+    if (!holderClassName.isEmpty()) {
+      if (!checkName("holderClassName", holderClassName, annotationNode)) return;
+    }
+    
+    JavacNode holderType = findInnerClass(typeNode, holderClassName);
+    if (holderType == null) {
+      holderType = makeHolderClass(source, typeNode, holderClassName);
+      FieldDeclaration holderInstanceField = createField(source, "INSTANCE", typeNode);
+      EclipseNode heldInstance = injectField(holderType, holderInstanceField);
+      
+      MethodDeclaration md = generateGetterMethod(staticGetterName, typeNode, type.typeParameters, source, holderClassName, heldInstance);
+      injectMethod(typeNode, md);
+      typeNode.rebuild();
+    } else {
+      annotationNode.addWarning("The Singleton holder inner class '" + holderClassName + "' already exists.");
+      return;
+    }*/
+  }
+  
+  /**
+   * Makes a new holder (a static, final, inner) class to hold the Singleton
+   * reference.
+   * 
+   * @param ast  the {@code AST} setup
+   * @param parent  the enclosing node
+   * @param holderClassName  the holder class name
+   * @return a new holder (a static, final, inner) class to hold the Singleton
+   * reference
+   */
+  private JavacNode makeHolderClass(JCAnnotation ast, JavacNode parent, String holderClassName) {
+    /*JCClassDecl parentTypeDecl = (JCClassDecl) parent.get();
+    JCClassDecl holder = new JCClassDecl(parentTypeDecl.compilationResult);
+    
+    
+    return injectType(parent, holder);*/
+    return null;
+  }
+  
+  /**
+   * Finds an inner class with the given name.
+   * 
+   * @param parent  the enclosing node
+   * @param name  the name of the inner class
+   * @return  the inner class with the given name; {@code null}
+   * if none was found
+   */
+  private JavacNode findInnerClass(JavacNode parent, String name) {
+    char[] c = name.toCharArray();
+    for (JavacNode child : parent.down()) {
+      if (child.getKind() != Kind.TYPE) continue;
+      JCClassDecl td = (JCClassDecl) child.get();
+      if (Arrays.equals(td.name.toString().toCharArray(), c)) return child;
+    }
+    return null;
+  }
+  
+}

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1284,6 +1284,44 @@ public class JavacHandlerUtil {
 		errorNode.addError(out.append(" are not allowed on builder classes.").toString());
 	}
 	
+	/**
+   * Performs a sanity check for the annotations on a {@code 'X'} type of class.
+   * 
+   * <p>
+   * Adds an appropriate error message to the <tt>errorNode</tt> if any unsupported annotation(s)
+   * was used in combination with the class type annotation: {@code X}.
+   * 
+   * @param typeNode  the type the annotation is used on
+   * @param errorNode  the node the errors (if any) should be displayed on; usually the annotation node
+   * @param classX  the type of the class; like {@code Builder}, {@code Singleton} etc. This will be used
+   * as such in the error/warning messages in case sanity check failed
+   * @param unsupportedAnnotations  a collection of all the unsupported annotations for the annotation in question
+   * @return the result of the sanity check; {@code true} if the validation passed; {@code false} otherwise
+   */
+	public static boolean sanityCheckForMethodGeneratingAnnotationsOnXClass(JavacNode typeNode, JavacNode errorNode, String classX,
+	    java.util.List<Class<? extends java.lang.annotation.Annotation>> unsupportedAnnotations) {
+    List<String> disallowed = List.nil();
+    for (JavacNode child : typeNode.down()) {
+      for (Class<? extends java.lang.annotation.Annotation> annType : unsupportedAnnotations) {
+        if (annotationTypeMatches(annType, child)) {
+          disallowed = disallowed.append(annType.getSimpleName());
+        }
+      }
+    }
+    
+    int size = disallowed.size();
+    if (size == 0) return true;
+    if (size == 1) {
+      errorNode.addError("@" + disallowed.head + " is not allowed on " + classX + " classes.");
+      return false;
+    }
+    StringBuilder out = new StringBuilder();
+    for (String a : disallowed) out.append("@").append(a).append(", ");
+    out.setLength(out.length() - 2);
+    errorNode.addError(out.append(" are not allowed on " + classX + " classes.").toString());
+    return false;
+  }
+	
 	static List<JCAnnotation> copyAnnotations(List<? extends JCExpression> in) {
 		ListBuffer<JCAnnotation> out = new ListBuffer<JCAnnotation>();
 		for (JCExpression expr : in) {

--- a/usage_examples/experimental/SingletonExample_post.jpage
+++ b/usage_examples/experimental/SingletonExample_post.jpage
@@ -1,0 +1,29 @@
+public class LazySingletonExample {
+	private LazySingletonExample() {}
+
+	private static final class SingletonHolder {
+		private static final LazySingletonExample INSTANCE = new LazySingletonExample();
+	}
+	
+	public static LazySingletonExample getInstance() {
+		return SingletonHolder.INSTANCE;
+	}
+	
+	public static void main(String[] args) {
+      assert getInstance() == getInstance();
+    }
+}
+
+class EagerSingletonExample {
+	private static final EagerSingletonExample INSTANCE = new EagerSingletonExample();
+	
+	private EagerSingletonExample() {}
+	
+	public static EagerSingletonExample getInstance() {
+		return INSTANCE;
+	}
+	
+	public static void main(String[] args) {
+      assert getInstance() == getInstance();
+    }
+}

--- a/usage_examples/experimental/SingletonExample_pre.jpage
+++ b/usage_examples/experimental/SingletonExample_pre.jpage
@@ -1,0 +1,16 @@
+import lombok.experimental.Singleton;
+import lombok.experimental.Singleton.Style;
+
+@Singleton (style = Style.LAZY)
+public class LazySingletonExample {
+    public static void main(String[] args) {
+      assert getInstance() == getInstance();
+    }
+}
+
+@Singleton (style = Style.EAGER)
+class EagerSingletonExample {
+    public static void main(String[] args) {
+      assert getInstance() == getInstance();
+    }
+}

--- a/website/features/experimental/Singleton.html
+++ b/website/features/experimental/Singleton.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html><head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<link rel="stylesheet" type="text/css" href="../../logi/reset.css" />
+	<link rel="stylesheet" type="text/css" href="../features.css" />
+	<link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon" />
+	<meta name="description" content="Spice up your java" />
+	<title>EXPERIMENTAL - @Singleton</title>
+</head><body><div id="pepper">
+	<div class="minimumHeight"></div>
+	<div class="meat">
+		<div class="header"><a href="../../index.html">Project Lombok</a></div>
+		<h1>@Singleton</h1>
+		<div class="byline">Singletons implemented right.</div>
+		<div class="since">
+			<h3>Since</h3>
+			<p>
+				@Singleton was introduced as experimental feature in lombok v1.16.7.
+			</p>
+		</div>
+		<div class="experimental">
+			<h3>Experimental</h3>
+			<p>
+			Experimental because:
+			<ul>
+				<li>New feature; unsure if this busts enough boilerplate</li>
+			</ul>
+			Current status: <em>positive</em> - Currently we feel this feature may move out of experimental status with no or minor changes soon.
+		</div>
+		<div class="overview">
+			<h3>Overview</h3>
+			<p>
+				The <code>@Singleton</code> annotation can be used to mark a class <code>Singleton</code> so that only instance of the type can ever
+				exist. A <code>public</code>, <code>static</code> getter method named <code>getInstance()</code> will be created for the clients to obtain the <code>Singleton</code> instance created.
+			</p>
+			</p><p>
+				The <code>@Singleton</code> comes in two flavors/styles - eager and lazy.
+				<ul>
+				    <li>
+						<b>Eager</b> (<code>style = Style.EAGER</code>) <br/>
+						Creates the <code>Singleton</code> instance eagerly during the class loading by declaring and initializing a static member variable (generated and
+						marked <code>private</code> by default) of the type. This is inherently thread-safe.<br/><br/>
+					</li>
+					<li>
+						<b>Lazy</b> (<code>style = Style.LAZY</code>) <br/>
+						Creates the <code>Singleton</code> instance lazily (on-demand) by declaring a <code>private</code> nested class containing the instance. It takes advantage of language guarantees about class initialization that the nested class is referenced no earlier (and therefore loaded no earlier by the class loader) than the moment that getInstance() is called (thus making it a thread-safe implementation).
+					</li>
+				</ul>
+			</p><p>
+				Any non-nullary constructor for such a class wouldn't make sense, so despite attempting to and possibly creating a nullary constructor (this is what the <code>
+				getInstance()</code> method calls to create the <code>Singleton</code> instance), it also warns the user of the presence of non-nullary constructor(s).
+			</p>
+		</div>
+		<div class="snippets">
+			<div class="pre">
+				<h3>With Lombok</h3>
+				<div class="snippet">@HTML_PRE@</div>
+			</div>
+			<div class="sep"></div>
+			<div class="post">
+				<h3>Vanilla Java</h3>
+				<div class="snippet">@HTML_POST@</div>
+			</div>
+		</div>
+		<div style="clear: left;"></div>
+		<div class="overview confKeys">
+			<h3>Supported configuration keys:</h3>
+			<dl>
+			<dt><code>lombok.singleton.flagUsage</code> = [<code>warning</code> | <code>error</code>] (default: not set)</dt>
+			<dd>Lombok will flag any usage of <code>@Singleton</code> as a warning or error if configured.</dd>
+			<dt><code>lombok.singleton.staticGetterName</code> = <em>A name for the getter of the <code>Singleton</code> instance</em> (default: <code>getInstance</code>)</dt>
+			<dd>Depending on the value configured, the clients of the type will be able to obtain the <code>Singleton</code> instance like: 
+			<code>SingletonType.getInstance()</code></dd>
+			<dt><code>lombok.singleton.instanceFieldName</code> = <em>A name for the <code>Singleton</code> instance field</em> (default: <code>INSTANCE</code>)</dt>
+			<dd>This shouldn't matter unless the user wants to configure a different field with the default name. In any case, the field with the configured name
+			will be used by the getter to return the <code>Singleton</code> instance</dd>
+			<dt><code>lombok.singleton.holderClassName</code> = <em>A name for the <code>Singleton</code> holder class</em> (default: <code>SingletonHolder</code>)</dt>
+			<dd>This shouldn't matter unless the user wants to configure a different class with the default name. In any case, the nested class with the configured name
+			will be used to hold the <code>Singleton</code> instance in the <code>Lazy</code> style</dd>
+			</dl>
+		</div>
+		<div class="overview">
+			<h3>Small print</h3><div class="smallprint">
+				<p>
+					Any user typed nullary/non-nullary constructor will not be modified to make them private - instead a simple warning will be emitted. Also warns
+					when a holder class (when the lazy style is used, of course) with the same name as the one that <code>@Singleton</code> needs is already present leaving the class untouched. Any uninitialized
+					final fields must be initialized through a user typed nullary constructor. Otherwise the compilation will fail with an appropriate error. If a field with
+					the name of the instance field that <code>@Singleton</code> attempts to generate already exists, no action is taken (a compilation error will result if
+					it's of a different type).
+				</p>
+			</div>
+		</div>
+		<div class="footer">
+			<a href="index.html">Back to experimental features</a> | <a href="ExtensionMethod.html">Previous feature (@ExtensionMethod)</a> | <a href="Delegate.html">Next feature (@Delegate)</a><br />
+			<a href="../../credits.html" class="creditsLink">credits</a> | <span class="copyright">Copyright &copy; 2009-2015 The Project Lombok Authors, licensed under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT license</a>.</span>
+		</div>
+		<div style="clear: both;"></div>
+	</div>
+</div>
+<script type="text/javascript">
+	var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+	document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+</script>
+<script type="text/javascript">
+	try {
+		var pageTracker = _gat._getTracker("UA-9884254-1");
+		pageTracker._trackPageview();
+	} catch(err) {}
+</script>
+</body></html>


### PR DESCRIPTION
The new experimental `@Singleton` annotation will help user build thread-safe Singleton classes that ensure only a single instance of them ever exist.

The implementation comes in two flavors:
* eager (creates and initializes a `private`, `static` and `final` field by invoking the `nullary` constructor)
* lazy (resorts to creating a nested class called the `holder` to hold the singleton instance)

The documentation also includes the usage samples and various configurable keys.