### PR TITLE
Wrong documentation variables fix.

### DIFF
--- a/src/core/lombok/Cleanup.java
+++ b/src/core/lombok/Cleanup.java
@@ -61,10 +61,10 @@ import java.lang.annotation.Target;
  *                 outStream.write(b, 0, r);
  *             }
  *         } finally {
- *             if (out != null) out.close();
+ *             if (outStream != null) outStream.close();
  *         }
  *     } finally {
- *         if (in != null) in.close();
+ *         if (inStream != null) inStream.close();
  *     }
  * }
  * </pre>


### PR DESCRIPTION
I've fixed documentation for Cleanup annotation. Doc provided before wrong variable information (you closed String instead of Closeable).