### PR TITLE
Introduce @Property annotation that'll generate getters and setters.

### DIFF
--- a/buildScripts/website.ant.xml
+++ b/buildScripts/website.ant.xml
@@ -169,6 +169,9 @@ such as converting the changelog into HTML, and creating javadoc.
 		<antcall target="-integrateSnippet">
 			<param name="transformationName" value="experimental/onX" />
 		</antcall>
+		<antcall target="-integrateSnippet">
+			<param name="transformationName" value="experimental/Property" />
+		</antcall>
 	</target>
 	
 	<target name="-website-dist">

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -47,6 +47,7 @@ import lombok.core.configuration.ConfigurationKey;
 import lombok.core.configuration.FlagUsageType;
 import lombok.experimental.Accessors;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.Property;
 import lombok.experimental.Wither;
 
 /**
@@ -159,7 +160,7 @@ public class HandlerUtil {
 			Arrays.<Class<? extends java.lang.annotation.Annotation>>asList(
 			Getter.class, Setter.class, Wither.class, ToString.class, EqualsAndHashCode.class, 
 			RequiredArgsConstructor.class, AllArgsConstructor.class, NoArgsConstructor.class, 
-			Data.class, Value.class, lombok.experimental.Value.class, FieldDefaults.class));
+			Data.class, Value.class, lombok.experimental.Value.class, FieldDefaults.class, Property.class));
 	
 	/**
 	 * Given the name of a field, return the 'base name' of that field. For example, {@code fFoobar} becomes {@code foobar} if {@code f} is in the prefix list.

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -51,6 +51,7 @@ import lombok.core.handlers.HandlerUtil;
 import lombok.eclipse.EclipseAST;
 import lombok.eclipse.EclipseNode;
 import lombok.experimental.Accessors;
+import lombok.experimental.Property;
 import lombok.experimental.Tolerate;
 
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
@@ -838,6 +839,7 @@ public class EclipseHandlerUtil {
 			EclipseNode containingType = field.up();
 			if (containingType != null) for (EclipseNode child : containingType.down()) {
 				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Data.class, child)) hasGetterAnnotation = true;
+				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Property.class, child)) hasGetterAnnotation = true;
 				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Getter.class, child)) {
 					AnnotationValues<Getter> ann = createAnnotation(Getter.class, child);
 					if (ann.getInstance().value() == AccessLevel.NONE) return null;   //Definitely WONT have a getter.

--- a/src/core/lombok/eclipse/handlers/HandleProperty.java
+++ b/src/core/lombok/eclipse/handlers/HandleProperty.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2009-2014 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.eclipse.handlers;
+
+import lombok.AccessLevel;
+import lombok.core.AnnotationValues;
+import lombok.eclipse.EclipseAnnotationHandler;
+import lombok.eclipse.EclipseNode;
+import lombok.experimental.Property;
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.mangosdk.spi.ProviderFor;
+
+/**
+ * Handles the {@code lombok.experimental.Property} annotation for eclipse.
+ */
+@ProviderFor(EclipseAnnotationHandler.class)
+public class HandleProperty extends EclipseAnnotationHandler<Property> {
+	@Override public void handle(AnnotationValues<Property> annotation, Annotation ast, EclipseNode annotationNode) {
+		EclipseNode typeNode = annotationNode.up();
+
+		new HandleGetter().generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
+		new HandleSetter().generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
+	}
+}

--- a/src/core/lombok/experimental/Property.java
+++ b/src/core/lombok/experimental/Property.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2013 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.experimental;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Put on any field/class to make lombok build a standard getter and setter at the same time.
+ * <p>
+ * Complete documentation is found at <a href="http://projectlombok.org/features/experimental/Property.html">the project lombok features page for &#64;Property</a>.
+ * Example:
+ * <pre>
+ *     private &#64;Property int foo;
+ * </pre>
+ * 
+ * will generate:
+ * 
+ * <pre>
+ *     public int getFoo() {
+ *         return this.foo;
+ *     }
+ *
+ *     public void setFoo(int foo) {
+ *         this.foo = foo;
+ *     }
+ * </pre>
+ * <p>
+ *
+ */
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+public @interface Property {
+}

--- a/src/core/lombok/javac/handlers/HandleGetter.java
+++ b/src/core/lombok/javac/handlers/HandleGetter.java
@@ -107,7 +107,7 @@ public class HandleGetter extends JavacAnnotationHandler<Getter> {
 	/**
 	 * Generates a getter on the stated field.
 	 * 
-	 * Used by {@link HandleData}.
+	 * Used by {@link HandleData}, {@link HandleProperty}.
 	 * 
 	 * The difference between this call and the handle method is as follows:
 	 * 

--- a/src/core/lombok/javac/handlers/HandleProperty.java
+++ b/src/core/lombok/javac/handlers/HandleProperty.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2014 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import lombok.AccessLevel;
+import lombok.core.AnnotationValues;
+import lombok.experimental.Property;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import org.mangosdk.spi.ProviderFor;
+
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+/**
+ * Handles the {@code lombok.experimental.Property} annotation for javac.
+ */
+@ProviderFor(JavacAnnotationHandler.class)
+public class HandleProperty extends JavacAnnotationHandler<Property> {
+	@Override public void handle(AnnotationValues<Property> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		deleteAnnotationIfNeccessary(annotationNode, Property.class);
+		JavacNode typeNode = annotationNode.up();
+
+		new HandleGetter().generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
+		new HandleSetter().generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true);
+	}
+}

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -95,7 +95,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 	/**
 	 * Generates a setter on the stated field.
 	 * 
-	 * Used by {@link HandleData}.
+	 * Used by {@link HandleData}, {@link HandleProperty}.
 	 * 
 	 * The difference between this call and the handle method is as follows:
 	 * 

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -48,6 +48,7 @@ import lombok.core.configuration.NullCheckExceptionType;
 import lombok.core.handlers.HandlerUtil;
 import lombok.delombok.LombokOptionsFactory;
 import lombok.experimental.Accessors;
+import lombok.experimental.Property;
 import lombok.experimental.Tolerate;
 import lombok.javac.Javac;
 import lombok.javac.JavacNode;
@@ -725,6 +726,7 @@ public class JavacHandlerUtil {
 			JavacNode containingType = field.up();
 			if (containingType != null) for (JavacNode child : containingType.down()) {
 				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Data.class, child)) hasGetterAnnotation = true;
+				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Property.class, child)) hasGetterAnnotation = true;
 				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Getter.class, child)) {
 					AnnotationValues<Getter> ann = createAnnotation(Getter.class, child);
 					if (ann.getInstance().value() == AccessLevel.NONE) return null;   //Definitely WONT have a getter.

--- a/usage_examples/experimental/PropertyExample_post.jpage
+++ b/usage_examples/experimental/PropertyExample_post.jpage
@@ -1,0 +1,31 @@
+import java.util.UUID;
+
+public class PropertyExample {
+	private UUID id;
+	private String name;
+	private int age;
+
+	public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return this.id;
+    }
+
+	public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getName() {
+        return this.name;
+    }
+
+	public void setAge(int age) {
+        this.age = age;
+    }
+
+    public int getAge() {
+        return this.age;
+    }
+}

--- a/usage_examples/experimental/PropertyExample_pre.jpage
+++ b/usage_examples/experimental/PropertyExample_pre.jpage
@@ -1,0 +1,8 @@
+import lombok.experimental.Peroperty;
+import java.util.UUID;
+
+@Property public class PropertyExample {
+	private UUID id;
+	private String name;
+	private int age;
+}

--- a/website/features/experimental/Property.html
+++ b/website/features/experimental/Property.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html><head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<link rel="stylesheet" type="text/css" href="../../logi/reset.css" />
+	<link rel="stylesheet" type="text/css" href="../features.css" />
+	<link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon" />
+	<meta name="description" content="Spice up your java" />
+	<title>@Property</title>
+</head><body><div id="pepper">
+	<div class="minimumHeight"></div>
+	<div class="meat">
+		<div class="header"><a href="../../index.html">Project Lombok</a></div>
+		<h1>@Property</h1>
+		<div class="byline">Handy shortcut for generating @Getter and @Setter at once</div>
+		<div class="since">
+			<h3>Since</h3>
+			<p>
+				@Property was introduced as experimental feature in lombok v1.16.9
+			</p>
+		</div>
+		<div class="experimental">
+			<h3>Experimental</h3>
+			<p>
+			Experimental because:
+			<ul>
+				<li>Still not sure that <code>@Property</code> will be approved.</li>
+			</ul>
+		</div>
+		<div class="overview">
+			<h3>Overview</h3>
+			<p>
+				There's pretty often a need in Java World to generate getters and setters for a class/property. For example when you're using some (ORM) frameworks.
+				Where @Data is overhead (and actually might work in a wrong way when you need to use only some fields in equals/hashCode and toString methods) when you use it. And you might become pretty tired to write @Getter and @Setter every time.
+			</p><p>
+				For example when you have lot of data model classes you might become tired to write each time <code>@Getter</code> and <code>@Setter</code>.
+			<br/>
+			<br/>
+			Example:<br/>
+			<br/>
+			<code>
+			&nbsp;&nbsp;@Getter<br/>
+			&nbsp;&nbsp;@Setter<br/>
+			&nbsp;&nbsp;public class Person {<br/>
+			&nbsp;&nbsp;&nbsp;&nbsp;private UUID id;<br/>
+			&nbsp;&nbsp;&nbsp;&nbsp;private String firstName;<br/>
+			&nbsp;&nbsp;&nbsp;&nbsp;private String lastName;<br/>
+			&nbsp;&nbsp;}<br/>
+			</code>
+			<br/>
+			<br/>
+			Instead you might want to reduce you boilerplate code to something smaller like:
+			<br/>
+			<br/>
+			<code>
+				&nbsp;&nbsp;@Property<br/>
+				&nbsp;&nbsp;public class Person {<br/>
+				&nbsp;&nbsp;&nbsp;&nbsp;private UUID id;<br/>
+				&nbsp;&nbsp;&nbsp;&nbsp;private String firstName;<br/>
+				&nbsp;&nbsp;&nbsp;&nbsp;private String lastName;<br/>
+				&nbsp;&nbsp;}<br/>
+			</code>
+			<br/>
+			<br/>
+			</p>
+		</div>
+		<div class="snippets">
+			<div class="pre">
+				<h3>With Lombok</h3>
+				<div class="snippet">@HTML_PRE@</div>
+			</div>
+			<div class="sep"></div>
+			<div class="post">
+				<h3>Vanilla Java</h3>
+				<div class="snippet">@HTML_POST@</div>
+			</div>
+		</div>
+		<div style="clear: left;"></div>
+		<div class="footer">
+			<a href="index.html">Back to experimental features</a> | <a href="onX.html">Previous feature (onX)</a> | <span class="disabled">Next feature</span><br />
+			<a href="../../credits.html" class="creditsLink">credits</a> | <span class="copyright">Copyright &copy; 2009-2014 The Project Lombok Authors, licensed under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT license</a>.</span>
+		</div>
+		<div style="clear: both;"></div>
+	</div>
+</div>
+<script type="text/javascript">
+	var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+	document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+</script>
+<script type="text/javascript">
+	try {
+		var pageTracker = _gat._getTracker("UA-9884254-1");
+		pageTracker._trackPageview();
+	} catch(err) {}
+</script>
+</body></html>

--- a/website/features/experimental/index.html
+++ b/website/features/experimental/index.html
@@ -36,6 +36,8 @@
 				<dd>Immutable 'setters' - methods that create a clone but with one changed field.</dd>
 				<dt><a href="onX.html"><code>onMethod= / onConstructor= / onParam=</code></a></dt>
 				<dd>Sup dawg, we heard you like annotations, so we put annotations in your annotations so you can annotate while you're annotating.</dd>
+				<dt><a href="Property.html"><code>@Property</code></a></dt>
+				<dd>Handy shortcut for generating @Getter and @Setter at once</dd>
 			</dl>
 		</div>
 		<div class="overview confKeys">

--- a/website/features/experimental/onX.html
+++ b/website/features/experimental/onX.html
@@ -69,7 +69,7 @@
 			</div>
 		</div>
 		<div class="footer">
-			<a href="index.html">Back to experimental features</a> | <a href="Wither.html">Previous feature (@Wither)</a> | <span class="disabled">Next feature</span><br />
+			<a href="index.html">Back to experimental features</a> | <a href="Wither.html">Previous feature (@Wither)</a> | <a href="Property.html">Next feature (@Property)</a><br />
 			<a href="../../credits.html" class="creditsLink">credits</a> | <span class="copyright">Copyright &copy; 2009-2014 The Project Lombok Authors, licensed under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT license</a>.</span>
 		</div>
 		<div style="clear: both;"></div>


### PR DESCRIPTION
Please merge "@Property" functionality. In big projects it starts to be very annoying to write @Getter @Setter annotation on each model class especially if you have a lot of them. It would be very nice if it was possible to use one simple annotation for this purpose.

When working with frameworks such as Hibernate that are forcing you to have getters and setters (writing @Getter and @Setter starts to be pretty boring after some time) it's not possible to use @Data annotation (which is pretty nice although and good for other purposes), because pretty often(always in our case) you need to have:
1. custom equals/hashCode method
2. custom toString method
