### PR TITLE
guard against possible npe

### DIFF
--- a/src/core/lombok/javac/handlers/HandleDelegate.java
+++ b/src/core/lombok/javac/handlers/HandleDelegate.java
@@ -312,7 +312,7 @@ public class HandleDelegate extends JavacAnnotationHandler<Delegate> {
 		for (TypeMirror param : sig.type.getTypeVariables()) {
 			Name name = ((TypeVar) param).tsym.name;
 			
-			ListBuffer<JCExpression> bounds = types.getBounds((TypeVar) param).isEmpty() ? null : new ListBuffer<JCExpression>();
+			ListBuffer<JCExpression> bounds = new ListBuffer<JCExpression>();
 			for (Type type : types.getBounds((TypeVar) param)) {
 				bounds.append(JavacResolution.typeToJCTree(type, annotation.getAst(), true));
 			}


### PR DESCRIPTION
    ListBuffer<JCExpression> bounds = types.getBounds((TypeVar) param).isEmpty() ? null : new     ListBuffer<JCExpression>();
			for (Type type : types.getBounds((TypeVar) param)) {
				bounds.append(JavacResolution.typeToJCTree(type, annotation.getAst(), true));
			}
			

--> if bounds is null, npe here
    typeParams.append(maker.TypeParameter(name, bounds.toList()));