### PR TITLE
fix JavaBeans naming convention #1023

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -420,11 +420,11 @@ public class HandlerUtil {
 		
 		char first = suffix.charAt(0);
 		if (Character.isLowerCase(first)) {
-			boolean useUpperCase = suffix.length() > 2 &&
+			boolean useLowerCase = suffix.length() >= 2 &&
 				(Character.isTitleCase(suffix.charAt(1)) || Character.isUpperCase(suffix.charAt(1)));
 			suffix = String.format("%s%s",
-					useUpperCase ? Character.toUpperCase(first) : Character.toTitleCase(first),
-					suffix.subSequence(1, suffix.length()));
+				useLowerCase ? Character.toLowerCase(first) : Character.toUpperCase(first),
+				suffix.subSequence(1, suffix.length()));
 		}
 		return String.format("%s%s", prefix, suffix);
 	}

--- a/test/core/src/lombok/core/TestHandlerUtil.java
+++ b/test/core/src/lombok/core/TestHandlerUtil.java
@@ -21,11 +21,34 @@
  */
 package lombok.core;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import static lombok.core.handlers.HandlerUtil.buildAccessorName;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
 
-@RunWith(Suite.class)
-@SuiteClasses({TestSingulars.class, TestHandlerUtil.class})
-public class RunCoreTests {
+public class TestHandlerUtil {
+	
+	@Test
+	public void testBuildAccessorName() {
+		
+		/* normal cases */
+		assertEquals("setFieldName", buildAccessorName("set", "fieldName"));
+		assertEquals("setI", buildAccessorName("set", "i"));
+		assertEquals("setI", buildAccessorName("set", "I"));
+		assertEquals("setUrl", buildAccessorName("set", "Url"));
+		
+		/* when the second character is uppercase, leave the first character unchanged */
+		assertEquals("setURL", buildAccessorName("set", "URL"));
+		assertEquals("setaI", buildAccessorName("set", "aI"));
+		assertEquals("setaIr", buildAccessorName("set", "aIr"));
+		
+		/* handle empty string cases */
+		assertEquals("URL", buildAccessorName("", "URL"));
+		assertEquals("set", buildAccessorName("set", ""));
+		try{
+			buildAccessorName("set", null);
+			buildAccessorName(null, "something");
+			fail("it's not supposed to be null");
+		}catch(NullPointerException e){}
+	}
 }


### PR DESCRIPTION
Fix for issue #1023 

Eclipse and Intellij generate getter and setter for pId as getpId and setpld respectively
while lombok generates getPld and setPId. 
When the first character is lowercase and the second character is uppercase in this case 'I' ('I' as an Ice scream), the first character of the field name should not be capitalized.
