### PR TITLE
fix #1657: EmptyLombokFileObject: file:// URI must not contain author…

### DIFF
--- a/src/core/lombok/javac/apt/EmptyLombokFileObject.java
+++ b/src/core/lombok/javac/apt/EmptyLombokFileObject.java
@@ -57,7 +57,7 @@ class EmptyLombokFileObject implements LombokFileObject {
 	}
 	
 	@Override public URI toUri() {
-		return URI.create("file://" + name);
+		return URI.create("file:///" + (name.startsWith("/") ? name.substring(1) : name));
 	}
 	
 	@Override public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {


### PR DESCRIPTION
Fix #1657,  change file URI with "file:///" in EmptyLombokFileObject.