### PR TITLE
Allow hashCode and equals generation to be skipped completely

### DIFF
--- a/src/core/lombok/EqualsAndHashCode.java
+++ b/src/core/lombok/EqualsAndHashCode.java
@@ -69,6 +69,12 @@ public @interface EqualsAndHashCode {
 	AnyAnnotation[] onParam() default {};
 	
 	/**
+	 * Whether hashCode and equals should be generated.
+	 * <strong>default: true</strong>
+	 */
+	boolean enabled() default true;
+	
+	/**
 	 * Placeholder annotation to enable the placement of annotations on the generated code.
 	 * @deprecated Don't use this annotation, ever - Read the documentation.
 	 */

--- a/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
@@ -92,6 +92,9 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 		
 		deleteAnnotationIfNeccessary(annotationNode, EqualsAndHashCode.class);
 		EqualsAndHashCode ann = annotation.getInstance();
+		if (!ann.enabled()) {
+			return;
+		}
 		List<String> excludes = List.from(ann.exclude());
 		List<String> includes = List.from(ann.of());
 		JavacNode typeNode = annotationNode.up();


### PR DESCRIPTION
Didn't find an option to switch off the generation of hashCode and equals completely.

I'm pretty new to Lombok, so please correct me if I'm missing anything here.