### PR TITLE
Add config key lombok.generatedAnnotationName and handling

### DIFF
--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -46,6 +46,13 @@ public class ConfigurationKeys {
 	public static final ConfigurationKey<Boolean> ADD_GENERATED_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.addGeneratedAnnotation", "Generate @javax.annotation.Generated on all generated code (default: true).") {};
 	
 	/**
+	 * lombok configuration: {@code lombok.generatedAnnotationName} = {@code com.fully.qualified.AnnotationName}.
+	 * 
+	 * If set, lombok generates {@code @com.fully.qualified.AnnotationName} on all fields, methods, and types that are generated. If the specified annotation is to be used by code coverage tools, {@code @Retention(RetentionPolicy.CLASS)} is usually required.
+	 */
+	public static final ConfigurationKey<String> GENERATED_ANNOTATION_NAME = new ConfigurationKey<String>("lombok.generatedAnnotationName", "Name of the annotation to generate on all generated code (default: javax.annotation.Generated).") {};
+	
+	/**
 	 * lombok configuration: {@code lombok.extern.findbugs.addSuppressFBWarnings} = {@code true} | {@code false}.
 	 * 
 	 * If {@code true}, lombok generates {@code edu.umd.cs.findbugs.annotations.SuppressFBWarnings} on all fields, methods, and types that are generated.

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1000,7 +1000,12 @@ public class JavacHandlerUtil {
 		if (!LombokOptionsFactory.getDelombokOptions(context).getFormatPreferences().generateGenerated()) return;
 		
 		if (!Boolean.FALSE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_GENERATED_ANNOTATIONS))) {
-			addAnnotation(mods, node, pos, source, context, "javax.annotation.Generated", node.getTreeMaker().Literal("lombok"));
+			String customAnnotation = node.getAst().readConfiguration(ConfigurationKeys.GENERATED_ANNOTATION_NAME);
+			if (customAnnotation == null || customAnnotation.trim().isEmpty()) {
+				addAnnotation(mods, node, pos, source, context, "javax.annotation.Generated", node.getTreeMaker().Literal("lombok"));
+			} else {
+				addAnnotation(mods, node, pos, source, context, customAnnotation, null);
+			}
 		}
 	}
 	


### PR DESCRIPTION
As per these open issues and discussions:

https://github.com/rzwitserloot/lombok/issues/1014
https://github.com/rzwitserloot/lombok/issues/1102
https://github.com/rzwitserloot/lombok/issues/624
https://groups.google.com/forum/#!topic/project-lombok/Vhj46vf2pWg
https://groups.google.com/forum/#!topic/jacoco/r_iWrlAYMp8
http://stackoverflow.com/questions/10276666/lombok-annotations-vs-code-coverage-in-cobertura-or-similar-tool

There is a need by people running code coverage tools to filter out methods generated by Lombok. Writing tests for generated methods is by most considered pointless and goes against the idea of Lombok of removing the clutter of these boiler plate methods by adding boiler plate tests.

Because the `@javax.annotation.Generated` annotation that is already added by Lombok to generated methods has a retention level of 'source', and almost all code coverage tools analyze class files, it is not possible to use the default annotation as a way to signal that those methods should be ignored.

This small PR adds a config key to supply your own annotation to be generated instead, which can then have a retention level of 'class' and can be used with code coverage tools. Example of such an annotation:

```
package com.someproject.util;

import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;

@Retention(RetentionPolicy.CLASS)
public @interface LombokIgnore {}
```

I have successfully tested this PR against Cobertura with the following snipped in my pom.xml:

```
<plugin>
	<groupId>org.codehaus.mojo</groupId>
	<artifactId>cobertura-maven-plugin</artifactId>
	<version>2.7</version>
	<configuration>
		<instrumentation>
			<ignoreMethodAnnotations>
				<ignoreMethodAnnotation>com.someproject.util.LombokIgnore</ignoreMethodAnnotation>
			</ignoreMethodAnnotations>
		</instrumentation>
	</configuration>
	<executions>
		<execution>
			<goals>
				<goal>clean</goal>
			</goals>
		</execution>
	</executions>
</plugin>
```