### PR TITLE
Add access level on logs annotations

### DIFF
--- a/src/core/lombok/extern/apachecommons/CommonsLog.java
+++ b/src/core/lombok/extern/apachecommons/CommonsLog.java
@@ -21,6 +21,8 @@
  */
 package lombok.extern.apachecommons;
 
+import lombok.AccessLevel;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -63,4 +65,10 @@ public @interface CommonsLog {
 	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
 	 */
 	String topic() default "";
+
+	/**
+	 * If you want your log to be non-private, you can specify an alternate access level here.
+	 */
+	lombok.AccessLevel value() default AccessLevel.PRIVATE;
+
 }

--- a/src/core/lombok/extern/java/Log.java
+++ b/src/core/lombok/extern/java/Log.java
@@ -21,6 +21,8 @@
  */
 package lombok.extern.java;
 
+import lombok.AccessLevel;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -62,4 +64,10 @@ public @interface Log {
 	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
 	 */
 	String topic() default "";
+
+	/**
+	 * If you want your log to be non-private, you can specify an alternate access level here.
+	 */
+	lombok.AccessLevel value() default AccessLevel.PRIVATE;
+
 }

--- a/src/core/lombok/extern/log4j/Log4j.java
+++ b/src/core/lombok/extern/log4j/Log4j.java
@@ -21,6 +21,8 @@
  */
 package lombok.extern.log4j;
 
+import lombok.AccessLevel;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -63,4 +65,10 @@ public @interface Log4j {
 	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
 	 */
 	String topic() default "";
+
+	/**
+	 * If you want your log to be non-private, you can specify an alternate access level here.
+	 */
+	lombok.AccessLevel value() default AccessLevel.PRIVATE;
+
 }

--- a/src/core/lombok/extern/log4j/Log4j2.java
+++ b/src/core/lombok/extern/log4j/Log4j2.java
@@ -21,6 +21,8 @@
  */
 package lombok.extern.log4j;
 
+import lombok.AccessLevel;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -63,4 +65,10 @@ public @interface Log4j2 {
 	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
 	 */
 	String topic() default "";
+
+	/**
+	 * If you want your log to be non-private, you can specify an alternate access level here.
+	 */
+	lombok.AccessLevel value() default AccessLevel.PRIVATE;
+
 }

--- a/src/core/lombok/extern/slf4j/Slf4j.java
+++ b/src/core/lombok/extern/slf4j/Slf4j.java
@@ -21,6 +21,8 @@
  */
 package lombok.extern.slf4j;
 
+import lombok.AccessLevel;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -62,5 +64,11 @@ public @interface Slf4j {
 	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
 	 */
 	String topic() default "";
+
+	/**
+	 * If you want your log to be non-private, you can specify an alternate access level here.
+	 */
+	lombok.AccessLevel value() default AccessLevel.PRIVATE;
+
 }
 

--- a/src/core/lombok/extern/slf4j/XSlf4j.java
+++ b/src/core/lombok/extern/slf4j/XSlf4j.java
@@ -21,6 +21,8 @@
  */
 package lombok.extern.slf4j;
 
+import lombok.AccessLevel;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -62,4 +64,10 @@ public @interface XSlf4j {
 	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
 	 */
 	String topic() default "";
+
+	/**
+	 * If you want your log to be non-private, you can specify an alternate access level here.
+	 */
+	lombok.AccessLevel value() default AccessLevel.PRIVATE;
+
 }


### PR DESCRIPTION
This change brings the possibility to add an access level on a log annotation (default: private for backward compatibility)
@rzwitserloot : I implemented it directly not knowing how to import the project correctly in my IntellIJ. I am opened to any modification/enhancement that need to be done, but I may need some help to import the project in the IDE :smile: . 
By the way, thank you for you project, it saved me and a lot of people around me a lot of time. :+1: 
