### PR TITLE
Update comments with 'public boolean canEqual' to 'protected boolean canEqual'

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -740,7 +740,7 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 	
 	
 	public MethodDeclaration createCanEqual(EclipseNode type, ASTNode source, List<Annotation> onParam) {
-		/* public boolean canEqual(final java.lang.Object other) {
+		/* protected boolean canEqual(final java.lang.Object other) {
 		 *     return other instanceof Outer.Inner.MyType;
 		 * }
 		 */

--- a/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
@@ -517,7 +517,7 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 	}
 
 	public JCMethodDecl createCanEqual(JavacNode typeNode, JCTree source, List<JCAnnotation> onParam) {
-		/* public boolean canEqual(final java.lang.Object other) {
+		/* protected boolean canEqual(final java.lang.Object other) {
 		 *     return other instanceof Outer.Inner.MyType;
 		 * }
 		 */


### PR DESCRIPTION
Code was changed to use protected in 4d24542dac058fcd, but the comments were left alone.

(tiny change. Was confused when looking at `createCanEqual` as the comments didn't seem to match what the code was doing. Because they don't.)

Signed-off-by: Ross Allan <ross@nallar.me>