### PR TITLE
usage_examples:Removed @NotNull from Vanilla Java

### DIFF
--- a/usage_examples/NonNullExample_post.jpage
+++ b/usage_examples/NonNullExample_post.jpage
@@ -1,9 +1,7 @@
-import lombok.NonNull;
-
 public class NonNullExample extends Something {
 	private String name;
 	
-	public NonNullExample(@NonNull Person person) {
+	public NonNullExample(Person person) {
 		super("Hello");
 		if (person == null) {
 			throw new NullPointerException("person");


### PR DESCRIPTION
Vanilla java example used @NotNull field in the constructor and import. Removed it.