### PR TITLE
ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS defaults to true

### DIFF
--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -4,6 +4,7 @@ Lombok Changelog
 ### v1.16.19 "Edgy Guinea Pig"
 * v1.16.18 is the latest stable release of Project Lombok.
 * PLATFORM: Possible support for jdk9 in the new IntelliJ, Netbeans and for Gradle.
+* BREAKING CHANGE: _lombok config_ key `lombok.addLombokGeneratedAnnotation` now defaults to `true` instead of false.
 * BREAKING CHANGE: _lombok config_ key `lombok.addJavaxGeneratedAnnotation` now defaults to `false` instead of true. Oracle broke this annotation with the release of JDK9, necessitating this breaking change.
 * BREAKING CHANGE: _lombok config_ key `lombok.anyConstructor.suppressConstructorProperties` is now deprecated and defaults to `true`, that is, by default lombok no longer automatically generates `@ConstructorProperties` annotations. New config key `lombok.anyConstructor.addConstructorProperties` now exists; set it to `true` if you want the old behavior. Oracle more or less broke this annotation with the release of JDK9, necessitating this breaking change.
 * DEVELOPMENT: Compiling lombok on JDK1.9 is now possible.

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -66,7 +66,7 @@ public class ConfigurationKeys {
 	 * 
 	 * If {@code true}, lombok generates {@code @lombok.Generated} on all fields, methods, and types that are generated.
 	 */
-	public static final ConfigurationKey<Boolean> ADD_LOMBOK_GENERATED_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.addLombokGeneratedAnnotation", "Generate @lombok.Generated on all generated code (default: false).") {};
+	public static final ConfigurationKey<Boolean> ADD_LOMBOK_GENERATED_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.addLombokGeneratedAnnotation", "Generate @lombok.Generated on all generated code (default: true).") {};
 	
 	/**
 	 * lombok configuration: {@code lombok.extern.findbugs.addSuppressFBWarnings} = {@code true} | {@code false}.

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -1367,7 +1367,7 @@ public class EclipseHandlerUtil {
 		if (HandlerUtil.shouldAddGenerated(node)) {
 			result = addAnnotation(source, result, JAVAX_ANNOTATION_GENERATED, new StringLiteral(LOMBOK, 0, 0, 0));
 		}
-		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS))) {
+		if (!Boolean.FALSE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS))) {
 			result = addAnnotation(source, result, LOMBOK_GENERATED, null);
 		}
 		return result;

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1064,7 +1064,7 @@ public class JavacHandlerUtil {
 		if (HandlerUtil.shouldAddGenerated(node)) {
 			addAnnotation(mods, node, pos, source, context, "javax.annotation.Generated", node.getTreeMaker().Literal("lombok"));
 		}
-		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS))) {
+		if (!Boolean.FALSE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS))) {
 			addAnnotation(mods, node, pos, source, context, "lombok.Generated", null);
 		}
 	}

--- a/website/templates/features/configuration.html
+++ b/website/templates/features/configuration.html
@@ -86,10 +86,10 @@
 			We advise against this; JDK9 breaks this annotation, and it's unlikely to ever get fixed.<br />
 			<em>NB:</em> Until Lombok v2.0.0, this setting defaulted to <code>true</code>.
 		</p><p>
-			Lombok can be configured to add <code>@lombok.Generated</code> annotations to all generated nodes where possible; useful for JaCoCo (which has built in support),
-			or other style checkers and code coverage tools:
+			Lombok is configured to add <code>@lombok.Generated</code> annotations to all generated nodes where possible; useful for JaCoCo (which has built in support),
+			or other style checkers and code coverage tools.  You can disable this with:
 			<div class="snippet example">
-				<code>lombok.addLombokGeneratedAnnotation = true</code>
+				<code>lombok.addLombokGeneratedAnnotation = false</code>
 			</div>
 		</p><p>
 			Lombok can add the <code>@SuppressFBWarnings</code> annotation which is useful if you want to run <a href="http://findbugs.sourceforge.net/">FindBugs</a> on your class files. To enable this feature, make sure findbugs is on the classpath when you compile, and add the following config key:


### PR DESCRIPTION
Now that jacoco 0.8.0 pays attention to @lombok.Generated, for ease of use change default of ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS to true.