### PR TITLE
Preserve default values on fields when using @Builder.Default

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -651,7 +651,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		FieldDeclaration fd = (FieldDeclaration) fieldNode.get();
 		out.returnType = copyType(fd.type, source);
 		out.statements = new Statement[] {new ReturnStatement(fd.initialization, pS, pE)};
-		fd.initialization = null;
 		
 		out.traverse(new SetGeneratedByVisitor(source), ((TypeDeclaration) fieldNode.up().get()).scope);
 		return out;

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -591,7 +591,6 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 		
 		JCStatement statement = maker.Return(field.init);
-		field.init = null;
 		
 		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
 		int modifiers = Flags.PRIVATE | Flags.STATIC;


### PR DESCRIPTION
Particularly, this allows `@NoArgsConstructor` to continue using default
values even when `@Builder.Default` is present on a field.

Closes #1347 

I did spend some time trying to get the tests to pass, but they seemed to be fundamentally broken. Particularly, I found a comment stating that the priority of `@Builder` is such that it must run before `@Value` so that `@Builder` can error if a field has both annotations. However, the presently existing test includes `@Value` and `@Builder`, and this is the use case that produced this bug in the first place, because the default value must be removed with `@Value` because `@Value` transforms fields to be final. That being said, I think there's more cleanup that needs to happen in `@Builder`, but I feel it is outside the scope of this issue.