### PR TITLE
[fix] Fix intellij build with jdk10 (#1572)

### DIFF
--- a/src/core/lombok/javac/apt/LombokFileObjects.java
+++ b/src/core/lombok/javac/apt/LombokFileObjects.java
@@ -106,7 +106,8 @@ final class LombokFileObjects {
 		"com.google.devtools.build.buildjar.javac.BlazeJavacMain$ClassloaderMaskingFileManager",
 		"com.google.devtools.build.java.turbine.javac.JavacTurbineCompiler$ClassloaderMaskingFileManager",
 		"org.netbeans.modules.java.source.parsing.ProxyFileManager",
-		"com.sun.tools.javac.api.ClientCodeWrapper$WrappedStandardJavaFileManager"
+		"com.sun.tools.javac.api.ClientCodeWrapper$WrappedStandardJavaFileManager",
+		"com.sun.tools.javac.main.DelegatingJavaFileManager$DelegatingSJFM" // IntelliJ + JDK10
 	);
 	
 	static Compiler getCompiler(JavaFileManager jfm) {

--- a/src/core/lombok/javac/apt/LombokFileObjects.java
+++ b/src/core/lombok/javac/apt/LombokFileObjects.java
@@ -131,6 +131,10 @@ final class LombokFileObjects {
 			catch (Throwable e) {}
 		}
 		try {
+			if (Class.forName("com.sun.tools.javac.file.PathFileObject") == null) throw new NullPointerException();
+			return new Java9Compiler(jfm);
+		} catch (Throwable e) {}
+		try {
 			if (Class.forName("com.sun.tools.javac.file.BaseFileObject") == null) throw new NullPointerException();
 			return Compiler.JAVAC7;
 		} catch (Throwable e) {}


### PR DESCRIPTION
Add a JavaFileManager class name to KNOWN_JAVA9_FILE_MANAGERS,
for IntelliJ build with JDK10.