### PR TITLE
fix issue #1440, #1472: wrap BasedFileManager for jdk9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Robbert Jan Grootjans <grootjans@gmail.com>
 Roel Spilker <r.spilker@gmail.com>
 Sander Koning <askoning@gmail.com>
 Szymon Pacanowski <spacanowski@gmail.com>
+Takuya Murakami <tmurakam@tmurakam.org>
 Taiki Sugawara <buzz.taiki@gmail.com>
 Thomas Darimont <thomas.darimont@gmail.com>
 Yun Zhi Lin <yun@yunspace.com>

--- a/src/core/lombok/javac/apt/LombokFileObjects.java
+++ b/src/core/lombok/javac/apt/LombokFileObjects.java
@@ -154,7 +154,7 @@ final class LombokFileObjects {
 		JavaFileManager manager;
 
 		public BaseFileManagerWrapper(JavaFileManager manager) {
-			super(StandardCharsets.UTF_8);
+			super(null); // use default encoding
 			this.manager = manager;
 		}
 		

--- a/src/core/lombok/javac/apt/LombokFileObjects.java
+++ b/src/core/lombok/javac/apt/LombokFileObjects.java
@@ -154,7 +154,7 @@ final class LombokFileObjects {
 		JavaFileManager manager;
 
 		public BaseFileManagerWrapper(JavaFileManager manager) {
-			super(StandardCharsets.UTF_8); // TODO:
+			super(StandardCharsets.UTF_8);
 			this.manager = manager;
 		}
 		

--- a/src/stubs/com/sun/tools/javac/file/BaseFileManager.java
+++ b/src/stubs/com/sun/tools/javac/file/BaseFileManager.java
@@ -4,5 +4,8 @@
 package com.sun.tools.javac.file;
 
 import javax.tools.JavaFileManager;
+import java.nio.charset.Charset;
 
-public abstract class BaseFileManager implements JavaFileManager{}
+public abstract class BaseFileManager implements JavaFileManager {
+    protected BaseFileManager(Charset charset) {}
+}


### PR DESCRIPTION
I've created a workaround to fix the issue #1440, #1472 for IntelliJ + Java9.
It works for me with IntelliJ 2017.3 EAP.

The wrappedManager is proxied with java.lang.reflect.Proxy, so it can't be cast to BaseFileManager.
So I created BaseFileManagerWrapper to wrap it.