### PR TITLE
WIP: add params to @ToString

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -552,7 +552,10 @@ ${sourceWarning}</echo>
 	
 	<target name="test-ecj" depends="dist, contrib, setupJavaOracle8TestEnvironment" unless="tests.skip">
 		<condition property="ecj.loc" value="lib/ecj9/*" else="lib/ecj8/*">
-			<equals arg1="${ant.java.version}" arg2="9" />
+			<or>
+				<equals arg1="${ant.java.version}" arg2="9" />
+				<equals arg1="${ant.java.version}" arg2="10" />
+			</or>
 		</condition>
 		<java classname="org.eclipse.jdt.internal.compiler.batch.Main" fork="true" failonerror="true">
 			<classpath path="${ecj.loc}" />

--- a/src/core/lombok/ToString.java
+++ b/src/core/lombok/ToString.java
@@ -75,4 +75,10 @@ public @interface ToString {
 	 * @return If {@code true}, always use direct field access instead of calling the getter method.
 	 */
 	boolean doNotUseGetters() default false;
+
+    boolean fqn() default false;
+	String prefix() default "(";
+	String separator() default "=";
+	String infix() default ", ";
+	String suffix() default ")";
 }

--- a/src/core/lombok/core/AnnotationValues.java
+++ b/src/core/lombok/core/AnnotationValues.java
@@ -42,31 +42,7 @@ public class AnnotationValues<A extends Annotation> {
 	private final Class<A> type;
 	private final Map<String, AnnotationValue> values;
 	private final LombokNode<?, ?, ?> ast;
-	
-	public static class ClassLiteral {
-		private final String className;
-		
-		public ClassLiteral(String className) {
-			this.className = className;
-		}
-		
-		public String getClassName() {
-			return className;
-		}
-	}
-	
-	public static class FieldSelect {
-		private final String finalPart;
-		
-		public FieldSelect(String finalPart) {
-			this.finalPart = finalPart;
-		}
-		
-		public String getFinalPart() {
-			return finalPart;
-		}
-	}
-	
+
 	/**
 	 * Represents a single method on the annotation class. For example, the value() method on the Getter annotation.
 	 */

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -453,7 +453,8 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 			for (BuilderFieldData bfd : builderFields) {
 				fieldNodes.addAll(bfd.createdFields);
 			}
-			MethodDeclaration md = HandleToString.createToString(builderType, fieldNodes, true, false, ast, FieldAccess.ALWAYS_FIELD);
+			MethodDeclaration md = HandleToString.createToString(builderType, ast, false, "(", false, true,
+					"=", FieldAccess.ALWAYS_FIELD, fieldNodes, ", ", ")");
 			if (md != null) injectMethod(builderType, md);
 		}
 		

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -402,7 +402,8 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			for (BuilderFieldData bfd : builderFields) {
 				fieldNodes.addAll(bfd.createdFields);
 			}
-			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, false, FieldAccess.ALWAYS_FIELD, ast);
+			JCMethodDecl md = HandleToString.createToString(builderType, ast, false, "(", false, true,
+					"=", FieldAccess.ALWAYS_FIELD, fieldNodes, ", ", ")");
 			if (md != null) injectMethod(builderType, md);
 		}
 		

--- a/src/utils/lombok/core/ClassLiteral.java
+++ b/src/utils/lombok/core/ClassLiteral.java
@@ -1,0 +1,13 @@
+package lombok.core;
+
+public class ClassLiteral {
+    private final String className;
+
+    public ClassLiteral(String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/src/utils/lombok/core/FieldSelect.java
+++ b/src/utils/lombok/core/FieldSelect.java
@@ -1,0 +1,13 @@
+package lombok.core;
+
+public class FieldSelect {
+    private final String finalPart;
+
+    public FieldSelect(String finalPart) {
+        this.finalPart = finalPart;
+    }
+
+    public String getFinalPart() {
+        return finalPart;
+    }
+}

--- a/src/utils/lombok/eclipse/Eclipse.java
+++ b/src/utils/lombok/eclipse/Eclipse.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import lombok.core.ClassLiteral;
+import lombok.core.FieldSelect;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
@@ -43,8 +45,6 @@ import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
-
-import lombok.core.AnnotationValues;
 
 public class Eclipse {
 	private static final Annotation[] EMPTY_ANNOTATIONS_ARRAY = new Annotation[0];
@@ -177,13 +177,13 @@ public class Eclipse {
 			default: return null;
 			}
 		} else if (e instanceof ClassLiteralAccess) {
-			return new AnnotationValues.ClassLiteral(Eclipse.toQualifiedName(((ClassLiteralAccess)e).type.getTypeName()));
+			return new ClassLiteral(Eclipse.toQualifiedName(((ClassLiteralAccess)e).type.getTypeName()));
 		} else if (e instanceof SingleNameReference) {
-			return new AnnotationValues.FieldSelect(new String(((SingleNameReference)e).token));
+			return new FieldSelect(new String(((SingleNameReference)e).token));
 		} else if (e instanceof QualifiedNameReference) {
 			String qName = Eclipse.toQualifiedName(((QualifiedNameReference)e).tokens);
 			int idx = qName.lastIndexOf('.');
-			return new AnnotationValues.FieldSelect(idx == -1 ? qName : qName.substring(idx+1));
+			return new FieldSelect(idx == -1 ? qName : qName.substring(idx+1));
 		}
 		
 		return null;

--- a/src/utils/lombok/javac/Javac.java
+++ b/src/utils/lombok/javac/Javac.java
@@ -36,7 +36,8 @@ import javax.lang.model.type.NoType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeVisitor;
 
-import lombok.core.AnnotationValues;
+import lombok.core.ClassLiteral;
+import lombok.core.FieldSelect;
 import lombok.javac.JavacTreeMaker.TreeTag;
 import lombok.javac.JavacTreeMaker.TypeTag;
 
@@ -148,10 +149,10 @@ public class Javac {
 		
 		if (expr instanceof JCIdent || expr instanceof JCFieldAccess) {
 			String x = expr.toString();
-			if (x.endsWith(".class")) return new AnnotationValues.ClassLiteral(x.substring(0, x.length() - 6));
+			if (x.endsWith(".class")) return new ClassLiteral(x.substring(0, x.length() - 6));
 			int idx = x.lastIndexOf('.');
 			if (idx > -1) x = x.substring(idx + 1);
-			return new AnnotationValues.FieldSelect(x);
+			return new FieldSelect(x);
 		}
 		
 		return null;

--- a/test/transform/resource/after-delombok/ToStringParams.java
+++ b/test/transform/resource/after-delombok/ToStringParams.java
@@ -1,0 +1,37 @@
+package lombok.test;
+class ToStringOuter {
+	int x;
+	String name;
+	class ToStringInner {
+		int y;
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "lombok.test.ToStringOuter.ToStringInner(y=" + this.y + ")";
+		}
+	}
+	static class ToStringStaticInner {
+		int y;
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "ToStringOuter.ToStringStaticInner(y = " + this.y + ")";
+		}
+	}
+	class ToStringMiddle {
+		class ToStringMoreInner extends ToStringInner {
+			String name;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "lombok.test.ToStringOuter.ToStringMiddle.ToStringMoreInner[\n\tsuper = " + super.toString() + ",\n\t" + this.name + "\n]";
+			}
+		}
+	}
+	
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public java.lang.String toString() {
+		return "lombok.test.ToStringOuter\n{\n    \"x\" : \"" + this.x + "\",\n    \"name\" : \"" + this.name + "\"\n}";
+	}
+}

--- a/test/transform/resource/after-ecj/ToStringParams.java
+++ b/test/transform/resource/after-ecj/ToStringParams.java
@@ -1,0 +1,48 @@
+package lombok.test;
+import lombok.ToString;
+@ToString(fqn = true, prefix = "\n{\n    \"", separator = "\" : \"", infix = "\",\n    \"", suffix = "\"\n}")
+class ToStringOuter {
+  @ToString(fqn = true)
+  class ToStringInner {
+    int y;
+    ToStringInner() {
+      super();
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("lombok.test.ToStringOuter.ToStringInner(y=" + this.y) + ")");
+    }
+  }
+  @ToString(separator = " = ")
+  static class ToStringStaticInner {
+    int y;
+    ToStringStaticInner() {
+      super();
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("ToStringOuter.ToStringStaticInner(y = " + this.y) + ")");
+    }
+  }
+  class ToStringMiddle {
+    @ToString(fqn = true, prefix = "[\n\t", callSuper = true, includeFieldNames = false, separator = " = ", infix = ",\n\t", suffix = "\n]")
+    class ToStringMoreInner extends ToStringInner {
+      String name;
+      ToStringMoreInner() {
+        super();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("lombok.test.ToStringOuter.ToStringMiddle.ToStringMoreInner[\n\tsuper = " + super.toString()) + ",\n\t") + this.name) + "\n]");
+      }
+    }
+    ToStringMiddle() {
+      super();
+    }
+  }
+  int x;
+  String name;
+  ToStringOuter() {
+    super();
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+    return (((("lombok.test.ToStringOuter\n{\n    \"x\" : \"" + this.x) + "\",\n    \"name\" : \"") + this.name) + "\"\n}");
+  }
+}

--- a/test/transform/resource/before/ToStringParams.java
+++ b/test/transform/resource/before/ToStringParams.java
@@ -1,0 +1,24 @@
+package lombok.test;
+import lombok.ToString;
+@ToString(fqn = true, prefix = "\n{\n    \"", separator = "\" : \"", infix = "\",\n    \"", suffix = "\"\n}")
+class ToStringOuter {
+	int x;
+	String name;
+
+	@ToString(fqn = true)
+	class ToStringInner {
+		int y;
+	}
+
+	@ToString(separator = " = ")
+	static class ToStringStaticInner {
+		int y;
+	}
+
+	class ToStringMiddle {
+		@ToString(fqn = true, prefix = "[\n\t", callSuper = true, includeFieldNames = false, separator = " = ", infix = ",\n\t", suffix = "\n]")
+		class ToStringMoreInner extends ToStringInner {
+			String name;
+		}
+	}
+}


### PR DESCRIPTION
Please consider addition of these parameters to `@ToString` :
- fqn - whether to print fully qualified name, default false
- prefix - what to add before properties, default "("
- separator - what to add between property name and value, default "="
- infix - what to add between property name/value pairs, default ", "
- suffix - what to add after properties, default ")"

Perhaps instead of boolean fqn, there should be some enum like ClassName (NONE, SHORT, FULL), where NONE means don't print class name at all.
I also think about adding forEach parameter - name of a method called for each property name/value pair - it  could help to deal with null values and special formatting for distinct properties.
The last one to think of is a pattern parameter - as you wrote in #1297 - "Not sure if we actually want this". But if eventually it will be implemented, then parameters proposed here just can be ignored.