### PR TITLE
Update instructions for using lombok with ecj and Maven

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Enrique da Costa Cambio <enrique.dacostacambio@gmail.com>
 Jappe van der Hel <jappe.vanderhel@gmail.com>
 Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>
+Mart Hagenaars <marthagenaars@gmail.com>
 Peter Grant <petercgrant@users.noreply.github.com>
 Philipp Eichhorn <peichhor@web.de>
 Reinier Zwitserloot <reinier@zwitserloot.com>

--- a/website/index.css
+++ b/website/index.css
@@ -40,6 +40,16 @@ h1 {
 	height: 170px;
 }
 
+.separator {
+	background-image: url(buttonbar.jpg);
+	width: 800px;
+	height: 8px;
+	line-height: 8px;
+	font-size: 14px;
+	text-align: center;
+	clear: both;
+}
+
 .endBar {
 	-webkit-border-bottom-right-radius: 15px 15px;
 	-webkit-border-bottom-left-radius: 15px 15px;
@@ -131,6 +141,10 @@ code {
 .downloadActions {
 	margin-top: 8px;
 	margin-left: 32px;
+}
+
+.note {
+	color: grey;
 }
 
 .footer {

--- a/website/setup/ecj.html
+++ b/website/setup/ecj.html
@@ -42,9 +42,33 @@
 		<div class="downloadHelp">
 			ecj (the eclipse standalone compiler) is compatible with lombok. Use the following command line to enable lombok with ecj:
 			<p>
-			<pre>
-java <strong>-javaagent:lombok.jar=ECJ -Xbootclasspath/p:lombok.jar</strong> -jar ecj.jar -cp lombok.jar <em>(rest of arguments)</em></pre>
+			<pre>java <strong>-javaagent:lombok.jar=ECJ</strong> -jar ecj.jar -cp lombok.jar -source 1.8 <em class="note">(rest of arguments)</em></pre>
+			<p>
+			You may have to add the following VM argument, if you're using an older version of lombok or java:
+			<pre><strong>-Xbootclasspath/p:lombok.jar</strong></pre>
+			<p>
 			If you're using a tool based on ecj, adding these VM arguments and adding lombok.jar to the classpath should work.
+		</div>
+		<div class="separator">
+		</div>
+		<div class="downloadHelp">
+			<h3>Using ecj with Maven</h3>
+			<p>
+				It is possible to <a href="pom.xml">configure</a> <code>maven-compiler-plugin</code> with <code>maven-dependency-plugin</code> and <code>plexus-compiler-eclipse</code>.
+			</p>
+			<p>
+				Before the <code>compile</code> phase, you will have to set your <code>MAVEN_OPTS</code> environment variable to include the <code>javaagent</code> argument.
+				In the example below, <code>target</code> is your <code>${project.build.directory}</code>.
+			</p>
+			<p>
+				Use the following commands in sequence to enable lombok with ecj in your Maven build:
+<pre>
+mvn clean <strong>dependency:copy@get-lombok</strong>
+set MAVEN_OPTS=<strong>-javaagent:target/lombok.jar=ECJ</strong> <em class="note">(or your OS's equivalent)</em>
+mvn install
+set MAVEN_OPTS= <em class="note">(or your OS's equivalent)</em>
+</pre>
+			</p>
 		</div>
 		<div class="endBar">
 		</div>

--- a/website/setup/pom.xml
+++ b/website/setup/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.projectlombok</groupId>
+	<artifactId>eclipse-compiler-test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<lombok.version>1.16.8</lombok.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.5.1</version>
+					<configuration>
+						<compilerId>eclipse</compilerId>
+						<source>1.8</source>
+						<target>1.8</target>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.codehaus.plexus</groupId>
+							<artifactId>plexus-compiler-eclipse</artifactId>
+							<version>2.7</version>
+						</dependency>
+						<dependency>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>2.10</version>
+					<executions>
+						<execution>
+							<id>get-lombok</id>
+							<goals>
+								<goal>copy</goal>
+							</goals>
+							<configuration>
+								<artifactItems>
+									<artifactItem>
+										<groupId>org.projectlombok</groupId>
+										<artifactId>lombok</artifactId>
+										<version>${lombok.version}</version>
+										<type>jar</type>
+										<outputDirectory>${project.build.directory}</outputDirectory>
+										<destFileName>lombok.jar</destFileName>
+									</artifactItem>
+								</artifactItems>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>


### PR DESCRIPTION
As requested by Roel.

These changes add instructions for how to get lombok to hook into an Eclipse compiler in `maven-compiler-plugin`. We are trying to emulate the Eclipse problem view by parsing the logs from a Maven build that uses the Eclipse compiler in a lombok-enabled project.