### PR TITLE
always return ShadowClassLoader.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ DaveLaw <project.lombok@apconsult.de>
 Dawid Rusin <dawidrusin90@gmail.com>
 Enrique da Costa Cambio <enrique.dacostacambio@gmail.com>
 Jappe van der Hel <jappe.vanderhel@gmail.com>
+Liu DongMiao <liudongmiao@gmail.com>
 Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>
 Mart Hagenaars <marthagenaars@gmail.com>

--- a/src/core/lombok/core/AnnotationProcessor.java
+++ b/src/core/lombok/core/AnnotationProcessor.java
@@ -103,7 +103,6 @@ public class AnnotationProcessor extends AbstractProcessor {
 					URL selfUrl = new File(ClassRootFinder.findClassRootOfClass(AnnotationProcessor.class)).toURI().toURL();
 					m.invoke(environmentClassLoader, selfUrl);
 				}
-				return environmentClassLoader;
 			}
 			
 			ClassLoader ourClassLoader = JavacDescriptor.class.getClassLoader();


### PR DESCRIPTION

It fixes `lombok` `1.16` doesn't works in `maven-compiler-plugin` `2.3.2` or old.
http://stackoverflow.com/questions/34358689
    
Furthermore, `maven-compiler-plugin` `2.4` requires `plexus-compiler-javac` `1.8.6`, which drops `org.codehaus.plexus.compiler.javac.IsolatedClassLoader`.
    
I love hack, but hate such hard code to fix possible problem.