### PR TITLE
fix JavaDoc of callSuper in the ToString annotation

### DIFF
--- a/src/core/lombok/ToString.java
+++ b/src/core/lombok/ToString.java
@@ -64,7 +64,7 @@ public @interface ToString {
 	 * Include the result of the superclass's implementation of {@code toString} in the output.
 	 * <strong>default: false</strong>
 	 * 
-	 * @return Whether to call the superclass's {@code equals} implementation as part of the generated equals algorithm.
+	 * @return Whether to call the superclass's {@code toString} implementation as part of the generated equals algorithm.
 	 */
 	boolean callSuper() default false;
 	

--- a/src/core/lombok/ToString.java
+++ b/src/core/lombok/ToString.java
@@ -64,7 +64,7 @@ public @interface ToString {
 	 * Include the result of the superclass's implementation of {@code toString} in the output.
 	 * <strong>default: false</strong>
 	 * 
-	 * @return Whether to call the superclass's {@code toString} implementation as part of the generated equals algorithm.
+	 * @return Whether to call the superclass's {@code toString} implementation as part of the generated toString algorithm.
 	 */
 	boolean callSuper() default false;
 	


### PR DESCRIPTION
It looks like there was a copy paste error in the javadoc it mentioned equals in the toString docs