### PR TITLE
Make the null check exception a little bit more explicit

### DIFF
--- a/src/core/lombok/core/configuration/NullCheckExceptionType.java
+++ b/src/core/lombok/core/configuration/NullCheckExceptionType.java
@@ -35,7 +35,7 @@ public enum NullCheckExceptionType {
 	},
 	NULL_POINTER_EXCEPTION {
 		@Override public String toExceptionMessage(String fieldName) {
-			return fieldName;
+			return fieldName + " is marked as @NonNull but is null";
 		}
 		
 		public String getExceptionType() {


### PR DESCRIPTION
Currently it is "NullPointerException: someFieldName" and that is not very
telling as to the reasons this exception is thrown. It should be easily identifiable that this is due to a Lombok null check. 