### PR TITLE
Added support for JBoss Logging v3.3.0-Final via @JBossLog [Issue #1103]

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Roel Spilker <r.spilker@gmail.com>
 Sander Koning <askoning@gmail.com>
 Szymon Pacanowski <spacanowski@gmail.com>
 Taiki Sugawara <buzz.taiki@gmail.com>
+Thomas Darimont <thomas.darimont@gmail.com>
 Yun Zhi Lin <yun@yunspace.com>
 
 By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok, and you certify that you have the right to do so for all commits you add to Project Lombok.

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -24,6 +24,8 @@
 		<dependency org="commons-logging" name="commons-logging" rev="1.1.1" conf="test->default; contrib->sources"/>
 		<dependency org="org.slf4j" name="slf4j-api" rev="1.6.1" conf="test->default; contrib->sources"/>
 		<dependency org="org.slf4j" name="slf4j-ext" rev="1.6.1" conf="test->default; contrib->sources"/>
+		<dependency org="org.jboss.logging" name="jboss-logging" rev="3.3.0.Final"  conf="test->default; contrib->sources"/>
+	
 		<dependency org="com.google.guava" name="guava" rev="18.0" conf="test->default; contrib->sources" />
 		<dependency org="com.google.code.findbugs" name="findbugs" rev="3.0.0" conf="test->master" />
 		

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -337,6 +337,13 @@ public class ConfigurationKeys {
 	public static final ConfigurationKey<FlagUsageType> LOG_XSLF4J_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.log.xslf4j.flagUsage", "Emit a warning or error if @XSlf4j is used.") {};
 	
 	/**
+	 * lombok configuration: {@code lombok.log.jbosslog.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 * 
+	 * If set, <em>any</em> usage of {@code @JBossLog} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> LOG_JBOSSLOG_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.log.jbosslog.flagUsage", "Emit a warning or error if @JBossLog is used.") {};
+	
+	/**
 	 * lombok configuration: {@code lombok.log.fieldName} = &lt;String: aJavaIdentifier&gt; (Default: {@code log}).
 	 * 
 	 * If set the various log annotations (which make a log field) will use the stated identifier instead of {@code log} as a name.

--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -229,6 +229,17 @@ public class HandleLog {
 		}
 	}
 	
+	/**
+	 * Handles the {@link lombok.extern.jbosslog.JBossLog} annotation for Eclipse.
+	 */
+	@ProviderFor(EclipseAnnotationHandler.class)
+	public static class HandleJBossLog extends EclipseAnnotationHandler<lombok.extern.jbosslog.JBossLog> {
+		@Override public void handle(AnnotationValues<lombok.extern.jbosslog.JBossLog> annotation, Annotation source, EclipseNode annotationNode) {
+			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_JBOSSLOG_FLAG_USAGE, "@JBossLog", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
+			processAnnotation(LoggingFramework.JBOSSLOG, annotation, source, annotationNode, annotation.getInstance().topic());
+		}
+	}
+	
 	enum LoggingFramework {
 		// private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(TargetType.class);
 		COMMONS("org.apache.commons.logging.Log", "org.apache.commons.logging.LogFactory", "getLog", "@CommonsLog"),
@@ -264,7 +275,9 @@ public class HandleLog {
 		
 		// private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(TargetType.class);
 		XSLF4J("org.slf4j.ext.XLogger", "org.slf4j.ext.XLoggerFactory", "getXLogger", "@XSlf4j"),
-		
+
+		// private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(TargetType.class);
+		JBOSSLOG("org.jboss.logging.Logger", "org.jboss.logging.Logger", "getLogger", "@JBossLog"),
 		;
 		
 		private final String loggerTypeName;

--- a/src/core/lombok/extern/jbosslog/JBossLog.java
+++ b/src/core/lombok/extern/jbosslog/JBossLog.java
@@ -1,0 +1,46 @@
+package lombok.extern.jbosslog;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Causes lombok to generate a logger field.
+ * <p>
+ * Complete documentation is found at <a href="https://projectlombok.org/features/Log.html">the project lombok features page for lombok log annotations</a>.
+ * <p>
+ * Example:
+ * <pre>
+ * &#64;JBossLog
+ * public class LogExample {
+ * }
+ * </pre>
+ * 
+ * will generate:
+ * 
+ * <pre>
+ * public class LogExample {
+ *     private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LogExample.class);
+ * }
+ * </pre>
+ * 
+ * This annotation is valid for classes and enumerations.<br />
+ * @see org.jboss.logging.Logger org.jboss.logging.Logger
+ * @see org.jboss.logging.Logger#getLogger(java.lang.Class) org.jboss.logging.Logger.getLogger(Class target)
+ * @see lombok.extern.apachecommons.CommonsLog &#64;CommonsLog
+ * @see lombok.extern.java.Log &#64;Log
+ * @see lombok.extern.log4j.Log4j &#64;Log4j
+ * @see lombok.extern.log4j.Log4j2 &#64;Log4j2
+ * @see lombok.extern.slf4j.XSlf4j &#64;XSlf4j
+ * @see lombok.extern.jbosslog.JBossLog &#64;JBossLog
+ *  */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface JBossLog {
+	
+	/**
+	 * Sets the category of the constructed Logger. By default, it will use the type where the annotation is placed.
+	 */
+	String topic() default "";
+}

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -175,6 +175,17 @@ public class HandleLog {
 		}
 	}
 	
+	/**
+	 * Handles the {@link lombok.extern.jbosslog.JBossLog} annotation for javac.
+	 */
+	@ProviderFor(JavacAnnotationHandler.class)
+	public static class HandleJBossLog extends JavacAnnotationHandler<lombok.extern.jbosslog.JBossLog> {
+		@Override public void handle(AnnotationValues<lombok.extern.jbosslog.JBossLog> annotation, JCAnnotation ast, JavacNode annotationNode) {
+			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_JBOSSLOG_FLAG_USAGE, "@JBossLog", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
+			processAnnotation(LoggingFramework.JBOSSLOG, annotation, annotationNode, annotation.getInstance().topic());
+		}
+	}
+	
 	enum LoggingFramework {
 		// private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(TargetType.class);
 		COMMONS(lombok.extern.apachecommons.CommonsLog.class, "org.apache.commons.logging.Log", "org.apache.commons.logging.LogFactory.getLog"),
@@ -200,6 +211,8 @@ public class HandleLog {
 		// private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(TargetType.class);
 		XSLF4J(lombok.extern.slf4j.XSlf4j.class, "org.slf4j.ext.XLogger", "org.slf4j.ext.XLoggerFactory.getXLogger"),
 		
+		// private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(TargetType.class);
+		JBOSSLOG(lombok.extern.jbosslog.JBossLog.class, "org.jboss.logging.Logger", "org.jboss.logging.Logger.getLogger")
 		;
 		
 		private final Class<? extends Annotation> annotationClass;

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -144,6 +144,7 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		classpath.add("lib/test/org.slf4j-slf4j-ext.jar");
 		classpath.add("lib/test/log4j-log4j.jar");
 		classpath.add("lib/test/org.apache.logging.log4j-log4j-api.jar");
+		classpath.add("lib/test/jboss-logging.jar");
 		classpath.add("lib/test/com.google.guava-guava.jar");
 		classpath.add("lib/test/com.google.code.findbugs-findbugs.jar");
 		return new FileSystem(classpath.toArray(new String[0]), new String[] {file.getAbsolutePath()}, "UTF-8");

--- a/test/transform/resource/after-delombok/LoggerJBossLog.java
+++ b/test/transform/resource/after-delombok/LoggerJBossLog.java
@@ -1,0 +1,23 @@
+class LoggerJBossLog {
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLog.class);
+}
+class LoggerJBossLogWithImport {
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithImport.class);
+}
+class LoggerJBossLogOuter {
+	static class Inner {
+		@java.lang.SuppressWarnings("all")
+		@javax.annotation.Generated("lombok")
+		private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Inner.class);
+	}
+}
+
+class LoggerJBossLogWithDifferentLoggerName {
+	@java.lang.SuppressWarnings("all")
+	@javax.annotation.Generated("lombok")
+	private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger("DifferentLogger");
+}

--- a/test/transform/resource/after-ecj/LoggerJBossLog.java
+++ b/test/transform/resource/after-ecj/LoggerJBossLog.java
@@ -1,0 +1,38 @@
+import lombok.extern.jbosslog.JBossLog;
+@lombok.extern.jbosslog.JBossLog class LoggerJBossLog {
+  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLog.class);
+  <clinit>() {
+  }
+  LoggerJBossLog() {
+    super();
+  }
+}
+@JBossLog class LoggerJBossLogWithImport {
+  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithImport.class);
+  <clinit>() {
+  }
+  LoggerJBossLogWithImport() {
+    super();
+  }
+}
+class LoggerJBossLogOuter {
+  static @lombok.extern.jbosslog.JBossLog class Inner {
+    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Inner.class);
+    <clinit>() {
+    }
+    Inner() {
+      super();
+    }
+  }
+  LoggerJBossLogOuter() {
+    super();
+  }
+}
+@JBossLog(topic = "DifferentLogger") class LoggerJBossLogWithDifferentLoggerName {
+  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger("DifferentLogger");
+  <clinit>() {
+  }
+  LoggerJBossLogWithDifferentLoggerName() {
+    super();
+  }
+}

--- a/test/transform/resource/before/LoggerJBossLog.java
+++ b/test/transform/resource/before/LoggerJBossLog.java
@@ -1,0 +1,20 @@
+import lombok.extern.jbosslog.JBossLog;
+
+@lombok.extern.jbosslog.JBossLog
+class LoggerJBossLog {
+}
+
+@JBossLog
+class LoggerJBossLogWithImport {
+}
+
+class LoggerJBossLogOuter {
+	@lombok.extern.jbosslog.JBossLog
+	static class Inner {
+		
+	}
+}
+
+@JBossLog(topic="DifferentLogger")
+class LoggerJBossLogWithDifferentLoggerName {
+}


### PR DESCRIPTION
This is my first contribution to lombok.

I ran `ant test` and tested the generated lombok dist jar in eclipse which correctly generated the JBoss Logger field.

I manually put the jboss-logging-3.3.0.Final.jar into  /lombok/lib/test/jboss-logging.jar to run the tests since I couldn't find another way to get the jar there - may be I missed something in the build process.

Cheers,
Thomas