### PR TITLE
Avoid "possible NPE" warnings for `throw Lombok.sneakyThrow(e)`

### DIFF
--- a/src/core/lombok/Lombok.java
+++ b/src/core/lombok/Lombok.java
@@ -48,12 +48,11 @@ public class Lombok {
 	 */
 	public static RuntimeException sneakyThrow(Throwable t) {
 		if (t == null) throw new NullPointerException("t");
-		Lombok.<RuntimeException>sneakyThrow0(t);
-		return null;
+		return Lombok.<RuntimeException>sneakyThrow0(t);
 	}
 	
 	@SuppressWarnings("unchecked")
-	private static <T extends Throwable> void sneakyThrow0(Throwable t) throws T {
+	private static <T extends Throwable> RuntimeException sneakyThrow0(Throwable t) throws T {
 		throw (T)t;
 	}
 	


### PR DESCRIPTION
Currently, the following code triggers a warning in IntelliJ.
(I'm using the current version, 2016.3.4.)

`    throw Lombok.sneakyThrow(e);`

> Dereference of 'Lombok.sneakyThrow(e)' may produce 'java.lang.NullPointerException'.

This change eliminates the warning.

All tests pass. I ran:

    ant setupJavaOpenJDK6TestEnvironment
    ant test
    ant setupJavaOpenJDK7TestEnvironment
    ant test
    ant setupJavaOracle7TestEnvironment
    ant test
    ant setupJavaOracle8TestEnvironment
    ant test