### PR TITLE
Fixes issue with BuilderDefault used with Builder and NoArgsConstructor.

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -644,7 +644,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		FieldDeclaration fd = (FieldDeclaration) fieldNode.get();
 		out.returnType = copyType(fd.type, source);
 		out.statements = new Statement[] {new ReturnStatement(fd.initialization, pS, pE)};
-		fd.initialization = null;
 		
 		out.traverse(new SetGeneratedByVisitor(source), ((TypeDeclaration) fieldNode.up().get()).scope);
 		return out;

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -582,7 +582,6 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 		
 		JCStatement statement = maker.Return(field.init);
-		field.init = null;
 		
 		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
 		int modifiers = Flags.PRIVATE | Flags.STATIC;


### PR DESCRIPTION
Below tests demos the issue this change fixes.  Basically if you want to use both @Builder and @NoArgsConstructor which we do because of legacy code, the @Builder.Default breaks the default initialization for @NoArgsConstructor.  We'd like the defaults values initialized when using both the builder and no arg construction of the object.

```
public class BuilderDefaultIssueUnitTest {
    @Test
    public void test() {
        Example example1 = Example.builder().build();
        Example example2 = new Example();

        assertEquals(example1.getSomeDefInitInteger(),example2.getSomeDefInitInteger());
        assertEquals(example2.getSomeDefInitString(),example1.getSomeDefInitString());
    }

    @Data
    @Builder
    @AllArgsConstructor
    @NoArgsConstructor
    public static class Example {
        @Builder.Default
        private int someDefInitInteger = 5;
        @Builder.Default
        private String someDefInitString = "Hello";
    }
}
```