### PR TITLE
support custom annotation again

### DIFF
--- a/src/launch/lombok/launch/ShadowClassLoader.java
+++ b/src/launch/lombok/launch/ShadowClassLoader.java
@@ -94,6 +94,7 @@ class ShadowClassLoader extends ClassLoader {
 	private final String sclSuffix;
 	private final List<String> parentExclusion = new ArrayList<String>();
 	private final List<String> highlanders = new ArrayList<String>();
+	private final Map<String, String> extensionBases = new HashMap<String, String>();
 	
 	/**
 	 * @param source The 'parent' classloader.
@@ -298,6 +299,11 @@ class ShadowClassLoader extends ClassLoader {
 	private boolean inOwnBase(URL item, String name) {
 		if (item == null) return false;
 		String itemString = item.toString();
+		if (extensionBases.containsKey(name)) {
+			String base = extensionBases.get(name);
+			int baseLength = base.length();
+			return (itemString.length() == baseLength + name.length()) && base.regionMatches(0, itemString, 0, baseLength);
+		}
 		return (itemString.length() == SELF_BASE_LENGTH + name.length()) && SELF_BASE.regionMatches(0, itemString, 0, SELF_BASE_LENGTH);
 	}
 	
@@ -372,16 +378,12 @@ class ShadowClassLoader extends ClassLoader {
 		
 		if (altName != null) {
 			URL res = super.getResource(altName);
-			if (res != null && (!noSuper || !isSystemResource(name))) return res;
+			if (res != null && (!noSuper || inOwnBase(res, altName))) return res;
 		}
 		
 		URL res = super.getResource(name);
-		if (res != null && (!noSuper || !isSystemResource(name))) return res;
+		if (res != null && (!noSuper || inOwnBase(res, name))) return res;
 		return null;
-	}
-	
-	private static boolean isSystemResource(String name) {
-		return ClassLoader.getSystemResource(name) != null;
 	}
 	
 	private boolean exclusionListMatch(String name) {
@@ -476,5 +478,21 @@ class ShadowClassLoader extends ClassLoader {
 	
 	public void addOverrideClasspathEntry(String entry) {
 		override.add(new File(entry));
+	}
+
+	/**
+	 * used in SpiLoadUtil via reflect
+	 *
+	 * @param url
+	 * @param name
+	 */
+	private void addExtensionBase(URL url, String name) {
+		String base = url.toString().split("!")[0] + "!/";
+		if (!base.equals(SELF_BASE)) {
+			String className = name.replace(".", "/") + ".class";
+			String altClassName = name.replace(".", "/") + ".SCL." + sclSuffix;
+			extensionBases.put(className, base);
+			extensionBases.put(altClassName, base);
+		}
 	}
 }

--- a/src/launch/lombok/launch/ShadowClassLoader.java
+++ b/src/launch/lombok/launch/ShadowClassLoader.java
@@ -372,12 +372,16 @@ class ShadowClassLoader extends ClassLoader {
 		
 		if (altName != null) {
 			URL res = super.getResource(altName);
-			if (res != null && (!noSuper || inOwnBase(res, altName))) return res;
+			if (res != null && (!noSuper || !isSystemResource(name))) return res;
 		}
 		
 		URL res = super.getResource(name);
-		if (res != null && (!noSuper || inOwnBase(res, name))) return res;
+		if (res != null && (!noSuper || !isSystemResource(name))) return res;
 		return null;
+	}
+	
+	private static boolean isSystemResource(String name) {
+		return ClassLoader.getSystemResource(name) != null;
 	}
 	
 	private boolean exclusionListMatch(String name) {


### PR DESCRIPTION
Since 1.16.X, lombok introduces `ShadowClassLoader`, which breaks custom annotation.
After digging into the codes, it's related to `inOwnBase`.
`InOwnBase` rejects any class not in `lombok.jar`, so it doesn't support custom annotation.

IMO, it's safe to use `!isSystemResource` instead of `inOwnBase`.
