### PR TITLE
Patch for renaming fields with Getter/Setter/Data in eclipse #210

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>
 Peter Grant <petercgrant@users.noreply.github.com>
 Philipp Eichhorn <peichhor@web.de>
+Rabea Gransberger <rgra@users.noreply.github.com>
 Reinier Zwitserloot <reinier@zwitserloot.com>
 Robbert Jan Grootjans <grootjans@gmail.com>
 Roel Spilker <r.spilker@gmail.com>


### PR DESCRIPTION
Patches the bytecode of RenameFieldProcessor and removes all methods marked with @Generated from the search results to avoid eclipse refactoring them.

Fixes Issue #210
