### PR TITLE
Property to force loading classes from Class50/*

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -86,7 +86,8 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 			}
 		});
 		
-		final boolean forceBaseResourceNames = !"".equals(System.getProperty("shadow.override.lombok", ""));
+		final boolean forceBaseResourceNames = !"".equals(System.getProperty("shadow.override.lombok", ""))
+			&& (System.getProperty("lombok.eclipseAgent.forceClass50", null) == null);
 		sm.setTransplantMapper(new TransplantMapper() {
 			public String mapResourceName(int classFileFormatVersion, String resourceName) {
 				if (classFileFormatVersion < 50 || forceBaseResourceNames) return resourceName;


### PR DESCRIPTION
An accident mentioned in #1523 is happen because of the code in [`EclipsePatcher.registerPatchScripts()`](https://github.com/rzwitserloot/lombok/blob/b1b49e062e5d64877891ecd327c1ffbd00df5636/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java#L89-L95) method prevents lombok to load classes from the `lombok.jar!Class50/*` paths and it tries to load legacy bytecodes instead of actual ones.

To resolve #1523 this PR introduces one new property:

The new `lombok.eclipseAgent.forceClass50` property allows Eclipse users to enforce loading actual bytecodes from `lombok.jar!Class50/*` even when `shadow.override.lombok` property is set.

An example of using this property in `eclipse.ini` is quite simple:
```
...
-vmargs
-javaagent:lombok.jar
-Dshadow.override.lombok=lombok.jar;some-other.jar
-Dlombok.eclipseAgent.forceClass50
...
```