### PR TITLE
@SuperBuilder: support for fields from parent classes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ DaveLaw <project.lombok@apconsult.de>
 Dave Brosius <dbrosius@mebigfatguy.com>
 Dawid Rusin <dawidrusin90@gmail.com>
 Enrique da Costa Cambio <enrique.dacostacambio@gmail.com>
+Jan Rieke <it@janrieke.de>
 Jappe van der Hel <jappe.vanderhel@gmail.com>
 Kevin Chirls <kchirls@users.noreply.github.com>
 Liu DongMiao <liudongmiao@gmail.com>

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -508,6 +508,15 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> WITHER_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.wither.flagUsage", "Emit a warning or error if @Wither is used.") {};
 	
+	// ----- SuperBuilder -----
+	
+	/**
+	 * lombok configuration: {@code lombok.superBuilder.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 * 
+	 * If set, <em>any</em> usage of {@code @SuperBuilder} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> SUPERBUILDER_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.superBuilder.flagUsage", "Emit a warning or error if @SuperBuilder is used.") {};
+
 	// ----- Configuration System -----
 	
 	/**

--- a/src/core/lombok/eclipse/handlers/EclipseSingularsRecipes.java
+++ b/src/core/lombok/eclipse/handlers/EclipseSingularsRecipes.java
@@ -229,7 +229,7 @@ public class EclipseSingularsRecipes {
 		 * control over the return type and value, use
 		 * {@link #generateMethods(SingularData, boolean, EclipseNode, boolean, Supplier, Supplier)}.
 		 */
-		public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, boolean chain) {
+		public void generateMethods(SingularData data, boolean deprecate, final EclipseNode builderType, boolean fluent, final boolean chain) {
 			// TODO: Make these lambdas when switching to a source level >= 1.8.
 			Supplier<TypeReference> returnType = new Supplier<TypeReference>() {
 				@Override public TypeReference get() {

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -434,7 +434,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		
 		if (constructorExists(builderType) == MemberExistsResult.NOT_EXISTS) {
 			ConstructorDeclaration cd = HandleConstructor.createConstructor(
-				AccessLevel.PACKAGE, builderType, Collections.<EclipseNode>emptyList(), false,
+				AccessLevel.PACKAGE, builderType, Collections.<EclipseNode>emptyList(), false, true,
 				annotationNode, Collections.<Annotation>emptyList());
 			if (cd != null) injectMethod(builderType, cd);
 		}
@@ -569,7 +569,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		
 		for (BuilderFieldData bfd : builderFields) {
 			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
-				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, type, statements, bfd.name);
+				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, type, statements, bfd.name, "this");
 			}
 		}
 		
@@ -640,7 +640,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		return trs;
 	}
 	
-	public MethodDeclaration generateDefaultProvider(char[] methodName, TypeParameter[] typeParameters, EclipseNode fieldNode, ASTNode source) {
+	public static MethodDeclaration generateDefaultProvider(char[] methodName, TypeParameter[] typeParameters, EclipseNode fieldNode, ASTNode source) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) fieldNode.top().get()).compilationResult);

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -434,7 +434,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		
 		if (constructorExists(builderType) == MemberExistsResult.NOT_EXISTS) {
 			ConstructorDeclaration cd = HandleConstructor.createConstructor(
-				AccessLevel.PACKAGE, builderType, Collections.<EclipseNode>emptyList(), false, true,
+				AccessLevel.PACKAGE, builderType, Collections.<EclipseNode>emptyList(), false,
 				annotationNode, Collections.<Annotation>emptyList());
 			if (cd != null) injectMethod(builderType, cd);
 		}

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -25,7 +25,6 @@ import static lombok.eclipse.Eclipse.*;
 import static lombok.core.handlers.HandlerUtil.*;
 import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,7 +40,6 @@ import org.eclipse.jdt.internal.compiler.ast.Assignment;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ConditionalExpression;
 import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;
-import org.eclipse.jdt.internal.compiler.ast.ExplicitConstructorCall;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.FalseLiteral;
 import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
@@ -52,7 +50,6 @@ import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.OperatorIds;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedQualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedSingleTypeReference;
-import org.eclipse.jdt.internal.compiler.ast.QualifiedNameReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedThisReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ReturnStatement;
@@ -84,7 +81,6 @@ import lombok.core.HandlerPriority;
 import lombok.eclipse.Eclipse;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
-import lombok.eclipse.handlers.EclipseHandlerUtil.MemberExistsResult;
 import lombok.eclipse.handlers.EclipseSingularsRecipes.EclipseSingularizer;
 import lombok.eclipse.handlers.EclipseSingularsRecipes.SingularData;
 import lombok.eclipse.handlers.HandleConstructor.SkipIfConstructorExists;
@@ -106,7 +102,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 	}
 	
 	private static class BuilderFieldData {
-		EclipseNode fieldNode;
 		TypeReference type;
 		char[] rawName;
 		char[] name;
@@ -160,10 +155,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		String builderMethodName = builderInstance.builderMethodName();
 		String buildMethodName = builderInstance.buildMethodName();
 		String builderClassName = builderInstance.builderClassName();
-		
-		boolean inherit = builderInstance.inherit();
-		boolean extensible = inherit || builderInstance.extensible(); // inherit implies extendable
-		
 		String toBuilderMethodName = "toBuilder";
 		boolean toBuilder = builderInstance.toBuilder();
 		List<char[]> typeArgsForToBuilder = null;
@@ -191,11 +182,9 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		boolean addCleaning = false;
 		boolean isStatic = true;
 		
-		TypeDeclaration td = null;
-		
 		if (parent.get() instanceof TypeDeclaration) {
 			tdParent = parent;
-			td = (TypeDeclaration) tdParent.get();
+			TypeDeclaration td = (TypeDeclaration) tdParent.get();
 			
 			List<EclipseNode> allFields = new ArrayList<EclipseNode>();
 			boolean valuePresent = (hasAnnotation(lombok.Value.class, parent) || hasAnnotation("lombok.experimental.Value", parent));
@@ -205,7 +194,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 				boolean isFinal = ((fd.modifiers & ClassFileConstants.AccFinal) != 0) || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));
 				
 				BuilderFieldData bfd = new BuilderFieldData();
-				bfd.fieldNode = fieldNode;
 				bfd.rawName = fieldNode.getName().toCharArray();
 				bfd.name = removePrefixFromField(fieldNode);
 				bfd.type = fd.type;
@@ -239,29 +227,15 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 				allFields.add(fieldNode);
 			}
 			
-			if (builderClassName.isEmpty()) builderClassName = new String(td.name) + "Builder";
-			
-			if (extensible) {
-				boolean callBuilderBasedSuperConstructor = td.superclass != null;
-				generateBuilderBasedConstructor(tdParent, builderFields, annotationNode, builderClassName, callBuilderBasedSuperConstructor);
-			} else {
-				handleConstructor.generateConstructor(tdParent, AccessLevel.PACKAGE, allFields, false, null, SkipIfConstructorExists.I_AM_BUILDER,
-					Collections.<Annotation>emptyList(), annotationNode);
-			}
+			handleConstructor.generateConstructor(tdParent, AccessLevel.PACKAGE, allFields, false, null, SkipIfConstructorExists.I_AM_BUILDER,
+				Collections.<Annotation>emptyList(), annotationNode);
 			
 			returnType = namePlusTypeParamsToTypeReference(td.name, td.typeParameters, p);
 			typeParams = td.typeParameters;
 			thrownExceptions = null;
 			nameOfStaticBuilderMethod = null;
+			if (builderClassName.isEmpty()) builderClassName = new String(td.name) + "Builder";
 		} else if (parent.get() instanceof ConstructorDeclaration) {
-			if (inherit) {
-				annotationNode.addError("@Builder(inherit=true) is only supported for type builders.");
-				return;
-			}
-			if (extensible) {
-				annotationNode.addError("@Builder(extensible=true) is only supported for type builders.");
-				return;
-			}
 			ConstructorDeclaration cd = (ConstructorDeclaration) parent.get();
 			if (cd.typeParameters != null && cd.typeParameters.length > 0) {
 				annotationNode.addError("@Builder is not supported on constructors with constructor type parameters.");
@@ -269,21 +243,13 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 			}
 			
 			tdParent = parent.up();
-			td = (TypeDeclaration) tdParent.get();
+			TypeDeclaration td = (TypeDeclaration) tdParent.get();
 			returnType = namePlusTypeParamsToTypeReference(td.name, td.typeParameters, p);
 			typeParams = td.typeParameters;
 			thrownExceptions = cd.thrownExceptions;
 			nameOfStaticBuilderMethod = null;
 			if (builderClassName.isEmpty()) builderClassName = new String(cd.selector) + "Builder";
 		} else if (parent.get() instanceof MethodDeclaration) {
-			if (inherit) {
-				annotationNode.addError("@Builder(inherit=true) is only supported for type builders.");
-				return;
-			}
-			if (extensible) {
-				annotationNode.addError("@Builder(extendable=true) is only supported for type builders.");
-				return;
-			}
 			MethodDeclaration md = (MethodDeclaration) parent.get();
 			tdParent = parent.up();
 			isStatic = md.isStatic();
@@ -414,20 +380,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		
 		EclipseNode builderType = findInnerClass(tdParent, builderClassName);
 		if (builderType == null) {
-			String superclassBuilderClassName = null;
-			if (inherit) {
-				if (td.superclass == null) {
-					annotationNode.addError("@Builder(inherit = true) requires that your class has an 'extends' clause.");
-					return;
-				}
-				
-				superclassBuilderClassName = builderInstance.superclassBuilderClassName();
-				if (superclassBuilderClassName == null || superclassBuilderClassName.isEmpty()) {
-					superclassBuilderClassName = new String(td.superclass.getLastToken()) + "Builder";
-				}
-			}
-			
-			builderType = makeBuilderClass(isStatic, tdParent, builderClassName, typeParams, ast, superclassBuilderClassName);
+			builderType = makeBuilderClass(isStatic, tdParent, builderClassName, typeParams, ast);
 		} else {
 			TypeDeclaration builderTypeDeclaration = (TypeDeclaration) builderType.get();
 			if (isStatic && (builderTypeDeclaration.modifiers & ClassFileConstants.AccStatic) == 0) {
@@ -491,7 +444,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		}
 		
 		if (methodExists(buildMethodName, builderType, -1) == MemberExistsResult.NOT_EXISTS) {
-			MethodDeclaration md = generateBuildMethod(tdParent, isStatic, buildMethodName, nameOfStaticBuilderMethod, returnType, builderFields, builderType, thrownExceptions, addCleaning, ast, extensible);
+			MethodDeclaration md = generateBuildMethod(tdParent, isStatic, buildMethodName, nameOfStaticBuilderMethod, returnType, builderFields, builderType, thrownExceptions, addCleaning, ast);
 			if (md != null) injectMethod(builderType, md);
 		}
 		
@@ -539,7 +492,8 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long) pS << 32 | pE;
 		
-		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) type.top().get()).compilationResult);
+		MethodDeclaration out = new MethodDeclaration(
+				((CompilationUnitDeclaration) type.top().get()).compilationResult);
 		out.selector = methodName.toCharArray();
 		out.modifiers = ClassFileConstants.AccPublic;
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
@@ -577,92 +531,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 
 	}
 	
-	/**
-	 * Generates a constructor that has a builder as the only parameter.
-	 * The values from the builder are used to initialize the fields of new instances.
-	 *
-	 * @param typeNode
-	 *            the type (with the {@code @Builder} annotation) for which a
-	 *            constructor should be generated.
-	 * @param builderFields a list of fields in the builder which should be assigned to new instances.
-	 * @param sourceNode the annotation (used for setting source code locations for the generated code).
-	 * @param builderClassnameAsParameter
-	 *            If {@code != null}, the only parameter of the constructor will
-	 *            be a builder with this classname; the constructor will then
-	 *            use the values within this builder to assign the fields of new
-	 *            instances.
-	 * @param callBuilderBasedSuperConstructor
-	 *            If {@code true}, the constructor will explicitly call a super
-	 *            constructor with the builder as argument. Requires
-	 *            {@code builderClassAsParameter != null}.
-	 */
-	private void generateBuilderBasedConstructor(EclipseNode typeNode, List<BuilderFieldData> builderFields, EclipseNode sourceNode,
-			String builderClassnameAsParameter, boolean callBuilderBasedSuperConstructor) {
-		
-		ASTNode source = sourceNode.get();
-		
-		TypeDeclaration typeDeclaration = ((TypeDeclaration) typeNode.get());
-		long p = (long) source.sourceStart << 32 | source.sourceEnd;
-		
-		ConstructorDeclaration constructor = new ConstructorDeclaration(((CompilationUnitDeclaration) typeNode.top().get()).compilationResult);
-		
-		constructor.modifiers = toEclipseModifier(AccessLevel.PROTECTED);
-		constructor.selector = typeDeclaration.name;
-		if (callBuilderBasedSuperConstructor) {
-			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.Super);
-			constructor.constructorCall.arguments = new Expression[] {new SingleNameReference("b".toCharArray(), p)};
-		} else {
-			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
-		}
-		constructor.constructorCall.sourceStart = source.sourceStart;
-		constructor.constructorCall.sourceEnd = source.sourceEnd;
-		constructor.thrownExceptions = null;
-		constructor.typeParameters = null;
-		constructor.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
-		constructor.bodyStart = constructor.declarationSourceStart = constructor.sourceStart = source.sourceStart;
-		constructor.bodyEnd = constructor.declarationSourceEnd = constructor.sourceEnd = source.sourceEnd;
-		constructor.arguments = null;
-		
-		List<Statement> statements = new ArrayList<Statement>();
-		List<Statement> nullChecks = new ArrayList<Statement>();
-		
-		for (BuilderFieldData fieldNode : builderFields) {
-			char[] fieldName = removePrefixFromField(fieldNode.fieldNode);
-			FieldReference thisX = new FieldReference(fieldNode.rawName, p);
-			int s = (int) (p >> 32);
-			int e = (int) p;
-			thisX.receiver = new ThisReference(s, e);
-			
-			Expression assignmentExpr;
-			if (fieldNode.singularData != null && fieldNode.singularData.getSingularizer() != null) {
-				fieldNode.singularData.getSingularizer().appendBuildCode(fieldNode.singularData, typeNode, statements, fieldNode.name, "b");
-				assignmentExpr = new SingleNameReference(fieldNode.name, p);
-			} else {
-				char[][] variableInBuilder = new char[][] {"b".toCharArray(), fieldName};
-				long[] positions = new long[] {p, p};
-				assignmentExpr = new QualifiedNameReference(variableInBuilder, positions, s, e);
-			}
-			
-			Assignment assignment = new Assignment(thisX, assignmentExpr, (int) p);
-			statements.add(assignment);
-			Annotation[] nonNulls = findAnnotations((FieldDeclaration)fieldNode.fieldNode.get(), NON_NULL_PATTERN);
-			if (nonNulls.length != 0) {
-				Statement nullCheck = generateNullCheck((FieldDeclaration)fieldNode.fieldNode.get(), sourceNode);
-				if (nullCheck != null) {
-					nullChecks.add(nullCheck);
-				}
-			}
-		}
-		
-		nullChecks.addAll(statements);
-		constructor.statements = nullChecks.isEmpty() ? null : nullChecks.toArray(new Statement[nullChecks.size()]);
-		constructor.arguments = new Argument[] {new Argument("b".toCharArray(), p, new SingleTypeReference(builderClassnameAsParameter.toCharArray(), p), Modifier.FINAL)};
-		
-		constructor.traverse(new SetGeneratedByVisitor(source), typeDeclaration.scope);
-		
-		injectMethod(typeNode, constructor);
-	}
-	
 	private MethodDeclaration generateCleanMethod(List<BuilderFieldData> builderFields, EclipseNode builderType, ASTNode source) {
 		List<Statement> statements = new ArrayList<Statement>();
 		
@@ -685,58 +553,49 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		return decl;
 	}
 	
-	/**
-	 * @param useBuilderBasedConstructor
-	 *            if true, the {@code build()} method will use a constructor
-	 *            that takes the builder instance as parameter (instead of a
-	 *            constructor with all relevant fields as parameters)
-	 */
-	public MethodDeclaration generateBuildMethod(EclipseNode tdParent, boolean isStatic, String name, char[] staticName, TypeReference returnType, List<BuilderFieldData> builderFields, EclipseNode type, TypeReference[] thrownExceptions, boolean addCleaning, ASTNode source, boolean useBuilderBasedConstructor) {
+	public MethodDeclaration generateBuildMethod(EclipseNode tdParent, boolean isStatic, String name, char[] staticName, TypeReference returnType, List<BuilderFieldData> builderFields, EclipseNode type, TypeReference[] thrownExceptions, boolean addCleaning, ASTNode source) {
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) type.top().get()).compilationResult);
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 		List<Statement> statements = new ArrayList<Statement>();
-		List<Expression> args = new ArrayList<Expression>();
 		
-		// Extendable builders assign their values in the constructor, not in this build() method.
-		if (!useBuilderBasedConstructor) {
-			if (addCleaning) {
-				FieldReference thisUnclean = new FieldReference(CLEAN_FIELD_NAME, 0);
-				thisUnclean.receiver = new ThisReference(0, 0);
-				Expression notClean = new UnaryExpression(thisUnclean, OperatorIds.NOT);
-				MessageSend invokeClean = new MessageSend();
-				invokeClean.selector = CLEAN_METHOD_NAME;
-				statements.add(new IfStatement(notClean, invokeClean, 0, 0));
+		if (addCleaning) {
+			FieldReference thisUnclean = new FieldReference(CLEAN_FIELD_NAME, 0);
+			thisUnclean.receiver = new ThisReference(0, 0);
+			Expression notClean = new UnaryExpression(thisUnclean, OperatorIds.NOT);
+			MessageSend invokeClean = new MessageSend();
+			invokeClean.selector = CLEAN_METHOD_NAME;
+			statements.add(new IfStatement(notClean, invokeClean, 0, 0));
+		}
+		
+		for (BuilderFieldData bfd : builderFields) {
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, type, statements, bfd.name);
 			}
-			
-			for (BuilderFieldData bfd : builderFields) {
-				if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
-					bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, type, statements, bfd.name, "this");
-				}
+		}
+		
+		List<Expression> args = new ArrayList<Expression>();
+		for (BuilderFieldData bfd : builderFields) {
+			if (bfd.nameOfSetFlag != null) {
+				MessageSend inv = new MessageSend();
+				inv.sourceStart = source.sourceStart;
+				inv.sourceEnd = source.sourceEnd;
+				inv.receiver = new SingleNameReference(((TypeDeclaration) tdParent.get()).name, 0L);
+				inv.selector = bfd.nameOfDefaultProvider;
+				inv.typeArguments = typeParameterNames(((TypeDeclaration) type.get()).typeParameters);
+				
+				args.add(new ConditionalExpression(
+					new SingleNameReference(bfd.nameOfSetFlag,  0L),
+					new SingleNameReference(bfd.name, 0L),
+					inv));
+			} else {
+				args.add(new SingleNameReference(bfd.name, 0L));
 			}
-			
-			for (BuilderFieldData bfd : builderFields) {
-				if (bfd.nameOfSetFlag != null) {
-					MessageSend inv = new MessageSend();
-					inv.sourceStart = source.sourceStart;
-					inv.sourceEnd = source.sourceEnd;
-					inv.receiver = new SingleNameReference(((TypeDeclaration) tdParent.get()).name, 0L);
-					inv.selector = bfd.nameOfDefaultProvider;
-					inv.typeArguments = typeParameterNames(((TypeDeclaration) type.get()).typeParameters);
-					
-					args.add(new ConditionalExpression(
-						new SingleNameReference(bfd.nameOfSetFlag,  0L),
-						new SingleNameReference(bfd.name, 0L),
-						inv));
-				} else {
-					args.add(new SingleNameReference(bfd.name, 0L));
-				}
-			}
-			
-			if (addCleaning) {
-				FieldReference thisUnclean = new FieldReference(CLEAN_FIELD_NAME, 0);
-				thisUnclean.receiver = new ThisReference(0, 0);
-				statements.add(new Assignment(thisUnclean, new TrueLiteral(0, 0), 0));
-			}
+		}
+		
+		if (addCleaning) {
+			FieldReference thisUnclean = new FieldReference(CLEAN_FIELD_NAME, 0);
+			thisUnclean.receiver = new ThisReference(0, 0);
+			statements.add(new Assignment(thisUnclean, new TrueLiteral(0, 0), 0));
 		}
 		
 		out.modifiers = ClassFileConstants.AccPublic;
@@ -748,13 +607,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		if (staticName == null) {
 			AllocationExpression allocationStatement = new AllocationExpression();
 			allocationStatement.type = copyType(out.returnType);
-			if (useBuilderBasedConstructor) {
-				// Use a constructor that only has this builder as parameter.
-				allocationStatement.arguments = new Expression[] {new ThisReference(0, 0)};
-			} else {
-				// Use a constructor with all the fields.
-				allocationStatement.arguments = args.isEmpty() ? null : args.toArray(new Expression[args.size()]);
-			}
+			allocationStatement.arguments = args.isEmpty() ? null : args.toArray(new Expression[args.size()]);
 			statements.add(new ReturnStatement(allocationStatement, 0, 0));
 		} else {
 			MessageSend invoke = new MessageSend();
@@ -903,7 +756,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		return null;
 	}
 	
-	public EclipseNode makeBuilderClass(boolean isStatic, EclipseNode tdParent, String builderClassName, TypeParameter[] typeParams, ASTNode source, String parentBuilderClassName) {
+	public EclipseNode makeBuilderClass(boolean isStatic, EclipseNode tdParent, String builderClassName, TypeParameter[] typeParams, ASTNode source) {
 		TypeDeclaration parent = (TypeDeclaration) tdParent.get();
 		TypeDeclaration builder = new TypeDeclaration(parent.compilationResult);
 		builder.bits |= Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
@@ -911,7 +764,6 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		if (isStatic) builder.modifiers |= ClassFileConstants.AccStatic;
 		builder.typeParameters = copyTypeParams(typeParams, source);
 		builder.name = builderClassName.toCharArray();
-		if (parentBuilderClassName != null) builder.superclass = new SingleTypeReference(parentBuilderClassName.toCharArray(), 0);
 		builder.traverse(new SetGeneratedByVisitor(source), (ClassScope) null);
 		return injectType(tdParent, builder);
 	}

--- a/src/core/lombok/eclipse/handlers/HandleBuilderDefault.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilderDefault.java
@@ -31,6 +31,7 @@ import lombok.core.AnnotationValues;
 import lombok.core.HandlerPriority;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
+import lombok.experimental.SuperBuilder;
 
 @ProviderFor(EclipseAnnotationHandler.class)
 @HandlerPriority(-1025) //HandleBuilder's level, minus one.
@@ -39,8 +40,9 @@ public class HandleBuilderDefault extends EclipseAnnotationHandler<Builder.Defau
 		EclipseNode annotatedField = annotationNode.up();
 		if (annotatedField.getKind() != Kind.FIELD) return;
 		EclipseNode classWithAnnotatedField = annotatedField.up();
-		if (!hasAnnotation(Builder.class, classWithAnnotatedField) && !hasAnnotation("lombok.experimental.Builder", classWithAnnotatedField)) {
-			annotationNode.addWarning("@Builder.Default requires @Builder on the class for it to mean anything.");
+		if (!hasAnnotation(Builder.class, classWithAnnotatedField) && !hasAnnotation("lombok.experimental.Builder", classWithAnnotatedField)
+				&& !hasAnnotation(SuperBuilder.class, classWithAnnotatedField)) {
+			annotationNode.addWarning("@Builder.Default requires @Builder or @SuperBuilder on the class for it to mean anything.");
 		}
 	}
 }

--- a/src/core/lombok/eclipse/handlers/HandleConstructor.java
+++ b/src/core/lombok/eclipse/handlers/HandleConstructor.java
@@ -259,7 +259,7 @@ public class HandleConstructor {
 		
 		ConstructorDeclaration constr = createConstructor(
 			staticConstrRequired ? AccessLevel.PRIVATE : level, typeNode, fields, allToDefault,
-			true, sourceNode, onConstructor);
+			sourceNode, onConstructor);
 		injectMethod(typeNode, constr);
 		if (staticConstrRequired) {
 			MethodDeclaration staticConstr = createStaticConstructor(level, staticName, typeNode, allToDefault ? Collections.<EclipseNode>emptyList() : fields, source);
@@ -301,7 +301,7 @@ public class HandleConstructor {
 	
 	@SuppressWarnings("deprecation") public static ConstructorDeclaration createConstructor(
 		AccessLevel level, EclipseNode type, Collection<EclipseNode> fields, boolean allToDefault,
-		boolean superConstructorCall, EclipseNode sourceNode, List<Annotation> onConstructor) {
+		EclipseNode sourceNode, List<Annotation> onConstructor) {
 		
 		ASTNode source = sourceNode.get();
 		TypeDeclaration typeDeclaration = ((TypeDeclaration) type.get());
@@ -324,11 +324,9 @@ public class HandleConstructor {
 		
 		constructor.modifiers = toEclipseModifier(level);
 		constructor.selector = typeDeclaration.name;
-		if (superConstructorCall) {
-			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
-			constructor.constructorCall.sourceStart = source.sourceStart;
-			constructor.constructorCall.sourceEnd = source.sourceEnd;
-		}
+		constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
+		constructor.constructorCall.sourceStart = source.sourceStart;
+		constructor.constructorCall.sourceEnd = source.sourceEnd;
 		constructor.thrownExceptions = null;
 		constructor.typeParameters = null;
 		constructor.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;

--- a/src/core/lombok/eclipse/handlers/HandleConstructor.java
+++ b/src/core/lombok/eclipse/handlers/HandleConstructor.java
@@ -259,7 +259,7 @@ public class HandleConstructor {
 		
 		ConstructorDeclaration constr = createConstructor(
 			staticConstrRequired ? AccessLevel.PRIVATE : level, typeNode, fields, allToDefault,
-			sourceNode, onConstructor);
+			true, sourceNode, onConstructor);
 		injectMethod(typeNode, constr);
 		if (staticConstrRequired) {
 			MethodDeclaration staticConstr = createStaticConstructor(level, staticName, typeNode, allToDefault ? Collections.<EclipseNode>emptyList() : fields, source);
@@ -301,7 +301,7 @@ public class HandleConstructor {
 	
 	@SuppressWarnings("deprecation") public static ConstructorDeclaration createConstructor(
 		AccessLevel level, EclipseNode type, Collection<EclipseNode> fields, boolean allToDefault,
-		EclipseNode sourceNode, List<Annotation> onConstructor) {
+		boolean superConstructorCall, EclipseNode sourceNode, List<Annotation> onConstructor) {
 		
 		ASTNode source = sourceNode.get();
 		TypeDeclaration typeDeclaration = ((TypeDeclaration) type.get());
@@ -324,9 +324,11 @@ public class HandleConstructor {
 		
 		constructor.modifiers = toEclipseModifier(level);
 		constructor.selector = typeDeclaration.name;
-		constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
-		constructor.constructorCall.sourceStart = source.sourceStart;
-		constructor.constructorCall.sourceEnd = source.sourceEnd;
+		if (superConstructorCall) {
+			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
+			constructor.constructorCall.sourceStart = source.sourceStart;
+			constructor.constructorCall.sourceEnd = source.sourceEnd;
+		}
 		constructor.thrownExceptions = null;
 		constructor.typeParameters = null;
 		constructor.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;

--- a/src/core/lombok/eclipse/handlers/HandleSetter.java
+++ b/src/core/lombok/eclipse/handlers/HandleSetter.java
@@ -119,7 +119,7 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		createSetterForField(level, fieldNode, sourceNode, false, empty, empty);
 	}
 	
-	public void handle(AnnotationValues<Setter> annotation, Annotation ast, EclipseNode annotationNode) {
+	@Override public void handle(AnnotationValues<Setter> annotation, Annotation ast, EclipseNode annotationNode) {
 		handleFlagUsage(annotationNode, ConfigurationKeys.SETTER_FLAG_USAGE, "@Setter");
 		
 		EclipseNode node = annotationNode.up();
@@ -196,22 +196,34 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		MethodDeclaration method = createSetter((TypeDeclaration) fieldNode.up().get(), false, fieldNode, setterName, null, shouldReturnThis, modifier, sourceNode, onMethod, onParam);
 		injectMethod(fieldNode.up(), method);
 	}
-	
+
 	static MethodDeclaration createSetter(TypeDeclaration parent, boolean deprecate, EclipseNode fieldNode, String name, char[] booleanFieldToSet, boolean shouldReturnThis, int modifier, EclipseNode sourceNode, List<Annotation> onMethod, List<Annotation> onParam) {
+		ASTNode source = sourceNode.get();
+		int pS = source.sourceStart, pE = source.sourceEnd;
+		
+		TypeReference returnType = null;
+		ReturnStatement returnThis = null;
+		if (shouldReturnThis) {
+			returnType = cloneSelfType(fieldNode, source);
+			ThisReference thisRef = new ThisReference(pS, pE);
+			returnThis = new ReturnStatement(thisRef, pS, pE);
+		}
+		
+		return createSetter(parent, deprecate, fieldNode, name, booleanFieldToSet, returnType, returnThis, modifier, sourceNode, onMethod, onParam);
+	}
+	
+	static MethodDeclaration createSetter(TypeDeclaration parent, boolean deprecate, EclipseNode fieldNode, String name, char[] booleanFieldToSet, TypeReference returnType, ReturnStatement returnStatement, int modifier, EclipseNode sourceNode, List<Annotation> onMethod, List<Annotation> onParam) {
 		FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 		ASTNode source = sourceNode.get();
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long)pS << 32 | pE;
 		MethodDeclaration method = new MethodDeclaration(parent.compilationResult);
 		method.modifiers = modifier;
-		if (shouldReturnThis) {
-			method.returnType = cloneSelfType(fieldNode, source);
-		}
-		
-		if (method.returnType == null) {
+		if (returnType != null) {
+			method.returnType = returnType;
+		} else {
 			method.returnType = TypeReference.baseTypeReference(TypeIds.T_void, 0);
 			method.returnType.sourceStart = pS; method.returnType.sourceEnd = pE;
-			shouldReturnThis = false;
 		}
 		Annotation[] deprecated = null;
 		if (isFieldDeprecated(fieldNode) || deprecate) {
@@ -248,10 +260,8 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 			statements.add(new Assignment(new SingleNameReference(booleanFieldToSet, p), new TrueLiteral(pS, pE), pE));
 		}
 		
-		if (shouldReturnThis) {
-			ThisReference thisRef = new ThisReference(pS, pE);
-			ReturnStatement returnThis = new ReturnStatement(thisRef, pS, pE);
-			statements.add(returnThis);
+		if (returnType != null && returnStatement != null) {
+			statements.add(returnStatement);
 		}
 		method.statements = statements.toArray(new Statement[0]);
 		param.annotations = copyAnnotations(source, nonNulls, nullables, onParam.toArray(new Annotation[0]));

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -368,7 +368,12 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 	}
 
 	private TypeReference[] getTypeParametersFrom(TypeReference typeRef) {
-		TypeReference[][] typeArgss = typeRef.getTypeArguments();
+		TypeReference[][] typeArgss = null;
+		if (typeRef instanceof ParameterizedQualifiedTypeReference) {
+			typeArgss = ((ParameterizedQualifiedTypeReference)typeRef).typeArguments;
+		} else if (typeRef instanceof ParameterizedSingleTypeReference) {
+			typeArgss = new TypeReference[][] {((ParameterizedSingleTypeReference)typeRef).typeArguments};
+		}
 		TypeReference[] typeArgs = new TypeReference[0];
 		if (typeArgss != null && typeArgss.length > 0) {
 			typeArgs = typeArgss[typeArgss.length - 1];
@@ -609,7 +614,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		}
 	}
 
-	private void makeSetterMethodsForBuilder(EclipseNode builderType, BuilderFieldData bfd, EclipseNode sourceNode, String builderGenericName) {
+	private void makeSetterMethodsForBuilder(EclipseNode builderType, BuilderFieldData bfd, EclipseNode sourceNode, final String builderGenericName) {
 		boolean deprecate = isFieldDeprecated(bfd.originalFieldNode);
 
 		// TODO: Make these lambdas when switching to a source level >= 1.8.

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -141,7 +141,6 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		java.util.List<BuilderFieldData> builderFields = new ArrayList<BuilderFieldData>();
 		TypeReference returnType;
 		TypeParameter[] typeParams;
-		TypeParameter[] superclassTypeParams = new TypeParameter[] {}; //TODO
 
 		boolean addCleaning = false;
 
@@ -267,7 +266,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		EclipseNode builderType = findInnerClass(tdParent, builderClassName);
 		if (builderType == null) {
 			builderType = generateBuilderAbstractClass(tdParent, builderClassName, superclassBuilderClass,
-					typeParams, superclassTypeParams, ast, classGenericName, builderGenericName);
+					typeParams, ast, classGenericName, builderGenericName);
 
 		} else {
 			annotationNode.addError("@SuperBuilder does not support customized builders. Use @Builder instead.");
@@ -360,7 +359,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 
 	private EclipseNode generateBuilderAbstractClass(EclipseNode tdParent, String builderClass,
 			TypeReference superclassBuilderClass, TypeParameter[] typeParams,
-			TypeParameter[] superclassTypeParams, ASTNode source, String classGenericName, String builderGenericName) {
+			ASTNode source, String classGenericName, String builderGenericName) {
 	
 		TypeDeclaration parent = (TypeDeclaration) tdParent.get();
 		TypeDeclaration builder = new TypeDeclaration(parent.compilationResult);

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -63,6 +63,7 @@ import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
@@ -335,7 +336,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		}
 
 		// Create a simple constructor for the BuilderImpl class.
-		ConstructorDeclaration cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, builderImplType, Collections.<EclipseNode>emptyList(), false, annotationNode, Collections.<Annotation>emptyList());
+		ConstructorDeclaration cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, builderImplType, Collections.<EclipseNode>emptyList(), false, false, annotationNode, Collections.<Annotation>emptyList());
 		if (cd != null) {
 			injectMethod(builderImplType, cd);
 		}
@@ -395,11 +396,9 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		if (callBuilderBasedSuperConstructor) {
 			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.Super);
 			constructor.constructorCall.arguments = new Expression[] {new SingleNameReference("b".toCharArray(), p)};
-		} else {
-			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
+			constructor.constructorCall.sourceStart = source.sourceStart;
+			constructor.constructorCall.sourceEnd = source.sourceEnd;
 		}
-		constructor.constructorCall.sourceStart = source.sourceStart;
-		constructor.constructorCall.sourceEnd = source.sourceEnd;
 		constructor.thrownExceptions = null;
 		constructor.typeParameters = null;
 		constructor.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
@@ -453,7 +452,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) tdParent.top().get()).compilationResult);
 		out.selector = SELF_METHOD.toCharArray();
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
-		out.modifiers = ClassFileConstants.AccAbstract | ClassFileConstants.AccProtected;
+		out.modifiers = ClassFileConstants.AccAbstract | ClassFileConstants.AccProtected | ExtraCompilerModifiers.AccSemicolonBody;
 		if (override) {
 			out.annotations = new Annotation[] {makeMarkerAnnotation(TypeConstants.JAVA_LANG_OVERRIDE, tdParent.get())};
 		}
@@ -477,7 +476,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) tdParent.top().get()).compilationResult);
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 
-		out.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccAbstract;
+		out.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccAbstract | ExtraCompilerModifiers.AccSemicolonBody;
 		out.selector = methodName.toCharArray();
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 		out.returnType = new SingleTypeReference(classGenericName.toCharArray(), 0);

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -225,7 +225,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		// You can use it to check whether to inherit or not.
 
 		returnType = namePlusTypeParamsToTypeReference(td.name, td.typeParameters, p);
-		typeParams = td.typeParameters;
+		typeParams = td.typeParameters != null ? td.typeParameters : new TypeParameter[0];
 
 		// <C, B> are the generics for our builder.
 		String classGenericName = "C";

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -63,7 +63,6 @@ import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
-import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
@@ -339,7 +338,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		}
 
 		// Create a simple constructor for the BuilderImpl class.
-		ConstructorDeclaration cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, builderImplType, Collections.<EclipseNode>emptyList(), false, false, annotationNode, Collections.<Annotation>emptyList());
+		ConstructorDeclaration cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, builderImplType, Collections.<EclipseNode>emptyList(), false, annotationNode, Collections.<Annotation>emptyList());
 		if (cd != null) {
 			injectMethod(builderImplType, cd);
 		}
@@ -445,9 +444,11 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		if (callBuilderBasedSuperConstructor) {
 			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.Super);
 			constructor.constructorCall.arguments = new Expression[] {new SingleNameReference("b".toCharArray(), p)};
-			constructor.constructorCall.sourceStart = source.sourceStart;
-			constructor.constructorCall.sourceEnd = source.sourceEnd;
+		} else {
+			constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
 		}
+		constructor.constructorCall.sourceStart = source.sourceStart;
+		constructor.constructorCall.sourceEnd = source.sourceEnd;
 		constructor.thrownExceptions = null;
 		constructor.typeParameters = null;
 		constructor.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
@@ -525,7 +526,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) tdParent.top().get()).compilationResult);
 		out.selector = SELF_METHOD.toCharArray();
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
-		out.modifiers = ClassFileConstants.AccAbstract | ClassFileConstants.AccProtected | ExtraCompilerModifiers.AccSemicolonBody;
+		out.modifiers = ClassFileConstants.AccAbstract | ClassFileConstants.AccProtected;
 		if (override) {
 			out.annotations = new Annotation[] {makeMarkerAnnotation(TypeConstants.JAVA_LANG_OVERRIDE, tdParent.get())};
 		}
@@ -549,7 +550,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) tdParent.top().get()).compilationResult);
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 
-		out.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccAbstract | ExtraCompilerModifiers.AccSemicolonBody;
+		out.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccAbstract;
 		out.selector = methodName.toCharArray();
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 		out.returnType = new SingleTypeReference(classGenericName.toCharArray(), 0);

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -115,6 +115,8 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 
 	@Override
 	public void handle(AnnotationValues<SuperBuilder> annotation, Annotation ast, EclipseNode annotationNode) {
+		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.SUPERBUILDER_FLAG_USAGE, "@SuperBuilder");
+		
 		long p = (long) ast.sourceStart << 32 | ast.sourceEnd;
 
 		SuperBuilder builderInstance = annotation.getInstance();

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -333,6 +333,11 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 			injectMethod(builderType, generateCleanMethod(builderFields, builderType, ast));
 		}
 
+		if ((td.modifiers & ClassFileConstants.AccAbstract) != 0) {
+			// Abstract classes to not get the Builder implementation nor the builder() method.
+			return;
+		}
+
 		// Create the builder implementation class.
 		EclipseNode builderImplType = findInnerClass(tdParent, builderImplClassName);
 		if (builderImplType == null) {

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseGuavaSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseGuavaSingularizer.java
@@ -27,6 +27,7 @@ import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import lombok.core.GuavaTypeMap;
 import lombok.core.LombokImmutableList;
@@ -58,7 +59,6 @@ import org.eclipse.jdt.internal.compiler.ast.Statement;
 import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
 abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 	protected String getSimpleTargetTypeName(SingularData data) {
@@ -97,18 +97,10 @@ abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, boolean chain) {
-		TypeReference returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		Statement returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generateSingularMethod(deprecate, returnType, returnStatement, data, builderType, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generatePluralMethod(deprecate, returnType, returnStatement, data, builderType, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generateClearMethod(deprecate, returnType, returnStatement, data,  builderType);
+	@Override public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, Supplier<TypeReference> returnType, Supplier<ReturnStatement> returnStatement) {
+		generateSingularMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType, fluent);
+		generatePluralMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType, fluent);
+		generateClearMethod(deprecate, returnType.get(), returnStatement.get(), data,  builderType);
 	}
 	
 	void generateClearMethod(boolean deprecate, TypeReference returnType, Statement returnStatement, SingularData data, EclipseNode builderType) {

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSetSingularizer.java
@@ -27,6 +27,7 @@ import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import lombok.core.handlers.HandlerUtil;
 import lombok.eclipse.EclipseNode;
@@ -52,7 +53,6 @@ import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
-import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
 abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingularizer {
 	@Override public List<char[]> listFieldsToBeGenerated(SingularData data, EclipseNode builderType) {
@@ -88,23 +88,15 @@ abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingula
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, boolean chain) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, Supplier<TypeReference> returnType, Supplier<ReturnStatement> returnStatement) {
 		if (useGuavaInstead(builderType)) {
-			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, fluent, chain);
+			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, fluent, returnType, returnStatement);
 			return;
 		}
 		
-		TypeReference returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		Statement returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generateSingularMethod(deprecate, returnType, returnStatement, data, builderType, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generatePluralMethod(deprecate, returnType, returnStatement, data, builderType, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generateClearMethod(deprecate, returnType, returnStatement, data, builderType);
+		generateSingularMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType, fluent);
+		generatePluralMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType, fluent);
+		generateClearMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType);
 	}
 	
 	private void generateClearMethod(boolean deprecate, TypeReference returnType, Statement returnStatement, SingularData data, EclipseNode builderType) {

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.Argument;
@@ -51,7 +52,6 @@ import org.eclipse.jdt.internal.compiler.ast.Statement;
 import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.mangosdk.spi.ProviderFor;
 
 import lombok.core.LombokImmutableList;
@@ -133,23 +133,15 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		return Arrays.asList(keyFieldNode, valueFieldNode);
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, boolean chain) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, EclipseNode builderType, boolean fluent, Supplier<TypeReference> returnType, Supplier<ReturnStatement> returnStatement) {
 		if (useGuavaInstead(builderType)) {
-			guavaMapSingularizer.generateMethods(data, deprecate, builderType, fluent, chain);
+			guavaMapSingularizer.generateMethods(data, deprecate, builderType, fluent, returnType, returnStatement);
 			return;
 		}
 		
-		TypeReference returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		Statement returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generateSingularMethod(deprecate, returnType, returnStatement, data, builderType, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generatePluralMethod(deprecate, returnType, returnStatement, data, builderType, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : TypeReference.baseTypeReference(TypeIds.T_void, 0);
-		returnStatement = chain ? new ReturnStatement(new ThisReference(0, 0), 0, 0) : null;
-		generateClearMethod(deprecate, returnType, returnStatement, data, builderType);
+		generateSingularMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType, fluent);
+		generatePluralMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType, fluent);
+		generateClearMethod(deprecate, returnType.get(), returnStatement.get(), data, builderType);
 	}
 	
 	private void generateClearMethod(boolean deprecate, TypeReference returnType, Statement returnStatement, SingularData data, EclipseNode builderType) {

--- a/src/core/lombok/javac/handlers/HandleBuilderDefault.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderDefault.java
@@ -31,6 +31,7 @@ import lombok.Builder;
 import lombok.core.AST.Kind;
 import lombok.core.AnnotationValues;
 import lombok.core.HandlerPriority;
+import lombok.experimental.SuperBuilder;
 import lombok.javac.JavacAnnotationHandler;
 import lombok.javac.JavacNode;
 
@@ -41,8 +42,9 @@ public class HandleBuilderDefault extends JavacAnnotationHandler<Builder.Default
 		JavacNode annotatedField = annotationNode.up();
 		if (annotatedField.getKind() != Kind.FIELD) return;
 		JavacNode classWithAnnotatedField = annotatedField.up();
-		if (!hasAnnotation(Builder.class, classWithAnnotatedField) && !hasAnnotation("lombok.experimental.Builder", classWithAnnotatedField)) {
-			annotationNode.addWarning("@Builder.Default requires @Builder on the class for it to mean anything.");
+		if (!hasAnnotation(Builder.class, classWithAnnotatedField) && !hasAnnotation("lombok.experimental.Builder", classWithAnnotatedField)
+				&& !hasAnnotation(SuperBuilder.class, classWithAnnotatedField)) {
+			annotationNode.addWarning("@Builder.Default requires @Builder or @SuperBuilder on the class for it to mean anything.");
 			deleteAnnotationIfNeccessary(annotationNode, Builder.Default.class);
 		}
 	}

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -21,13 +21,22 @@
  */
 package lombok.javac.handlers;
 
-import static lombok.core.handlers.HandlerUtil.*;
 import static lombok.javac.Javac.*;
+import static lombok.core.handlers.HandlerUtil.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
-import static lombok.javac.handlers.JavacHandlerUtil.toAllSetterNames;
-import static lombok.javac.handlers.JavacHandlerUtil.toSetterName;
 
 import java.util.Collection;
+
+import lombok.AccessLevel;
+import lombok.ConfigurationKeys;
+import lombok.Setter;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.javac.Javac;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import lombok.javac.handlers.JavacHandlerUtil.FieldAccess;
 
 import org.mangosdk.spi.ProviderFor;
 
@@ -47,18 +56,6 @@ import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
-
-import lombok.AccessLevel;
-import lombok.ConfigurationKeys;
-import lombok.Setter;
-import lombok.core.AST.Kind;
-import lombok.core.AnnotationValues;
-import lombok.javac.Javac;
-import lombok.javac.JavacAnnotationHandler;
-import lombok.javac.JavacNode;
-import lombok.javac.JavacTreeMaker;
-import lombok.javac.handlers.JavacHandlerUtil.CopyJavadoc;
-import lombok.javac.handlers.JavacHandlerUtil.FieldAccess;
 
 /**
  * Handles the {@code lombok.Setter} annotation for javac.

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -262,18 +262,17 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		}
 
 		// Create the toString() method for the abstract builder.
-		if (methodExists("toString", builderType, 0) == MemberExistsResult.NOT_EXISTS) {
-			java.util.List<JavacNode> fieldNodes = new ArrayList<JavacNode>();
-			for (BuilderFieldData bfd : builderFields) {
-				fieldNodes.addAll(bfd.createdFields);
-			}
-			// Let toString() call super.toString() if there is a superclass, so that it also shows fields from the superclass' builder.
-			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, superclassBuilderClassExpression != null, FieldAccess.ALWAYS_FIELD, ast);
-			if (md != null) {
-				injectMethod(builderType, md);
-			}
+		java.util.List<JavacNode> fieldNodes = new ArrayList<JavacNode>();
+		for (BuilderFieldData bfd : builderFields) {
+			fieldNodes.addAll(bfd.createdFields);
+		}
+		// Let toString() call super.toString() if there is a superclass, so that it also shows fields from the superclass' builder.
+		JCMethodDecl toStringMethod = HandleToString.createToString(builderType, fieldNodes, true, superclassBuilderClassExpression != null, FieldAccess.ALWAYS_FIELD, ast);
+		if (toStringMethod != null) {
+			injectMethod(builderType, toStringMethod);
 		}
 
+		// If clean methods are requested, add them now.
 		if (addCleaning) {
 			injectMethod(builderType, generateCleanMethod(builderFields, builderType, ast));
 		}
@@ -304,10 +303,10 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		// Add the builder() method to the annotated class.
 		// Allow users to specify their own builder() methods, e.g., to provide default values.
 		if (methodExists(builderMethodName, tdParent, -1) == MemberExistsResult.NOT_EXISTS) {
-			JCMethodDecl md = generateBuilderMethod(builderMethodName, builderClassName, builderImplClassName, annotationNode, tdParent, typeParams);
-			recursiveSetGeneratedBy(md, ast, annotationNode.getContext());
-			if (md != null) {
-				injectMethod(tdParent, md);
+			JCMethodDecl builderMethod = generateBuilderMethod(builderMethodName, builderClassName, builderImplClassName, annotationNode, tdParent, typeParams);
+			recursiveSetGeneratedBy(builderMethod, ast, annotationNode.getContext());
+			if (builderMethod != null) {
+				injectMethod(tdParent, builderMethod);
 			}
 		}
 

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -236,6 +236,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			for (BuilderFieldData bfd : builderFields) {
 				fieldNodes.addAll(bfd.createdFields);
 			}
+			// TODO: toString() should also call super.toString(), so that it also shows fields from the superclass.
 			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, false, FieldAccess.ALWAYS_FIELD, ast);
 			if (md != null) injectMethod(builderType, md);
 		}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -377,7 +377,13 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, typeNode.getContext());
 		Name builderClassname = typeNode.toName(builderClassName);
-		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags), builderVariableName, maker.Ident(builderClassname), null);
+		// Now add the <?, ?>.
+		ListBuffer<JCExpression> typeParams = new ListBuffer<JCExpression>();
+		JCWildcard wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
+		typeParams.add(wildcard);
+		typeParams.add(wildcard);
+		JCTypeApply paramType = maker.TypeApply(maker.Ident(builderClassname), typeParams.toList());
+		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags), builderVariableName, paramType, null);
 		params.append(param);
 
 		if (callBuilderBasedSuperConstructor) {

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -181,7 +181,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			String superclassBuilderClassName = extendsClause.toString() + "Builder";
 			superclassBuilderClassExpression = chainDots(tdParent, extendsClause.toString(), superclassBuilderClassName);
 		}
-		// If there is no superclass, superclassBuilderClassName is still == null at this point.
+		// If there is no superclass, superclassBuilderClassExpression is still == null at this point.
 		// You can use it to check whether to inherit or not.
 
 		returnType = namePlusTypeParamsToTypeReference(tdParent.getTreeMaker(), td.name, td.typarams);
@@ -257,8 +257,8 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			for (BuilderFieldData bfd : builderFields) {
 				fieldNodes.addAll(bfd.createdFields);
 			}
-			// TODO: toString() should also call super.toString(), so that it also shows fields from the superclass.
-			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, false, FieldAccess.ALWAYS_FIELD, ast);
+			// Let toString() call super.toString() if there is a superclass, so that it also shows fields from the superclass' builder.
+			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, superclassBuilderClassExpression != null, FieldAccess.ALWAYS_FIELD, ast);
 			if (md != null) injectMethod(builderType, md);
 		}
 		

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -95,6 +95,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 	@Override
 	public void handle(AnnotationValues<SuperBuilder> annotation, JCAnnotation ast, JavacNode annotationNode) {
 		SuperBuilder superbuilderAnnotation = annotation.getInstance();
+		deleteAnnotationIfNeccessary(annotationNode, SuperBuilder.class);
 
 		String builderMethodName = superbuilderAnnotation.builderMethodName();
 		String buildMethodName = superbuilderAnnotation.buildMethodName();

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -1,0 +1,649 @@
+/*
+ * Copyright (C) 2013-2018 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.javac.Javac.*;
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import java.util.ArrayList;
+
+import org.mangosdk.spi.ProviderFor;
+
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import com.sun.tools.javac.tree.JCTree.JCModifiers;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCTypeApply;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Builder.ObtainVia;
+import lombok.ConfigurationKeys;
+import lombok.Singular;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.core.handlers.HandlerUtil;
+import lombok.experimental.NonFinal;
+import lombok.experimental.SuperBuilder;
+import lombok.javac.Javac;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import lombok.javac.handlers.JavacHandlerUtil.FieldAccess;
+import lombok.javac.handlers.JavacHandlerUtil.MemberExistsResult;
+import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
+import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
+
+@ProviderFor(JavacAnnotationHandler.class)
+@HandlerPriority(-1024) //-2^10; to ensure we've picked up @FieldDefault's changes (-2048) but @Value hasn't removed itself yet (-512), so that we can error on presence of it on the builder classes.
+public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
+//	private HandleConstructor handleConstructor = new HandleConstructor();
+	
+//	private static final boolean toBoolean(Object expr, boolean defaultValue) {
+//		if (expr == null) return defaultValue;
+//		if (expr instanceof JCLiteral) return ((Integer) ((JCLiteral) expr).value) != 0;
+//		return ((Boolean) expr).booleanValue();
+//	}
+	
+	private static class BuilderFieldData {
+		JCExpression type;
+		Name rawName;
+		Name name;
+		Name nameOfDefaultProvider;
+		Name nameOfSetFlag;
+		SingularData singularData;
+		ObtainVia obtainVia;
+		JavacNode obtainViaNode;
+		JavacNode originalFieldNode;
+		
+		java.util.List<JavacNode> createdFields = new ArrayList<JavacNode>();
+	}
+	
+	@Override public void handle(AnnotationValues<SuperBuilder> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		SuperBuilder builderInstance = annotation.getInstance();
+		
+		String builderMethodName = builderInstance.builderMethodName();
+		String buildMethodName = builderInstance.buildMethodName();
+		String builderClassName = builderInstance.builderClassName();
+		String superclassBuilderClassName = builderInstance.superclassBuilderClassName();
+		boolean inherit = builderInstance.inherit();
+		String toBuilderMethodName = "toBuilder";
+		boolean toBuilder = builderInstance.toBuilder();
+		
+		if (builderMethodName == null) builderMethodName = "builder";
+		if (buildMethodName == null) buildMethodName = "build";
+		if (builderClassName == null) builderClassName = "";
+		if (superclassBuilderClassName == null) superclassBuilderClassName = "";
+		
+		if (!checkName("builderMethodName", builderMethodName, annotationNode)) return;
+		if (!checkName("buildMethodName", buildMethodName, annotationNode)) return;
+		if (!builderClassName.isEmpty()) {
+			if (!checkName("builderClassName", builderClassName, annotationNode)) return;
+		}
+		
+		JavacNode tdParent = annotationNode.up();
+		
+		java.util.List<BuilderFieldData> builderFields = new ArrayList<BuilderFieldData>();
+		JCExpression returnType;
+		List<JCTypeParameter> typeParams = List.nil();
+		List<JCExpression> thrownExceptions = List.nil();
+		
+		boolean addCleaning = false;
+		
+		if (!(tdParent.get() instanceof JCClassDecl)) {
+			annotationNode.addError("@SuperBuilder is only supported on types.");
+			return;
+		}
+
+		// Gather all fields of the class that should be set by the builder.
+		JCClassDecl td = (JCClassDecl) tdParent.get();
+		ListBuffer<JavacNode> allFields = new ListBuffer<JavacNode>();
+		boolean valuePresent = (hasAnnotation(lombok.Value.class, tdParent) || hasAnnotation("lombok.experimental.Value", tdParent));
+		for (JavacNode fieldNode : HandleConstructor.findAllFields(tdParent, true)) {
+			JCVariableDecl fd = (JCVariableDecl) fieldNode.get();
+			JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, true);
+			boolean isFinal = (fd.mods.flags & Flags.FINAL) != 0 || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));
+			BuilderFieldData bfd = new BuilderFieldData();
+			bfd.rawName = fd.name;
+			bfd.name = removePrefixFromField(fieldNode);
+			bfd.type = fd.vartype;
+			bfd.singularData = getSingularData(fieldNode);
+			bfd.originalFieldNode = fieldNode;
+			
+			if (bfd.singularData != null && isDefault != null) {
+				isDefault.addError("@Builder.Default and @Singular cannot be mixed.");
+				isDefault = null;
+			}
+			
+			if (fd.init == null && isDefault != null) {
+				isDefault.addWarning("@Builder.Default requires an initializing expression (' = something;').");
+				isDefault = null;
+			}
+			
+			if (fd.init != null && isDefault == null) {
+				if (isFinal) continue;
+				fieldNode.addWarning("@SuperBuilder will ignore the initializing expression entirely. If you want the initializing expression to serve as default, add @Builder.Default. If it is not supposed to be settable during building, make the field final.");
+			}
+			
+			if (isDefault != null) {
+				bfd.nameOfDefaultProvider = tdParent.toName("$default$" + bfd.name);
+				bfd.nameOfSetFlag = tdParent.toName(bfd.name + "$set");
+				JCMethodDecl md = generateDefaultProvider(bfd.nameOfDefaultProvider, fieldNode, td.typarams);
+				recursiveSetGeneratedBy(md, ast, annotationNode.getContext());
+				if (md != null) injectMethod(tdParent, md);
+			}
+			addObtainVia(bfd, fieldNode);
+			builderFields.add(bfd);
+			allFields.append(fieldNode);
+		}
+
+		// Set the default names of the builder classes if not customized via annotation.
+		if (builderClassName.isEmpty()) builderClassName = td.name.toString() + "Builder";
+		String builderImplClassName = builderClassName + "Impl";
+		JCTree extendsClause = Javac.getExtendsClause(td);
+		if (superclassBuilderClassName.isEmpty() && extendsClause != null) {
+			superclassBuilderClassName = extendsClause + "Builder";
+		}
+		
+		boolean useInheritanceOnBuilder = extendsClause != null && inherit;
+		generateBuilderBasedConstructor(tdParent, builderFields, annotationNode, builderClassName, useInheritanceOnBuilder);
+
+		returnType = namePlusTypeParamsToTypeReference(tdParent.getTreeMaker(), td.name, td.typarams);
+		typeParams = td.typarams;
+		thrownExceptions = List.nil();
+
+		// Create the abstract builder class.
+		JavacNode builderType = findInnerClass(tdParent, builderClassName);
+		if (builderType == null) {
+			builderType = makeBuilderClass(true, true, annotationNode, tdParent, builderClassName, useInheritanceOnBuilder ? superclassBuilderClassName : null, typeParams, ast);
+		} else {
+			annotationNode.addError("@SuperBuilder does not support customized builders. Use @Builder instead.");
+		}
+
+		// Create the builder implementation class.
+		JavacNode builderImplType = findInnerClass(tdParent, builderImplClassName);
+		if (builderImplType == null) {
+			builderImplType = makeBuilderClass(false, false, annotationNode, tdParent, builderImplClassName, builderClassName, typeParams, ast);
+		} else {
+			annotationNode.addError("@SuperBuilder does not support customized builders. Use @Builder instead.");
+		}
+		
+		// Check that all builder fields for @Singular and @ObtainVia.
+		for (BuilderFieldData bfd : builderFields) {
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				if (bfd.singularData.getSingularizer().requiresCleaning()) {
+					addCleaning = true;
+					break;
+				}
+			}
+			if (bfd.obtainVia != null) {
+				if (bfd.obtainVia.field().isEmpty() == bfd.obtainVia.method().isEmpty()) {
+					bfd.obtainViaNode.addError("The syntax is either @ObtainVia(field = \"fieldName\") or @ObtainVia(method = \"methodName\").");
+					return;
+				}
+				if (bfd.obtainVia.method().isEmpty() && bfd.obtainVia.isStatic()) {
+					bfd.obtainViaNode.addError("@ObtainVia(isStatic = true) is not valid unless 'method' has been set.");
+					return;
+				}
+			}
+		}
+
+		// Generate the fields in the builder class that hold the values for the instance. 
+		generateBuilderFields(builderType, builderFields, ast);
+		if (addCleaning) {
+			JavacTreeMaker maker = builderType.getTreeMaker();
+			JCVariableDecl uncleanField = maker.VarDef(maker.Modifiers(Flags.PRIVATE), builderType.toName("$lombokUnclean"), maker.TypeIdent(CTC_BOOLEAN), null);
+			injectFieldAndMarkGenerated(builderType, uncleanField);
+		}
+
+		// Create a simple constructor for the builder class.
+		JCMethodDecl cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, List.<JCAnnotation>nil(), builderImplType, List.<JavacNode>nil(), false, annotationNode);
+		if (cd != null) injectMethod(builderImplType, cd);
+		
+		// Create the setter methods in the abstract builder.
+		for (BuilderFieldData bfd : builderFields) {
+			makeSetterMethodsForBuilder(builderType, bfd, annotationNode);
+		}
+		
+		// Create the build() method in the BuilderImpl.
+		if (methodExists(buildMethodName, builderType, -1) == MemberExistsResult.NOT_EXISTS) {
+			JCMethodDecl md = generateBuildMethod(tdParent, buildMethodName, returnType, builderImplType, thrownExceptions, ast);
+			if (md != null) injectMethod(builderImplType, md);
+		}
+		
+		// Create the toString() method for the abstract builder.
+		if (methodExists("toString", builderType, 0) == MemberExistsResult.NOT_EXISTS) {
+			java.util.List<JavacNode> fieldNodes = new ArrayList<JavacNode>();
+			for (BuilderFieldData bfd : builderFields) {
+				fieldNodes.addAll(bfd.createdFields);
+			}
+			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, false, FieldAccess.ALWAYS_FIELD, ast);
+			if (md != null) injectMethod(builderType, md);
+		}
+		
+		if (addCleaning) injectMethod(builderType, generateCleanMethod(builderFields, builderType, ast));
+		
+		// Add the builder() method to the annotated class.
+		if (methodExists(builderMethodName, tdParent, -1) == MemberExistsResult.NOT_EXISTS) {
+			JCMethodDecl md = generateBuilderMethod(builderMethodName, builderClassName, builderImplClassName, annotationNode, tdParent, typeParams);
+			recursiveSetGeneratedBy(md, ast, annotationNode.getContext());
+			if (md != null) injectMethod(tdParent, md);
+		}
+		
+		if (toBuilder) {
+			switch (methodExists(toBuilderMethodName, tdParent, 0)) {
+			case EXISTS_BY_USER:
+				annotationNode.addWarning("Not generating toBuilder() as it already exists.");
+				return;
+			case NOT_EXISTS:
+				List<JCTypeParameter> tps = typeParams;
+				JCMethodDecl md = generateToBuilderMethod(toBuilderMethodName, builderClassName, tdParent, tps, builderFields, ast);
+				if (md != null) injectMethod(tdParent, md);
+			}
+		}
+		
+		recursiveSetGeneratedBy(builderType.get(), ast, annotationNode.getContext());
+		recursiveSetGeneratedBy(builderImplType.get(), ast, annotationNode.getContext());
+	}
+	
+//	private static String unpack(JCExpression expr) {
+//		StringBuilder sb = new StringBuilder();
+//		unpack(sb, expr);
+//		return sb.toString();
+//	}
+	
+//	private static void unpack(StringBuilder sb, JCExpression expr) {
+//		if (expr instanceof JCIdent) {
+//			sb.append(((JCIdent) expr).name.toString());
+//			return;
+//		}
+//		
+//		if (expr instanceof JCFieldAccess) {
+//			JCFieldAccess jcfa = (JCFieldAccess) expr;
+//			unpack(sb, jcfa.selected);
+//			sb.append(".").append(jcfa.name.toString());
+//			return;
+//		}
+//		
+//		if (expr instanceof JCTypeApply) {
+//			sb.setLength(0);
+//			sb.append("ERR:");
+//			sb.append("@Builder(toBuilder=true) is not supported if returning a type with generics applied to an intermediate.");
+//			sb.append("__ERR__");
+//			return;
+//		}
+//		
+//		sb.setLength(0);
+//		sb.append("ERR:");
+//		sb.append("Expected a type of some sort, not a " + expr.getClass().getName());
+//		sb.append("__ERR__");
+//	}
+	
+
+	/**
+	 * Generates a constructor that has a builder as the only parameter.
+	 * The values from the builder are used to initialize the fields of new instances.
+	 *
+	 * @param typeNode
+	 *            the type (with the {@code @Builder} annotation) for which a
+	 *            constructor should be generated.
+	 * @param builderFields a list of fields in the builder which should be assigned to new instances.
+	 * @param source the annotation (used for setting source code locations for the generated code).
+	 * @param callBuilderBasedSuperConstructor
+	 *            If {@code true}, the constructor will explicitly call a super
+	 *            constructor with the builder as argument. Requires
+	 *            {@code builderClassAsParameter != null}.
+	 */
+	private void generateBuilderBasedConstructor(JavacNode typeNode, java.util.List<BuilderFieldData> builderFields, JavacNode source, String builderClassName, boolean callBuilderBasedSuperConstructor) {
+		JavacTreeMaker maker = typeNode.getTreeMaker();
+		
+		AccessLevel level = AccessLevel.PROTECTED;
+		boolean isEnum = (((JCClassDecl) typeNode.get()).mods.flags & Flags.ENUM) != 0;
+		if (isEnum) {
+			level = AccessLevel.PRIVATE;
+		}
+		
+		ListBuffer<JCStatement> nullChecks = new ListBuffer<JCStatement>();
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+		
+		Name builderVariableName = typeNode.toName("b");
+		for (BuilderFieldData bfd : builderFields) {
+			List<JCAnnotation> nonNulls = findAnnotations(bfd.originalFieldNode, NON_NULL_PATTERN);
+			if (!nonNulls.isEmpty()) {
+				JCStatement nullCheck = generateNullCheck(maker, bfd.originalFieldNode, source);
+				if (nullCheck != null) {
+					nullChecks.append(nullCheck);
+				}
+			}
+			
+			JCExpression rhs;
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, bfd.originalFieldNode, bfd.type, statements, bfd.name);
+				rhs = maker.Ident(bfd.singularData.getPluralName());
+			} else {
+				rhs = maker.Select(maker.Ident(builderVariableName), bfd.rawName);
+			}
+			JCFieldAccess thisX = maker.Select(maker.Ident(bfd.originalFieldNode.toName("this")), bfd.rawName);
+			
+			JCExpression assign = maker.Assign(thisX, rhs);
+				
+			statements.append(maker.Exec(assign));
+		}
+		
+		JCModifiers mods = maker.Modifiers(toJavacModifier(level), List.<JCAnnotation>nil());
+		
+		// Create a constructor that has just the builder as parameter.
+		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
+		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, typeNode.getContext());
+		Name builderClassname = typeNode.toName(builderClassName);
+		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags), builderVariableName, maker.Ident(builderClassname), null);
+		params.append(param);
+
+		if (callBuilderBasedSuperConstructor) {
+			// The first statement must be the call to the super constructor.
+			JCMethodInvocation callToSuperConstructor = maker.Apply(List.<JCExpression>nil(),
+					maker.Ident(typeNode.toName("super")),
+					List.<JCExpression>of(maker.Ident(builderVariableName)));
+			statements.prepend(maker.Exec(callToSuperConstructor));
+		}
+
+		JCMethodDecl constr = recursiveSetGeneratedBy(maker.MethodDef(mods, typeNode.toName("<init>"),
+			null, List.<JCTypeParameter>nil(), params.toList(), List.<JCExpression>nil(),
+			maker.Block(0L, nullChecks.appendList(statements).toList()), null), source.get(), typeNode.getContext());
+
+		injectMethod(typeNode, constr, null, Javac.createVoidType(typeNode.getSymbolTable(), CTC_VOID));
+	}
+
+	private JCMethodDecl generateToBuilderMethod(String toBuilderMethodName, String builderClassName, JavacNode type, List<JCTypeParameter> typeParams, java.util.List<BuilderFieldData> builderFields, JCAnnotation ast) {
+		// return new ThingieBuilder<A, B>().setA(this.a).setB(this.b);
+		JavacTreeMaker maker = type.getTreeMaker();
+		
+		ListBuffer<JCExpression> typeArgs = new ListBuffer<JCExpression>();
+		for (JCTypeParameter typeParam : typeParams) {
+			typeArgs.append(maker.Ident(typeParam.name));
+		}
+		
+		JCExpression call = maker.NewClass(null, List.<JCExpression>nil(), namePlusTypeParamsToTypeReference(maker, type.toName(builderClassName), typeParams), List.<JCExpression>nil(), null);
+		JCExpression invoke = call;
+		for (BuilderFieldData bfd : builderFields) {
+			Name setterName = bfd.name;
+			JCExpression arg;
+			if (bfd.obtainVia == null || !bfd.obtainVia.field().isEmpty()) {
+				arg = maker.Select(maker.Ident(type.toName("this")), bfd.obtainVia == null ? bfd.rawName : type.toName(bfd.obtainVia.field()));
+			} else {
+				if (bfd.obtainVia.isStatic()) {
+					JCExpression c = maker.Select(maker.Ident(type.toName(type.getName())), type.toName(bfd.obtainVia.method()));
+					arg = maker.Apply(List.<JCExpression>nil(), c, List.<JCExpression>of(maker.Ident(type.toName("this"))));
+				} else {
+					JCExpression c = maker.Select(maker.Ident(type.toName("this")), type.toName(bfd.obtainVia.method()));
+					arg = maker.Apply(List.<JCExpression>nil(), c, List.<JCExpression>nil());
+				}
+			}
+			invoke = maker.Apply(List.<JCExpression>nil(), maker.Select(invoke, setterName), List.of(arg));
+		}
+		JCStatement statement = maker.Return(invoke);
+		
+		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
+		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName(toBuilderMethodName), namePlusTypeParamsToTypeReference(maker, type.toName(builderClassName), typeParams), List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+	
+	private JCMethodDecl generateCleanMethod(java.util.List<BuilderFieldData> builderFields, JavacNode type, JCTree source) {
+		JavacTreeMaker maker = type.getTreeMaker();
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+		
+		for (BuilderFieldData bfd : builderFields) {
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.singularData.getSingularizer().appendCleaningCode(bfd.singularData, type, source, statements);
+			}
+		}
+		
+		statements.append(maker.Exec(maker.Assign(maker.Select(maker.Ident(type.toName("this")), type.toName("$lombokUnclean")), maker.Literal(CTC_BOOLEAN, 0))));
+		JCBlock body = maker.Block(0, statements.toList());
+		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName("$lombokClean"), maker.Type(Javac.createVoidType(type.getSymbolTable(), CTC_VOID)), List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+		/*
+		 * 		if (shouldReturnThis) {
+			methodType = cloneSelfType(field);
+		}
+		
+		if (methodType == null) {
+			//WARNING: Do not use field.getSymbolTable().voidType - that field has gone through non-backwards compatible API changes within javac1.6.
+			methodType = treeMaker.Type(Javac.createVoidType(treeMaker, CTC_VOID));
+			shouldReturnThis = false;
+		}
+
+		 */
+	}
+	
+	private JCMethodDecl generateBuildMethod(JavacNode tdParent, String buildName, JCExpression returnType, JavacNode type, List<JCExpression> thrownExceptions, JCTree source) {
+		JavacTreeMaker maker = type.getTreeMaker();
+		
+		JCExpression call;
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+		
+		// Use a constructor that only has this builder as parameter.
+		List<JCExpression> builderArg = List.<JCExpression>of(maker.Ident(type.toName("this")));
+		call = maker.NewClass(null, List.<JCExpression>nil(), returnType, builderArg, null);
+		statements.append(maker.Return(call));
+		
+		JCBlock body = maker.Block(0, statements.toList());
+		
+		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName(buildName), returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), thrownExceptions, body, null);
+	}
+	
+	public JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
+		
+		JCStatement statement = maker.Return(field.init);
+		field.init = null;
+		
+		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
+		int modifiers = Flags.PRIVATE | Flags.STATIC;
+		return maker.MethodDef(maker.Modifiers(modifiers), methodName, cloneType(maker, field.vartype, field, fieldNode.getContext()), copyTypeParams(fieldNode, params), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+	
+	public JCMethodDecl generateBuilderMethod(String builderMethodName, String builderClassName, String builderImplClassName, JavacNode source, JavacNode type, List<JCTypeParameter> typeParams) {
+		JavacTreeMaker maker = type.getTreeMaker();
+		
+		ListBuffer<JCExpression> typeArgs = new ListBuffer<JCExpression>();
+		for (JCTypeParameter typeParam : typeParams) {
+			typeArgs.append(maker.Ident(typeParam.name));
+		}
+		
+		JCExpression call = maker.NewClass(null, List.<JCExpression>nil(), namePlusTypeParamsToTypeReference(maker, type.toName(builderImplClassName), typeParams), List.<JCExpression>nil(), null);
+		JCStatement statement = maker.Return(call);
+		
+		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
+		int modifiers = Flags.PUBLIC;
+		modifiers |= Flags.STATIC;
+		return maker.MethodDef(maker.Modifiers(modifiers), type.toName(builderMethodName), namePlusTypeParamsToTypeReference(maker, type.toName(builderClassName), typeParams), copyTypeParams(source, typeParams), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+	
+	public void generateBuilderFields(JavacNode builderType, java.util.List<BuilderFieldData> builderFields, JCTree source) {
+		int len = builderFields.size();
+		java.util.List<JavacNode> existing = new ArrayList<JavacNode>();
+		for (JavacNode child : builderType.down()) {
+			if (child.getKind() == Kind.FIELD) existing.add(child);
+		}
+		
+		for (int i = len - 1; i >= 0; i--) {
+			BuilderFieldData bfd = builderFields.get(i);
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.createdFields.addAll(bfd.singularData.getSingularizer().generateFields(bfd.singularData, builderType, source));
+			} else {
+				JavacNode field = null, setFlag = null;
+				for (JavacNode exists : existing) {
+					Name n = ((JCVariableDecl) exists.get()).name;
+					if (n.equals(bfd.name)) field = exists;
+					if (n.equals(bfd.nameOfSetFlag)) setFlag = exists;
+				}
+				JavacTreeMaker maker = builderType.getTreeMaker();
+				if (field == null) {
+					JCModifiers mods = maker.Modifiers(Flags.PRIVATE);
+					JCVariableDecl newField = maker.VarDef(mods, bfd.name, cloneType(maker, bfd.type, source, builderType.getContext()), null);
+					field = injectFieldAndMarkGenerated(builderType, newField);
+				}
+				if (setFlag == null && bfd.nameOfSetFlag != null) {
+					JCModifiers mods = maker.Modifiers(Flags.PRIVATE);
+					JCVariableDecl newField = maker.VarDef(mods, bfd.nameOfSetFlag, maker.TypeIdent(CTC_BOOLEAN), null);
+					injectFieldAndMarkGenerated(builderType, newField);
+				}
+				bfd.createdFields.add(field);
+			}
+		}
+	}
+	
+	public void makeSetterMethodsForBuilder(JavacNode builderType, BuilderFieldData fieldNode, JavacNode source) {
+		boolean deprecate = isFieldDeprecated(fieldNode.originalFieldNode);
+		if (fieldNode.singularData == null || fieldNode.singularData.getSingularizer() == null) {
+			makeSimpleSetterMethodForBuilder(builderType, deprecate, fieldNode.createdFields.get(0), fieldNode.nameOfSetFlag, source, true, true);
+		} else {
+			fieldNode.singularData.getSingularizer().generateMethods(fieldNode.singularData, deprecate, builderType, source.get(), true, true);
+		}
+	}
+	
+	private void makeSimpleSetterMethodForBuilder(JavacNode builderType, boolean deprecate, JavacNode fieldNode, Name nameOfSetFlag, JavacNode source, boolean fluent, boolean chain) {
+		Name fieldName = ((JCVariableDecl) fieldNode.get()).name;
+		
+		for (JavacNode child : builderType.down()) {
+			if (child.getKind() != Kind.METHOD) continue;
+			JCMethodDecl methodDecl = (JCMethodDecl) child.get();
+			Name existingName = methodDecl.name;
+			if (existingName.equals(fieldName) && !isTolerate(fieldNode, methodDecl)) return;
+		}
+		
+		String setterName = fluent ? fieldNode.getName() : HandlerUtil.buildAccessorName("set", fieldNode.getName());
+		
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+		
+		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, deprecate, fieldNode, maker, setterName, nameOfSetFlag, chain, source, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
+		
+		injectMethod(builderType, newMethod);
+	}
+	
+	public JavacNode findInnerClass(JavacNode parent, String name) {
+		for (JavacNode child : parent.down()) {
+			if (child.getKind() != Kind.TYPE) continue;
+			JCClassDecl td = (JCClassDecl) child.get();
+			if (td.name.contentEquals(name)) return child;
+		}
+		return null;
+	}
+	
+	public JavacNode makeBuilderClass(boolean isAbstract, boolean isPublic, JavacNode source, JavacNode tdParent, String builderClassName, String parentBuilderClassName, List<JCTypeParameter> typeParams, JCAnnotation ast) {
+		JavacTreeMaker maker = tdParent.getTreeMaker();
+		int modifiers = Flags.STATIC;
+		if (isAbstract) modifiers |= Flags.ABSTRACT;
+		if (isPublic) {
+			modifiers |= Flags.PUBLIC;
+		} else {
+			modifiers |= Flags.PRIVATE;
+		}
+		JCModifiers mods = maker.Modifiers(modifiers);
+		
+		JCExpression extending = null;
+		if (parentBuilderClassName != null) {
+			extending = maker.Ident(tdParent.toName(parentBuilderClassName));
+		}
+		JCClassDecl builder = maker.ClassDef(mods, tdParent.toName(builderClassName), copyTypeParams(source, typeParams), extending, List.<JCExpression>nil(), List.<JCTree>nil());
+		return injectType(tdParent, builder);
+	}
+	
+	private void addObtainVia(BuilderFieldData bfd, JavacNode node) {
+		for (JavacNode child : node.down()) {
+			if (!annotationTypeMatches(ObtainVia.class, child)) continue;
+			AnnotationValues<ObtainVia> ann = createAnnotation(ObtainVia.class, child);
+			bfd.obtainVia = ann.getInstance();
+			bfd.obtainViaNode = child;
+			deleteAnnotationIfNeccessary(child, ObtainVia.class);
+			return;
+		}
+	}
+	
+	/**
+	 * Returns the explicitly requested singular annotation on this node (field
+	 * or parameter), or null if there's no {@code @Singular} annotation on it.
+	 * 
+	 * @param node The node (field or method param) to inspect for its name and potential {@code @Singular} annotation.
+	 */
+	private SingularData getSingularData(JavacNode node) {
+		for (JavacNode child : node.down()) {
+			if (!annotationTypeMatches(Singular.class, child)) continue;
+			Name pluralName = node.getKind() == Kind.FIELD ? removePrefixFromField(node) : ((JCVariableDecl) node.get()).name;
+			AnnotationValues<Singular> ann = createAnnotation(Singular.class, child);
+			deleteAnnotationIfNeccessary(child, Singular.class);
+			String explicitSingular = ann.getInstance().value();
+			if (explicitSingular.isEmpty()) {
+				if (Boolean.FALSE.equals(node.getAst().readConfiguration(ConfigurationKeys.SINGULAR_AUTO))) {
+					node.addError("The singular must be specified explicitly (e.g. @Singular(\"task\")) because auto singularization is disabled.");
+					explicitSingular = pluralName.toString();
+				} else {
+					explicitSingular = autoSingularize(pluralName.toString());
+					if (explicitSingular == null) {
+						node.addError("Can't singularize this name; please specify the singular explicitly (i.e. @Singular(\"sheep\"))");
+						explicitSingular = pluralName.toString();
+					}
+				}
+			}
+			Name singularName = node.toName(explicitSingular);
+			
+			JCExpression type = null;
+			if (node.get() instanceof JCVariableDecl) {
+				type = ((JCVariableDecl) node.get()).vartype;
+			}
+			
+			String name = null;
+			List<JCExpression> typeArgs = List.nil();
+			if (type instanceof JCTypeApply) {
+				typeArgs = ((JCTypeApply) type).arguments;
+				type = ((JCTypeApply) type).clazz;
+			}
+			
+			name = type.toString();
+			
+			String targetFqn = JavacSingularsRecipes.get().toQualified(name);
+			JavacSingularizer singularizer = JavacSingularsRecipes.get().getSingularizer(targetFqn);
+			if (singularizer == null) {
+				node.addError("Lombok does not know how to create the singular-form builder methods for type '" + name + "'; they won't be generated.");
+				return null;
+			}
+			
+			return new SingularData(child, singularName, pluralName, typeArgs, targetFqn, singularizer);
+		}
+		
+		return null;
+	}
+}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2013-2018 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -88,33 +88,41 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		ObtainVia obtainVia;
 		JavacNode obtainViaNode;
 		JavacNode originalFieldNode;
-		
+
 		java.util.List<JavacNode> createdFields = new ArrayList<JavacNode>();
 	}
-	
+
 	@Override
 	public void handle(AnnotationValues<SuperBuilder> annotation, JCAnnotation ast, JavacNode annotationNode) {
-		SuperBuilder builderInstance = annotation.getInstance();
-		
-		String builderMethodName = builderInstance.builderMethodName();
-		String buildMethodName = builderInstance.buildMethodName();
-		
-		if (builderMethodName == null) builderMethodName = "builder";
-		if (buildMethodName == null) buildMethodName = "build";
-		
-		if (!checkName("builderMethodName", builderMethodName, annotationNode)) return;
-		if (!checkName("buildMethodName", buildMethodName, annotationNode)) return;
-		
+		SuperBuilder superbuilderAnnotation = annotation.getInstance();
+
+		String builderMethodName = superbuilderAnnotation.builderMethodName();
+		String buildMethodName = superbuilderAnnotation.buildMethodName();
+
+		if (builderMethodName == null) {
+			builderMethodName = "builder";
+		}
+		if (buildMethodName == null) {
+			buildMethodName = "build";
+		}
+
+		if (!checkName("builderMethodName", builderMethodName, annotationNode)) {
+			return;
+		}
+		if (!checkName("buildMethodName", buildMethodName, annotationNode)) {
+			return;
+		}
+
 		JavacNode tdParent = annotationNode.up();
-		
+
 		java.util.List<BuilderFieldData> builderFields = new ArrayList<BuilderFieldData>();
 		JCExpression returnType;
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrownExceptions = List.nil();
 		List<JCExpression> superclassTypeParams = List.nil();
-		
+
 		boolean addCleaning = false;
-		
+
 		if (!(tdParent.get() instanceof JCClassDecl)) {
 			annotationNode.addError("@SuperBuilder is only supported on types.");
 			return;
@@ -134,28 +142,32 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			bfd.type = fd.vartype;
 			bfd.singularData = getSingularData(fieldNode);
 			bfd.originalFieldNode = fieldNode;
-			
+
 			if (bfd.singularData != null && isDefault != null) {
 				isDefault.addError("@Builder.Default and @Singular cannot be mixed.");
 				isDefault = null;
 			}
-			
+
 			if (fd.init == null && isDefault != null) {
 				isDefault.addWarning("@Builder.Default requires an initializing expression (' = something;').");
 				isDefault = null;
 			}
-			
+
 			if (fd.init != null && isDefault == null) {
-				if (isFinal) continue;
+				if (isFinal) {
+					continue;
+				}
 				fieldNode.addWarning("@SuperBuilder will ignore the initializing expression entirely. If you want the initializing expression to serve as default, add @Builder.Default. If it is not supposed to be settable during building, make the field final.");
 			}
-			
+
 			if (isDefault != null) {
 				bfd.nameOfDefaultProvider = tdParent.toName("$default$" + bfd.name);
 				bfd.nameOfSetFlag = tdParent.toName(bfd.name + "$set");
 				JCMethodDecl md = generateDefaultProvider(bfd.nameOfDefaultProvider, fieldNode, td.typarams);
 				recursiveSetGeneratedBy(md, ast, annotationNode.getContext());
-				if (md != null) injectMethod(tdParent, md);
+				if (md != null) {
+					injectMethod(tdParent, md);
+				}
 			}
 			addObtainVia(bfd, fieldNode);
 			builderFields.add(bfd);
@@ -172,11 +184,11 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			superclassTypeParams = ((JCTypeApply)extendsClause).getTypeArguments();
 			// A class name with a generics type, e.g., "Superclass<A>".
 			extendsClause = ((JCTypeApply)extendsClause).getType();
-		} 
+		}
 		if (extendsClause instanceof JCFieldAccess) {
 			Name superclassClassName = ((JCFieldAccess)extendsClause).getIdentifier();
 			String superclassBuilderClassName = superclassClassName + "Builder";
-			superclassBuilderClassExpression = tdParent.getTreeMaker().Select((JCFieldAccess)extendsClause, 
+			superclassBuilderClassExpression = tdParent.getTreeMaker().Select((JCFieldAccess)extendsClause,
 					tdParent.toName(superclassBuilderClassName));
 		} else if (extendsClause != null) {
 			String superclassBuilderClassName = extendsClause.toString() + "Builder";
@@ -187,7 +199,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 
 		returnType = namePlusTypeParamsToTypeReference(tdParent.getTreeMaker(), td.name, td.typarams);
 		typeParams = td.typarams;
-		
+
 		// <C, B> are the generics for our builder.
 		String classGenericName = "C";
 		String builderGenericName = "B";
@@ -199,22 +211,9 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		}
 		classGenericName = generateNonclashingNameFor(classGenericName, typeParamStrings);
 		builderGenericName = generateNonclashingNameFor(builderGenericName, typeParamStrings);
-		
+
 		thrownExceptions = List.nil();
 
-		generateBuilderBasedConstructor(tdParent, typeParams, builderFields, annotationNode, builderClassName, 
-				superclassBuilderClassExpression != null);
-
-		// Create the abstract builder class.
-		JavacNode builderType = findInnerClass(tdParent, builderClassName);
-		if (builderType == null) {
-			builderType = makeBuilderAbstractClass(annotationNode, tdParent, builderClassName, superclassBuilderClassExpression, 
-					typeParams, superclassTypeParams, ast, classGenericName, builderGenericName);
-		} else {
-			annotationNode.addError("@SuperBuilder does not support customized builders. Use @Builder instead.");
-			return;
-		}
-		
 		// Check validity of @ObtainVia fields, and add check if adding cleaning for @Singular is necessary.
 		for (BuilderFieldData bfd : builderFields) {
 			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
@@ -235,7 +234,17 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			}
 		}
 
-		// Generate the fields in the abstract builder class that hold the values for the instance. 
+		// Create the abstract builder class.
+		JavacNode builderType = findInnerClass(tdParent, builderClassName);
+		if (builderType == null) {
+			builderType = generateBuilderAbstractClass(annotationNode, tdParent, builderClassName, superclassBuilderClassExpression,
+					typeParams, superclassTypeParams, ast, classGenericName, builderGenericName);
+		} else {
+			annotationNode.addError("@SuperBuilder does not support customized builders. Use @Builder instead.");
+			return;
+		}
+
+		// Generate the fields in the abstract builder class that hold the values for the instance.
 		generateBuilderFields(builderType, builderFields, ast);
 		if (addCleaning) {
 			JavacTreeMaker maker = builderType.getTreeMaker();
@@ -249,9 +258,9 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 
 		// Create the setter methods in the abstract builder.
 		for (BuilderFieldData bfd : builderFields) {
-			makeSetterMethodsForBuilder(builderType, bfd, annotationNode, builderGenericName);
+			generateSetterMethodsForBuilder(builderType, bfd, annotationNode, builderGenericName);
 		}
-		
+
 		// Create the toString() method for the abstract builder.
 		if (methodExists("toString", builderType, 0) == MemberExistsResult.NOT_EXISTS) {
 			java.util.List<JavacNode> fieldNodes = new ArrayList<JavacNode>();
@@ -260,15 +269,19 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			}
 			// Let toString() call super.toString() if there is a superclass, so that it also shows fields from the superclass' builder.
 			JCMethodDecl md = HandleToString.createToString(builderType, fieldNodes, true, superclassBuilderClassExpression != null, FieldAccess.ALWAYS_FIELD, ast);
-			if (md != null) injectMethod(builderType, md);
+			if (md != null) {
+				injectMethod(builderType, md);
+			}
 		}
-		
-		if (addCleaning) injectMethod(builderType, generateCleanMethod(builderFields, builderType, ast));
-		
+
+		if (addCleaning) {
+			injectMethod(builderType, generateCleanMethod(builderFields, builderType, ast));
+		}
+
 		// Create the builder implementation class.
 		JavacNode builderImplType = findInnerClass(tdParent, builderImplClassName);
 		if (builderImplType == null) {
-			builderImplType = makeBuilderImplClass(annotationNode, tdParent, builderImplClassName, builderClassName, typeParams, ast);
+			builderImplType = generateBuilderImplClass(annotationNode, tdParent, builderImplClassName, builderClassName, typeParams, ast);
 		} else {
 			annotationNode.addError("@SuperBuilder does not support customized builders. Use @Builder instead.");
 			return;
@@ -276,325 +289,37 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 
 		// Create a simple constructor for the BuilderImpl class.
 		JCMethodDecl cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, List.<JCAnnotation>nil(), builderImplType, List.<JavacNode>nil(), false, annotationNode);
-		if (cd != null) injectMethod(builderImplType, cd);
+		if (cd != null) {
+			injectMethod(builderImplType, cd);
+		}
 
 		// Create the self() and build() methods in the BuilderImpl.
 		injectMethod(builderImplType, generateSelfMethod(builderImplType));
 		injectMethod(builderImplType, generateBuildMethod(buildMethodName, returnType, builderImplType, thrownExceptions));
-		
+
+		// Generate a constructor in the annotated class that takes a builder as argument.
+		generateBuilderBasedConstructor(tdParent, typeParams, builderFields, annotationNode, builderClassName,
+				superclassBuilderClassExpression != null);
+
 		// Add the builder() method to the annotated class.
+		// Allow users to specify their own builder() methods, e.g., to provide default values.
 		if (methodExists(builderMethodName, tdParent, -1) == MemberExistsResult.NOT_EXISTS) {
 			JCMethodDecl md = generateBuilderMethod(builderMethodName, builderClassName, builderImplClassName, annotationNode, tdParent, typeParams);
 			recursiveSetGeneratedBy(md, ast, annotationNode.getContext());
-			if (md != null) injectMethod(tdParent, md);
+			if (md != null) {
+				injectMethod(tdParent, md);
+			}
 		}
-		
+
 		recursiveSetGeneratedBy(builderType.get(), ast, annotationNode.getContext());
 		recursiveSetGeneratedBy(builderImplType.get(), ast, annotationNode.getContext());
 	}
-	
-	private String generateNonclashingNameFor(String classGenericName, java.util.List<String> typeParamStrings) {
-		if (!typeParamStrings.contains(classGenericName))
-			return classGenericName;
-		int counter = 2;
-		while (typeParamStrings.contains(classGenericName + counter)) {
-			counter++;
-		}
-		return classGenericName + counter;
-	}
-	
 
 	/**
-	 * Generates a constructor that has a builder as the only parameter.
-	 * The values from the builder are used to initialize the fields of new instances.
-	 *
-	 * @param typeNode
-	 *            the type (with the {@code @Builder} annotation) for which a
-	 *            constructor should be generated.
-	 * @param typeParams 
-	 * @param builderFields a list of fields in the builder which should be assigned to new instances.
-	 * @param source the annotation (used for setting source code locations for the generated code).
-	 * @param callBuilderBasedSuperConstructor
-	 *            If {@code true}, the constructor will explicitly call a super
-	 *            constructor with the builder as argument. Requires
-	 *            {@code builderClassAsParameter != null}.
+	 * Creates and returns the abstract builder class and injects it into the annotated class.
 	 */
-	private void generateBuilderBasedConstructor(JavacNode typeNode, List<JCTypeParameter> typeParams, java.util.List<BuilderFieldData> builderFields, JavacNode source, String builderClassName, boolean callBuilderBasedSuperConstructor) {
-		JavacTreeMaker maker = typeNode.getTreeMaker();
-		
-		AccessLevel level = AccessLevel.PROTECTED;
-		boolean isEnum = (((JCClassDecl) typeNode.get()).mods.flags & Flags.ENUM) != 0;
-		if (isEnum) {
-			level = AccessLevel.PRIVATE;
-		}
-		
-		ListBuffer<JCStatement> nullChecks = new ListBuffer<JCStatement>();
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		
-		Name builderVariableName = typeNode.toName("b");
-		for (BuilderFieldData bfd : builderFields) {
-			List<JCAnnotation> nonNulls = findAnnotations(bfd.originalFieldNode, NON_NULL_PATTERN);
-			if (!nonNulls.isEmpty()) {
-				JCStatement nullCheck = generateNullCheck(maker, bfd.originalFieldNode, source);
-				if (nullCheck != null) {
-					nullChecks.append(nullCheck);
-				}
-			}
-			
-			JCExpression rhs;
-			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
-				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, bfd.originalFieldNode, bfd.type, statements, bfd.name, "b");
-				rhs = maker.Ident(bfd.singularData.getPluralName());
-			} else {
-				rhs = maker.Select(maker.Ident(builderVariableName), bfd.rawName);
-			}
-			JCFieldAccess thisX = maker.Select(maker.Ident(bfd.originalFieldNode.toName("this")), bfd.rawName);
-			
-			JCExpression assign = maker.Assign(thisX, rhs);
-				
-			statements.append(maker.Exec(assign));
-		}
-		
-		JCModifiers mods = maker.Modifiers(toJavacModifier(level), List.<JCAnnotation>nil());
-		
-		// Create a constructor that has just the builder as parameter.
-		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
-		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, typeNode.getContext());
-		Name builderClassname = typeNode.toName(builderClassName);
-		// First add all generics that are present on the parent type.
-		ListBuffer<JCExpression> typeParamsForBuilderParameter = getTypeParamExpressions(typeParams, maker);
-		// Now add the <?, ?>.
-		JCWildcard wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
-		typeParamsForBuilderParameter.add(wildcard);
-		wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
-		typeParamsForBuilderParameter.add(wildcard);
-		JCTypeApply paramType = maker.TypeApply(maker.Ident(builderClassname), typeParamsForBuilderParameter.toList());
-		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags), builderVariableName, paramType, null);
-		params.append(param);
-
-		if (callBuilderBasedSuperConstructor) {
-			// The first statement must be the call to the super constructor.
-			JCMethodInvocation callToSuperConstructor = maker.Apply(List.<JCExpression>nil(),
-					maker.Ident(typeNode.toName("super")),
-					List.<JCExpression>of(maker.Ident(builderVariableName)));
-			statements.prepend(maker.Exec(callToSuperConstructor));
-		}
-
-		JCMethodDecl constr = recursiveSetGeneratedBy(maker.MethodDef(mods, typeNode.toName("<init>"),
-			null, List.<JCTypeParameter>nil(), params.toList(), List.<JCExpression>nil(),
-			maker.Block(0L, nullChecks.appendList(statements).toList()), null), source.get(), typeNode.getContext());
-
-		injectMethod(typeNode, constr, null, Javac.createVoidType(typeNode.getSymbolTable(), CTC_VOID));
-	}
-
-	private ListBuffer<JCExpression> getTypeParamExpressions(List<? extends JCTree> typeParams, JavacTreeMaker maker) {
-		ListBuffer<JCExpression> typeParamsForBuilderParameter = new ListBuffer<JCExpression>();
-		for (JCTree typeParam : typeParams) {
-			if (typeParam instanceof JCTypeParameter) {
-				typeParamsForBuilderParameter.add(maker.Ident(((JCTypeParameter)typeParam).getName()));
-			} else if (typeParam instanceof JCIdent) {
-				typeParamsForBuilderParameter.add(maker.Ident(((JCIdent)typeParam).getName()));
-			}
-		}
-		return typeParamsForBuilderParameter;
-	}
-
-	private JCMethodDecl generateAbstractSelfMethod(JavacNode type, boolean override, String builderGenericName) {
-		JavacTreeMaker maker = type.getTreeMaker();
-		List<JCAnnotation> annotations = List.nil();
-		if (override) {
-			JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(type, "Override"), List.<JCExpression>nil());
-			annotations = List.of(overrideAnnotation);
-		}
-		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED | Flags.ABSTRACT, annotations);
-		Name name = type.toName(SELF_METHOD);
-		JCExpression returnType = maker.Ident(type.toName(builderGenericName));
-
-		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), null, null);
-	}
-	
-	private JCMethodDecl generateSelfMethod(JavacNode builderImplType) {
-		JavacTreeMaker maker = builderImplType.getTreeMaker();
-
-		JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(builderImplType, "Override"), List.<JCExpression>nil());
-		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED, List.of(overrideAnnotation));
-		Name name = builderImplType.toName(SELF_METHOD);
-		JCExpression returnType = maker.Ident(builderImplType.toName(builderImplType.getName()));
-
-		JCStatement statement = maker.Return(maker.Ident(builderImplType.toName("this")));
-		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
-
-		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
-	}
-	
-	private JCMethodDecl generateAbstractBuildMethod(JavacNode type, String methodName, boolean override, String classGenericName) {
-		JavacTreeMaker maker = type.getTreeMaker();
-		List<JCAnnotation> annotations = List.nil();
-		if (override) {
-			JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(type, "Override"), List.<JCExpression>nil());
-			annotations = List.of(overrideAnnotation);
-		}
-		JCModifiers modifiers = maker.Modifiers(Flags.PUBLIC | Flags.ABSTRACT, annotations);
-		Name name = type.toName(methodName);
-		JCExpression returnType = maker.Ident(type.toName(classGenericName));
-
-		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), null, null);
-	}
-	
-	private JCMethodDecl generateCleanMethod(java.util.List<BuilderFieldData> builderFields, JavacNode type, JCTree source) {
-		JavacTreeMaker maker = type.getTreeMaker();
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		
-		for (BuilderFieldData bfd : builderFields) {
-			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
-				bfd.singularData.getSingularizer().appendCleaningCode(bfd.singularData, type, source, statements);
-			}
-		}
-		
-		statements.append(maker.Exec(maker.Assign(maker.Select(maker.Ident(type.toName("this")), type.toName("$lombokUnclean")), maker.Literal(CTC_BOOLEAN, 0))));
-		JCBlock body = maker.Block(0, statements.toList());
-		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName("$lombokClean"), maker.Type(Javac.createVoidType(type.getSymbolTable(), CTC_VOID)), List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
-	}
-	
-	private JCMethodDecl generateBuildMethod(String buildName, JCExpression returnType, JavacNode type, List<JCExpression> thrownExceptions) {
-		JavacTreeMaker maker = type.getTreeMaker();
-		
-		JCExpression call;
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		
-		// Use a constructor that only has this builder as parameter.
-		List<JCExpression> builderArg = List.<JCExpression>of(maker.Ident(type.toName("this")));
-		call = maker.NewClass(null, List.<JCExpression>nil(), returnType, builderArg, null);
-		statements.append(maker.Return(call));
-		
-		JCBlock body = maker.Block(0, statements.toList());
-
-		JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(type, "Override"), List.<JCExpression>nil());
-		JCModifiers modifiers = maker.Modifiers(Flags.PUBLIC, List.of(overrideAnnotation));
-		
-		return maker.MethodDef(modifiers, type.toName(buildName), returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), thrownExceptions, body, null);
-	}
-	
-	public JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
-		JavacTreeMaker maker = fieldNode.getTreeMaker();
-		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
-		
-		JCStatement statement = maker.Return(field.init);
-		field.init = null;
-		
-		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
-		int modifiers = Flags.PRIVATE | Flags.STATIC;
-		return maker.MethodDef(maker.Modifiers(modifiers), methodName, cloneType(maker, field.vartype, field, fieldNode.getContext()), copyTypeParams(fieldNode, params), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
-	}
-	
-	public JCMethodDecl generateBuilderMethod(String builderMethodName, String builderClassName, String builderImplClassName, JavacNode source, JavacNode type, List<JCTypeParameter> typeParams) {
-		JavacTreeMaker maker = type.getTreeMaker();
-		
-		ListBuffer<JCExpression> typeArgs = new ListBuffer<JCExpression>();
-		for (JCTypeParameter typeParam : typeParams) {
-			typeArgs.append(maker.Ident(typeParam.name));
-		}
-		
-		JCExpression call = maker.NewClass(null, List.<JCExpression>nil(), namePlusTypeParamsToTypeReference(maker, type.toName(builderImplClassName), typeParams), List.<JCExpression>nil(), null);
-		JCStatement statement = maker.Return(call);
-		
-		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
-		int modifiers = Flags.PUBLIC;
-		modifiers |= Flags.STATIC;
-		
-		// Add any type params of the annotated class to the return type.
-		ListBuffer<JCExpression> typeParameterNames = new ListBuffer<JCExpression>();
-		typeParameterNames.addAll(typeParameterNames(maker, typeParams));
-		// Now add the <?, ?>.
-		JCWildcard wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
-		typeParameterNames.add(wildcard);
-		typeParameterNames.add(wildcard);
-		JCTypeApply returnType = maker.TypeApply(maker.Ident(type.toName(builderClassName)), typeParameterNames.toList());
-
-		return maker.MethodDef(maker.Modifiers(modifiers), type.toName(builderMethodName), returnType, copyTypeParams(source, typeParams), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
-	}
-	
-	public void generateBuilderFields(JavacNode builderType, java.util.List<BuilderFieldData> builderFields, JCTree source) {
-		int len = builderFields.size();
-		java.util.List<JavacNode> existing = new ArrayList<JavacNode>();
-		for (JavacNode child : builderType.down()) {
-			if (child.getKind() == Kind.FIELD) existing.add(child);
-		}
-		
-		for (int i = len - 1; i >= 0; i--) {
-			BuilderFieldData bfd = builderFields.get(i);
-			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
-				bfd.createdFields.addAll(bfd.singularData.getSingularizer().generateFields(bfd.singularData, builderType, source));
-			} else {
-				JavacNode field = null, setFlag = null;
-				for (JavacNode exists : existing) {
-					Name n = ((JCVariableDecl) exists.get()).name;
-					if (n.equals(bfd.name)) field = exists;
-					if (n.equals(bfd.nameOfSetFlag)) setFlag = exists;
-				}
-				JavacTreeMaker maker = builderType.getTreeMaker();
-				if (field == null) {
-					JCModifiers mods = maker.Modifiers(Flags.PRIVATE);
-					JCVariableDecl newField = maker.VarDef(mods, bfd.name, cloneType(maker, bfd.type, source, builderType.getContext()), null);
-					field = injectFieldAndMarkGenerated(builderType, newField);
-				}
-				if (setFlag == null && bfd.nameOfSetFlag != null) {
-					JCModifiers mods = maker.Modifiers(Flags.PRIVATE);
-					JCVariableDecl newField = maker.VarDef(mods, bfd.nameOfSetFlag, maker.TypeIdent(CTC_BOOLEAN), null);
-					injectFieldAndMarkGenerated(builderType, newField);
-				}
-				bfd.createdFields.add(field);
-			}
-		}
-	}
-	
-	public void makeSetterMethodsForBuilder(final JavacNode builderType, BuilderFieldData fieldNode, JavacNode source, final String builderGenericName) {
-		boolean deprecate = isFieldDeprecated(fieldNode.originalFieldNode);
-		final JavacTreeMaker maker = builderType.getTreeMaker();
-		// TODO: Make these lambdas when switching to a source level >= 1.8.
-		Supplier<JCExpression> returnType = new Supplier<JCExpression>() { @Override public JCExpression get() {
-			return maker.Ident(builderType.toName(builderGenericName));
-		}};
-		Supplier<? extends JCReturn> returnStatement = new Supplier<JCReturn>() { @Override public JCReturn get() {
-			return maker.Return(maker.Apply(List.<JCExpression>nil(), maker.Ident(builderType.toName(SELF_METHOD)), List.<JCExpression>nil()));
-		}};
-		if (fieldNode.singularData == null || fieldNode.singularData.getSingularizer() == null) {
-			makeSimpleSetterMethodForBuilder(builderType, deprecate, fieldNode.createdFields.get(0), fieldNode.nameOfSetFlag, source, true, true, returnType.get(), returnStatement.get());
-		} else {
-			fieldNode.singularData.getSingularizer().generateMethods(fieldNode.singularData, deprecate, builderType, source.get(), true, returnType, returnStatement);
-		}
-	}
-	
-	private void makeSimpleSetterMethodForBuilder(JavacNode builderType, boolean deprecate, JavacNode fieldNode, Name nameOfSetFlag, JavacNode source, boolean fluent, boolean chain, JCExpression returnType, JCReturn returnStatement) {
-		Name fieldName = ((JCVariableDecl) fieldNode.get()).name;
-		
-		for (JavacNode child : builderType.down()) {
-			if (child.getKind() != Kind.METHOD) continue;
-			JCMethodDecl methodDecl = (JCMethodDecl) child.get();
-			Name existingName = methodDecl.name;
-			if (existingName.equals(fieldName) && !isTolerate(fieldNode, methodDecl)) return;
-		}
-		
-		String setterName = fluent ? fieldNode.getName() : HandlerUtil.buildAccessorName("set", fieldNode.getName());
-		
-		JavacTreeMaker maker = fieldNode.getTreeMaker();
-		
-		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, deprecate, fieldNode, maker, setterName, nameOfSetFlag, returnType, returnStatement, source, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
-		
-		injectMethod(builderType, newMethod);
-	}
-	
-	public JavacNode findInnerClass(JavacNode parent, String name) {
-		for (JavacNode child : parent.down()) {
-			if (child.getKind() != Kind.TYPE) continue;
-			JCClassDecl td = (JCClassDecl) child.get();
-			if (td.name.contentEquals(name)) return child;
-		}
-		return null;
-	}
-	
-	public JavacNode makeBuilderAbstractClass(JavacNode source, JavacNode tdParent, String builderClass,
-			JCExpression superclassBuilderClassExpression, List<JCTypeParameter> typeParams, 
+	private JavacNode generateBuilderAbstractClass(JavacNode source, JavacNode tdParent, String builderClass,
+			JCExpression superclassBuilderClassExpression, List<JCTypeParameter> typeParams,
 			List<JCExpression> superclassTypeParams, JCAnnotation ast, String classGenericName, String builderGenericName) {
 		JavacTreeMaker maker = tdParent.getTreeMaker();
 		JCModifiers mods = maker.Modifiers(Flags.STATIC | Flags.ABSTRACT | Flags.PUBLIC);
@@ -628,15 +353,18 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			typeParamsForBuilder.add(maker.Ident(tdParent.toName(builderGenericName)));
 			extending = maker.TypeApply(superclassBuilderClassExpression, typeParamsForBuilder.toList());
 		}
-		
+
 		JCClassDecl builder = maker.ClassDef(mods, builderClassName, allTypeParams.toList(), extending, List.<JCExpression>nil(), List.<JCTree>nil());
 		return injectType(tdParent, builder);
 	}
-	
-	public JavacNode makeBuilderImplClass(JavacNode source, JavacNode tdParent, String builderImplClass, String builderAbstractClass, List<JCTypeParameter> typeParams, JCAnnotation ast) {
+
+	/**
+	 * Creates and returns the concrete builder implementation class and injects it into the annotated class.
+	 */
+	private JavacNode generateBuilderImplClass(JavacNode source, JavacNode tdParent, String builderImplClass, String builderAbstractClass, List<JCTypeParameter> typeParams, JCAnnotation ast) {
 		JavacTreeMaker maker = tdParent.getTreeMaker();
 		JCModifiers mods = maker.Modifiers(Flags.STATIC | Flags.PRIVATE | Flags.FINAL);
-		
+
 		// Extend the abstract builder.
 		JCExpression extending = maker.Ident(tdParent.toName(builderAbstractClass));
 		// Add any type params of the annotated class.
@@ -658,14 +386,290 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		typeParamsForBuilder.add(annotatedClass);
 		typeParamsForBuilder.add(builderImplClassExpression);
 		extending = maker.TypeApply(extending, typeParamsForBuilder.toList());
-		
+
 		JCClassDecl builder = maker.ClassDef(mods, tdParent.toName(builderImplClass), copyTypeParams(source, typeParams), extending, List.<JCExpression>nil(), List.<JCTree>nil());
 		return injectType(tdParent, builder);
 	}
-	
+
+	/**
+	 * Generates a constructor that has a builder as the only parameter.
+	 * The values from the builder are used to initialize the fields of new instances.
+	 *
+	 * @param typeNode
+	 *            the type (with the {@code @Builder} annotation) for which a
+	 *            constructor should be generated.
+	 * @param typeParams
+	 * @param builderFields a list of fields in the builder which should be assigned to new instances.
+	 * @param source the annotation (used for setting source code locations for the generated code).
+	 * @param callBuilderBasedSuperConstructor
+	 *            If {@code true}, the constructor will explicitly call a super
+	 *            constructor with the builder as argument. Requires
+	 *            {@code builderClassAsParameter != null}.
+	 */
+	private void generateBuilderBasedConstructor(JavacNode typeNode, List<JCTypeParameter> typeParams, java.util.List<BuilderFieldData> builderFields, JavacNode source, String builderClassName, boolean callBuilderBasedSuperConstructor) {
+		JavacTreeMaker maker = typeNode.getTreeMaker();
+
+		AccessLevel level = AccessLevel.PROTECTED;
+
+		ListBuffer<JCStatement> nullChecks = new ListBuffer<JCStatement>();
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+
+		Name builderVariableName = typeNode.toName("b");
+		for (BuilderFieldData bfd : builderFields) {
+			List<JCAnnotation> nonNulls = findAnnotations(bfd.originalFieldNode, NON_NULL_PATTERN);
+			if (!nonNulls.isEmpty()) {
+				JCStatement nullCheck = generateNullCheck(maker, bfd.originalFieldNode, source);
+				if (nullCheck != null) {
+					nullChecks.append(nullCheck);
+				}
+			}
+
+			JCExpression rhs;
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, bfd.originalFieldNode, bfd.type, statements, bfd.name, "b");
+				rhs = maker.Ident(bfd.singularData.getPluralName());
+			} else {
+				rhs = maker.Select(maker.Ident(builderVariableName), bfd.rawName);
+			}
+			JCFieldAccess thisX = maker.Select(maker.Ident(typeNode.toName("this")), bfd.rawName);
+
+			JCExpression assign = maker.Assign(thisX, rhs);
+
+			statements.append(maker.Exec(assign));
+		}
+
+		JCModifiers mods = maker.Modifiers(toJavacModifier(level), List.<JCAnnotation>nil());
+
+		// Create a constructor that has just the builder as parameter.
+		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
+		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, typeNode.getContext());
+		Name builderClassname = typeNode.toName(builderClassName);
+		// First add all generics that are present on the parent type.
+		ListBuffer<JCExpression> typeParamsForBuilderParameter = getTypeParamExpressions(typeParams, maker);
+		// Now add the <?, ?>.
+		JCWildcard wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
+		typeParamsForBuilderParameter.add(wildcard);
+		wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
+		typeParamsForBuilderParameter.add(wildcard);
+		JCTypeApply paramType = maker.TypeApply(maker.Ident(builderClassname), typeParamsForBuilderParameter.toList());
+		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags), builderVariableName, paramType, null);
+		params.append(param);
+
+		if (callBuilderBasedSuperConstructor) {
+			// The first statement must be the call to the super constructor.
+			JCMethodInvocation callToSuperConstructor = maker.Apply(List.<JCExpression>nil(),
+					maker.Ident(typeNode.toName("super")),
+					List.<JCExpression>of(maker.Ident(builderVariableName)));
+			statements.prepend(maker.Exec(callToSuperConstructor));
+		}
+
+		JCMethodDecl constr = recursiveSetGeneratedBy(maker.MethodDef(mods, typeNode.toName("<init>"),
+			null, List.<JCTypeParameter>nil(), params.toList(), List.<JCExpression>nil(),
+			maker.Block(0L, nullChecks.appendList(statements).toList()), null), source.get(), typeNode.getContext());
+
+		injectMethod(typeNode, constr, null, Javac.createVoidType(typeNode.getSymbolTable(), CTC_VOID));
+	}
+
+	private JCMethodDecl generateBuilderMethod(String builderMethodName, String builderClassName, String builderImplClassName, JavacNode source, JavacNode type, List<JCTypeParameter> typeParams) {
+		JavacTreeMaker maker = type.getTreeMaker();
+
+		ListBuffer<JCExpression> typeArgs = new ListBuffer<JCExpression>();
+		for (JCTypeParameter typeParam : typeParams) {
+			typeArgs.append(maker.Ident(typeParam.name));
+		}
+
+		JCExpression call = maker.NewClass(null, List.<JCExpression>nil(), namePlusTypeParamsToTypeReference(maker, type.toName(builderImplClassName), typeParams), List.<JCExpression>nil(), null);
+		JCStatement statement = maker.Return(call);
+
+		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
+		int modifiers = Flags.PUBLIC;
+		modifiers |= Flags.STATIC;
+
+		// Add any type params of the annotated class to the return type.
+		ListBuffer<JCExpression> typeParameterNames = new ListBuffer<JCExpression>();
+		typeParameterNames.addAll(typeParameterNames(maker, typeParams));
+		// Now add the <?, ?>.
+		JCWildcard wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
+		typeParameterNames.add(wildcard);
+		typeParameterNames.add(wildcard);
+		JCTypeApply returnType = maker.TypeApply(maker.Ident(type.toName(builderClassName)), typeParameterNames.toList());
+
+		return maker.MethodDef(maker.Modifiers(modifiers), type.toName(builderMethodName), returnType, copyTypeParams(source, typeParams), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+
+	private JCMethodDecl generateAbstractSelfMethod(JavacNode type, boolean override, String builderGenericName) {
+		JavacTreeMaker maker = type.getTreeMaker();
+		List<JCAnnotation> annotations = List.nil();
+		if (override) {
+			JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(type, "Override"), List.<JCExpression>nil());
+			annotations = List.of(overrideAnnotation);
+		}
+		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED | Flags.ABSTRACT, annotations);
+		Name name = type.toName(SELF_METHOD);
+		JCExpression returnType = maker.Ident(type.toName(builderGenericName));
+
+		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), null, null);
+	}
+
+	private JCMethodDecl generateSelfMethod(JavacNode builderImplType) {
+		JavacTreeMaker maker = builderImplType.getTreeMaker();
+
+		JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(builderImplType, "Override"), List.<JCExpression>nil());
+		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED, List.of(overrideAnnotation));
+		Name name = builderImplType.toName(SELF_METHOD);
+		JCExpression returnType = maker.Ident(builderImplType.toName(builderImplType.getName()));
+
+		JCStatement statement = maker.Return(maker.Ident(builderImplType.toName("this")));
+		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
+
+		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+
+	private JCMethodDecl generateAbstractBuildMethod(JavacNode type, String methodName, boolean override, String classGenericName) {
+		JavacTreeMaker maker = type.getTreeMaker();
+		List<JCAnnotation> annotations = List.nil();
+		if (override) {
+			JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(type, "Override"), List.<JCExpression>nil());
+			annotations = List.of(overrideAnnotation);
+		}
+		JCModifiers modifiers = maker.Modifiers(Flags.PUBLIC | Flags.ABSTRACT, annotations);
+		Name name = type.toName(methodName);
+		JCExpression returnType = maker.Ident(type.toName(classGenericName));
+
+		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), null, null);
+	}
+
+	private JCMethodDecl generateBuildMethod(String buildName, JCExpression returnType, JavacNode type, List<JCExpression> thrownExceptions) {
+		JavacTreeMaker maker = type.getTreeMaker();
+
+		JCExpression call;
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+
+		// Use a constructor that only has this builder as parameter.
+		List<JCExpression> builderArg = List.<JCExpression>of(maker.Ident(type.toName("this")));
+		call = maker.NewClass(null, List.<JCExpression>nil(), returnType, builderArg, null);
+		statements.append(maker.Return(call));
+
+		JCBlock body = maker.Block(0, statements.toList());
+
+		JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(type, "Override"), List.<JCExpression>nil());
+		JCModifiers modifiers = maker.Modifiers(Flags.PUBLIC, List.of(overrideAnnotation));
+
+		return maker.MethodDef(modifiers, type.toName(buildName), returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), thrownExceptions, body, null);
+	}
+
+	private JCMethodDecl generateCleanMethod(java.util.List<BuilderFieldData> builderFields, JavacNode type, JCTree source) {
+		JavacTreeMaker maker = type.getTreeMaker();
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+
+		for (BuilderFieldData bfd : builderFields) {
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.singularData.getSingularizer().appendCleaningCode(bfd.singularData, type, source, statements);
+			}
+		}
+
+		statements.append(maker.Exec(maker.Assign(maker.Select(maker.Ident(type.toName("this")), type.toName("$lombokUnclean")), maker.Literal(CTC_BOOLEAN, 0))));
+		JCBlock body = maker.Block(0, statements.toList());
+		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName("$lombokClean"), maker.Type(Javac.createVoidType(type.getSymbolTable(), CTC_VOID)), List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+
+	private JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
+
+		JCStatement statement = maker.Return(field.init);
+		field.init = null;
+
+		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
+		int modifiers = Flags.PRIVATE | Flags.STATIC;
+		return maker.MethodDef(maker.Modifiers(modifiers), methodName, cloneType(maker, field.vartype, field, fieldNode.getContext()), copyTypeParams(fieldNode, params), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
+	}
+
+	private void generateBuilderFields(JavacNode builderType, java.util.List<BuilderFieldData> builderFields, JCTree source) {
+		int len = builderFields.size();
+		java.util.List<JavacNode> existing = new ArrayList<JavacNode>();
+		for (JavacNode child : builderType.down()) {
+			if (child.getKind() == Kind.FIELD) {
+				existing.add(child);
+			}
+		}
+
+		for (int i = len - 1; i >= 0; i--) {
+			BuilderFieldData bfd = builderFields.get(i);
+			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
+				bfd.createdFields.addAll(bfd.singularData.getSingularizer().generateFields(bfd.singularData, builderType, source));
+			} else {
+				JavacNode field = null, setFlag = null;
+				for (JavacNode exists : existing) {
+					Name n = ((JCVariableDecl) exists.get()).name;
+					if (n.equals(bfd.name)) {
+						field = exists;
+					}
+					if (n.equals(bfd.nameOfSetFlag)) {
+						setFlag = exists;
+					}
+				}
+				JavacTreeMaker maker = builderType.getTreeMaker();
+				if (field == null) {
+					JCModifiers mods = maker.Modifiers(Flags.PRIVATE);
+					JCVariableDecl newField = maker.VarDef(mods, bfd.name, cloneType(maker, bfd.type, source, builderType.getContext()), null);
+					field = injectFieldAndMarkGenerated(builderType, newField);
+				}
+				if (setFlag == null && bfd.nameOfSetFlag != null) {
+					JCModifiers mods = maker.Modifiers(Flags.PRIVATE);
+					JCVariableDecl newField = maker.VarDef(mods, bfd.nameOfSetFlag, maker.TypeIdent(CTC_BOOLEAN), null);
+					injectFieldAndMarkGenerated(builderType, newField);
+				}
+				bfd.createdFields.add(field);
+			}
+		}
+	}
+
+	private void generateSetterMethodsForBuilder(final JavacNode builderType, BuilderFieldData fieldNode, JavacNode source, final String builderGenericName) {
+		boolean deprecate = isFieldDeprecated(fieldNode.originalFieldNode);
+		final JavacTreeMaker maker = builderType.getTreeMaker();
+		// TODO: Make these lambdas when switching to a source level >= 1.8.
+		Supplier<JCExpression> returnType = new Supplier<JCExpression>() { @Override public JCExpression get() {
+			return maker.Ident(builderType.toName(builderGenericName));
+		}};
+		Supplier<? extends JCReturn> returnStatement = new Supplier<JCReturn>() { @Override public JCReturn get() {
+			return maker.Return(maker.Apply(List.<JCExpression>nil(), maker.Ident(builderType.toName(SELF_METHOD)), List.<JCExpression>nil()));
+		}};
+		if (fieldNode.singularData == null || fieldNode.singularData.getSingularizer() == null) {
+			generateSimpleSetterMethodForBuilder(builderType, deprecate, fieldNode.createdFields.get(0), fieldNode.nameOfSetFlag, source, true, true, returnType.get(), returnStatement.get());
+		} else {
+			fieldNode.singularData.getSingularizer().generateMethods(fieldNode.singularData, deprecate, builderType, source.get(), true, returnType, returnStatement);
+		}
+	}
+
+	private void generateSimpleSetterMethodForBuilder(JavacNode builderType, boolean deprecate, JavacNode fieldNode, Name nameOfSetFlag, JavacNode source, boolean fluent, boolean chain, JCExpression returnType, JCReturn returnStatement) {
+		Name fieldName = ((JCVariableDecl) fieldNode.get()).name;
+
+		for (JavacNode child : builderType.down()) {
+			if (child.getKind() != Kind.METHOD) {
+				continue;
+			}
+			JCMethodDecl methodDecl = (JCMethodDecl) child.get();
+			Name existingName = methodDecl.name;
+			if (existingName.equals(fieldName) && !isTolerate(fieldNode, methodDecl)) {
+				return;
+			}
+		}
+
+		String setterName = fluent ? fieldNode.getName() : HandlerUtil.buildAccessorName("set", fieldNode.getName());
+
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+
+		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, deprecate, fieldNode, maker, setterName, nameOfSetFlag, returnType, returnStatement, source, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
+
+		injectMethod(builderType, newMethod);
+	}
+
 	private void addObtainVia(BuilderFieldData bfd, JavacNode node) {
 		for (JavacNode child : node.down()) {
-			if (!annotationTypeMatches(ObtainVia.class, child)) continue;
+			if (!annotationTypeMatches(ObtainVia.class, child)) {
+				continue;
+			}
 			AnnotationValues<ObtainVia> ann = createAnnotation(ObtainVia.class, child);
 			bfd.obtainVia = ann.getInstance();
 			bfd.obtainViaNode = child;
@@ -673,16 +677,18 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			return;
 		}
 	}
-	
+
 	/**
 	 * Returns the explicitly requested singular annotation on this node (field
 	 * or parameter), or null if there's no {@code @Singular} annotation on it.
-	 * 
+	 *
 	 * @param node The node (field or method param) to inspect for its name and potential {@code @Singular} annotation.
 	 */
 	private SingularData getSingularData(JavacNode node) {
 		for (JavacNode child : node.down()) {
-			if (!annotationTypeMatches(Singular.class, child)) continue;
+			if (!annotationTypeMatches(Singular.class, child)) {
+				continue;
+			}
 			Name pluralName = node.getKind() == Kind.FIELD ? removePrefixFromField(node) : ((JCVariableDecl) node.get()).name;
 			AnnotationValues<Singular> ann = createAnnotation(Singular.class, child);
 			deleteAnnotationIfNeccessary(child, Singular.class);
@@ -700,31 +706,67 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 				}
 			}
 			Name singularName = node.toName(explicitSingular);
-			
+
 			JCExpression type = null;
 			if (node.get() instanceof JCVariableDecl) {
 				type = ((JCVariableDecl) node.get()).vartype;
 			}
-			
+
 			String name = null;
 			List<JCExpression> typeArgs = List.nil();
 			if (type instanceof JCTypeApply) {
 				typeArgs = ((JCTypeApply) type).arguments;
 				type = ((JCTypeApply) type).clazz;
 			}
-			
+
 			name = type.toString();
-			
+
 			String targetFqn = JavacSingularsRecipes.get().toQualified(name);
 			JavacSingularizer singularizer = JavacSingularsRecipes.get().getSingularizer(targetFqn);
 			if (singularizer == null) {
 				node.addError("Lombok does not know how to create the singular-form builder methods for type '" + name + "'; they won't be generated.");
 				return null;
 			}
-			
+
 			return new SingularData(child, singularName, pluralName, typeArgs, targetFqn, singularizer);
 		}
-		
+
 		return null;
+	}
+
+	private String generateNonclashingNameFor(String classGenericName, java.util.List<String> typeParamStrings) {
+		if (!typeParamStrings.contains(classGenericName)) {
+			return classGenericName;
+		}
+		int counter = 2;
+		while (typeParamStrings.contains(classGenericName + counter)) {
+			counter++;
+		}
+		return classGenericName + counter;
+	}
+
+	private JavacNode findInnerClass(JavacNode parent, String name) {
+		for (JavacNode child : parent.down()) {
+			if (child.getKind() != Kind.TYPE) {
+				continue;
+			}
+			JCClassDecl td = (JCClassDecl) child.get();
+			if (td.name.contentEquals(name)) {
+				return child;
+			}
+		}
+		return null;
+	}
+
+	private ListBuffer<JCExpression> getTypeParamExpressions(List<? extends JCTree> typeParams, JavacTreeMaker maker) {
+		ListBuffer<JCExpression> typeParamsForBuilderParameter = new ListBuffer<JCExpression>();
+		for (JCTree typeParam : typeParams) {
+			if (typeParam instanceof JCTypeParameter) {
+				typeParamsForBuilderParameter.add(maker.Ident(((JCTypeParameter)typeParam).getName()));
+			} else if (typeParam instanceof JCIdent) {
+				typeParamsForBuilderParameter.add(maker.Ident(((JCIdent)typeParam).getName()));
+			}
+		}
+		return typeParamsForBuilderParameter;
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -94,6 +94,8 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 
 	@Override
 	public void handle(AnnotationValues<SuperBuilder> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.SUPERBUILDER_FLAG_USAGE, "@SuperBuilder");
+		
 		SuperBuilder superbuilderAnnotation = annotation.getInstance();
 		deleteAnnotationIfNeccessary(annotationNode, SuperBuilder.class);
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -200,7 +200,7 @@ public class JavacSingularsRecipes {
 		 * Generates the singular, plural, and clear methods for the given
 		 * {@link SingularData}.<br>
 		 * Uses the given <code>builderType</code> as return type if
-		 * <code>chain == true</code>, <code>void</code> otherwise.. If you need more
+		 * <code>chain == true</code>, <code>void</code> otherwise. If you need more
 		 * control over the return type and value, use
 		 * {@link #generateMethods(SingularData, boolean, JavacNode, JCTree, boolean, JCExpression, JCStatement)}.
 		 */

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -194,7 +194,30 @@ public class JavacSingularsRecipes {
 		}
 		
 		public abstract java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JCTree source);
-		public abstract void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, boolean chain);
+		
+		/**
+		 * Generates the singular, plural, and clear methods for the given
+		 * {@link SingularData}.<br>
+		 * Uses the given <code>builderType</code> as return type if
+		 * <code>chain == true</code>, <code>void</code> otherwise.. If you need more
+		 * control over the return type and value, use
+		 * {@link #generateMethods(SingularData, boolean, JavacNode, JCTree, boolean, JCExpression, JCStatement)}.
+		 */
+		public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, boolean chain) {
+			JavacTreeMaker maker = builderType.getTreeMaker();
+			JCExpression returnType = chain ?
+					cloneSelfType(builderType) : 
+						maker.Type(createVoidType(builderType.getSymbolTable(), CTC_VOID));
+			JCStatement returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
+			generateMethods(data, deprecate, builderType, source, fluent, returnType, returnStatement);
+		}
+		/**
+		 * Generates the singular, plural, and clear methods for the given
+		 * {@link SingularData}.<br>
+		 * Uses the given <code>returnType</code> and <code>returnStatement</code> for the generated methods. 
+		 */
+		public abstract void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement);
+		
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);
 		
 		public boolean requiresCleaning() {

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -36,7 +36,6 @@ import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
@@ -70,19 +69,10 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, boolean chain) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
-		Symtab symbolTable = builderType.getSymbolTable();
-		JCExpression returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		JCStatement returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
 		generateSingularMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-
-		returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
 		generatePluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
 		generateClearMethod(deprecate, maker, returnType, returnStatement, data, builderType, source);
 	}
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -25,6 +25,7 @@ import static lombok.javac.Javac.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
 import java.util.Collections;
+import java.util.function.Supplier;
 
 import lombok.core.GuavaTypeMap;
 import lombok.core.LombokImmutableList;
@@ -69,11 +70,11 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, Supplier<JCExpression> returnType, Supplier<? extends JCStatement> returnStatement) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
-		generateSingularMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		generatePluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		generateClearMethod(deprecate, maker, returnType, returnStatement, data, builderType, source);
+		generateSingularMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source, fluent);
+		generatePluralMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source, fluent);
+		generateClearMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source);
 	}
 	
 	private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -25,6 +25,7 @@ import static lombok.javac.Javac.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
 import java.util.Collections;
+import java.util.function.Supplier;
 
 import lombok.core.handlers.HandlerUtil;
 import lombok.javac.JavacNode;
@@ -75,16 +76,16 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, Supplier<JCExpression> returnType, Supplier<? extends JCStatement> returnStatement) {
 		if (useGuavaInstead(builderType)) {
 			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnType, returnStatement);
 			return;
 		}
 		
 		JavacTreeMaker maker = builderType.getTreeMaker();
-		generateSingularMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		generatePluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		generateClearMethod(deprecate, maker, returnType, returnStatement, data, builderType, source);
+		generateSingularMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source, fluent);
+		generatePluralMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source, fluent);
+		generateClearMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source);
 	}
 	
 	private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -33,7 +33,6 @@ import lombok.javac.handlers.JavacHandlerUtil;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
@@ -76,26 +75,15 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, boolean chain) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement) {
 		if (useGuavaInstead(builderType)) {
-			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, source, fluent, chain);
+			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnType, returnStatement);
 			return;
 		}
 		
 		JavacTreeMaker maker = builderType.getTreeMaker();
-		Symtab symbolTable = builderType.getSymbolTable();
-		Name thisName = builderType.toName("this");
-		
-		JCExpression returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		JCStatement returnStatement = chain ? maker.Return(maker.Ident(thisName)) : null;
 		generateSingularMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		returnStatement = chain ? maker.Return(maker.Ident(thisName)) : null;
 		generatePluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		returnStatement = chain ? maker.Return(maker.Ident(thisName)) : null;
 		generateClearMethod(deprecate, maker, returnType, returnStatement, data, builderType, source);
 	}
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -25,6 +25,7 @@ import static lombok.javac.Javac.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 import lombok.core.LombokImmutableList;
 import lombok.core.handlers.HandlerUtil;
@@ -100,16 +101,16 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return Arrays.asList(keyFieldNode, valueFieldNode);
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, Supplier<JCExpression> returnType, Supplier<? extends JCStatement> returnStatement) {
 		if (useGuavaInstead(builderType)) {
 			guavaMapSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnType, returnStatement);
 			return;
 		}
 		
 		JavacTreeMaker maker = builderType.getTreeMaker();
-		generateSingularMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		generatePluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		generateClearMethod(deprecate, maker, returnType, returnStatement, data, builderType, source);
+		generateSingularMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source, fluent);
+		generatePluralMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source, fluent);
+		generateClearMethod(deprecate, maker, returnType.get(), returnStatement.get(), data, builderType, source);
 	}
 	
 	private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -37,7 +37,6 @@ import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 import org.mangosdk.spi.ProviderFor;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
@@ -101,25 +100,15 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return Arrays.asList(keyFieldNode, valueFieldNode);
 	}
 	
-	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, boolean chain) {
+	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, JCExpression returnType, JCStatement returnStatement) {
 		if (useGuavaInstead(builderType)) {
-			guavaMapSingularizer.generateMethods(data, deprecate, builderType, source, fluent, chain);
+			guavaMapSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnType, returnStatement);
 			return;
 		}
 		
 		JavacTreeMaker maker = builderType.getTreeMaker();
-		Symtab symbolTable = builderType.getSymbolTable();
-		
-		JCExpression returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		JCStatement returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
 		generateSingularMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
 		generatePluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent);
-		
-		returnType = chain ? cloneSelfType(builderType) : maker.Type(createVoidType(symbolTable, CTC_VOID));
-		returnStatement = chain ? maker.Return(maker.Ident(builderType.toName("this"))) : null;
 		generateClearMethod(deprecate, maker, returnType, returnStatement, data, builderType, source);
 	}
 	

--- a/test/transform/resource/after-delombok/SuperBuilderAbstract.java
+++ b/test/transform/resource/after-delombok/SuperBuilderAbstract.java
@@ -1,0 +1,129 @@
+public class SuperBuilderAbstract {
+	public static class Parent {
+		int parentField;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private int parentField;
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B parentField(final int parentField) {
+				this.parentField = parentField;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderAbstract.Parent.ParentBuilder(parentField=" + this.parentField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent build() {
+				return new Parent(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<?, ?> b) {
+			this.parentField = b.parentField;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static ParentBuilder<?, ?> builder() {
+			return new ParentBuilderImpl();
+		}
+	}
+	public static abstract class Child extends Parent {
+		double childField;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+			@java.lang.SuppressWarnings("all")
+			private double childField;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B childField(final double childField) {
+				this.childField = childField;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderAbstract.Child.ChildBuilder(super=" + super.toString() + ", childField=" + this.childField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<?, ?> b) {
+			super(b);
+			this.childField = b.childField;
+		}
+	}
+	public static class GrandChild extends Child {
+		String grandChildField;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class GrandChildBuilder<C extends GrandChild, B extends GrandChildBuilder<C, B>> extends Child.ChildBuilder<C, B> {
+			@java.lang.SuppressWarnings("all")
+			private String grandChildField;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B grandChildField(final String grandChildField) {
+				this.grandChildField = grandChildField;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderAbstract.GrandChild.GrandChildBuilder(super=" + super.toString() + ", grandChildField=" + this.grandChildField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class GrandChildBuilderImpl extends GrandChildBuilder<GrandChild, GrandChildBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private GrandChildBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected GrandChildBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public GrandChild build() {
+				return new GrandChild(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected GrandChild(final GrandChildBuilder<?, ?> b) {
+			super(b);
+			this.grandChildField = b.grandChildField;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static GrandChildBuilder<?, ?> builder() {
+			return new GrandChildBuilderImpl();
+		}
+	}
+	public static void test() {
+		GrandChild x = GrandChild.builder().grandChildField("").parentField(5).childField(2.5).build();
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderBasic.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasic.java
@@ -1,6 +1,5 @@
 import java.util.List;
 public class SuperBuilderBasic {
-	@lombok.experimental.SuperBuilder
 	public static class Parent {
 		int field1;
 		List<String> items;
@@ -79,7 +78,6 @@ public class SuperBuilderBasic {
 			return new ParentBuilderImpl();
 		}
 	}
-	@lombok.experimental.SuperBuilder
 	public static class Child extends Parent {
 		double field3;
 		@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/SuperBuilderBasic.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasic.java
@@ -1,6 +1,7 @@
 import java.util.List;
 
 public class SuperBuilderBasic {
+	@lombok.experimental.SuperBuilder
 	public static class Parent {
 		int field1;
 		List<String> items;
@@ -97,7 +98,7 @@ public class SuperBuilderBasic {
 		}
 	}
 
-
+	@lombok.experimental.SuperBuilder
 	public static class Child extends Parent {
 		double field3;
 
@@ -130,7 +131,7 @@ public class SuperBuilderBasic {
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
-				return "SuperBuilderBasic.Child.ChildBuilder(field3=" + this.field3 + ")";
+				return "SuperBuilderBasic.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
 			}
 		}
 

--- a/test/transform/resource/after-delombok/SuperBuilderBasic.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasic.java
@@ -4,6 +4,8 @@ public class SuperBuilderBasic {
 	public static class Parent {
 		int field1;
 		List<String> items;
+
+		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<?, ?> b) {
 			this.field1 = b.field1;
 			java.util.List<String> items;
@@ -11,101 +13,153 @@ public class SuperBuilderBasic {
 			case 0: 
 				items = java.util.Collections.emptyList();
 				break;
+
 			case 1: 
 				items = java.util.Collections.singletonList(b.items.get(0));
 				break;
+
 			default: 
 				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
 			}
 			this.items = items;
 		}
-		private static class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
-			@Override
-			public Parent build() {
-				return new Parent(this);
-			}
-			
-			@Override
-			public ParentBuilderImpl self() {
-				return this;
-			}
-		}
-		public abstract static class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+
+
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private int field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
+
 			@java.lang.SuppressWarnings("all")
-			ParentBuilder() {
-			}
+			protected abstract B self();
+
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+
 			@java.lang.SuppressWarnings("all")
 			public B field1(final int field1) {
 				this.field1 = field1;
 				return self();
 			}
+
 			@java.lang.SuppressWarnings("all")
 			public B item(final String item) {
 				if (this.items == null) this.items = new java.util.ArrayList<String>();
 				this.items.add(item);
 				return self();
 			}
+
 			@java.lang.SuppressWarnings("all")
 			public B items(final java.util.Collection<? extends String> items) {
 				if (this.items == null) this.items = new java.util.ArrayList<String>();
 				this.items.addAll(items);
 				return self();
 			}
+
 			@java.lang.SuppressWarnings("all")
 			public B clearItems() {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+
+			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
+			public java.lang.String toString() {
+				return "SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+			}
 		}
+
+
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent build() {
+				return new Parent(this);
+			}
+		}
+
+		@java.lang.SuppressWarnings("all")
 		public static ParentBuilder<?, ?> builder() {
 			return new ParentBuilderImpl();
 		}
 	}
+
+
 	public static class Child extends Parent {
 		double field3;
-		protected Child(ChildBuilder<?, ?> b) {
+
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<?, ?> b) {
 			super(b);
 			this.field3 = b.field3;
 		}
-		private static class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
-			@Override
-			public Child build() {
-				return new Child(this);
-			}
-			
-			@Override
-			public ChildBuilderImpl self() {
-				return this;
-			}
-		}
-		public abstract static class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<Child, B> {
+
+
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
+
+			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			ChildBuilder() {
-			}
+			protected abstract B self();
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+
 			@java.lang.SuppressWarnings("all")
 			public B field3(final double field3) {
 				this.field3 = field3;
 				return self();
 			}
+
+			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
+			public java.lang.String toString() {
+				return "SuperBuilderBasic.Child.ChildBuilder(field3=" + this.field3 + ")";
+			}
 		}
+
+
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child build() {
+				return new Child(this);
+			}
+		}
+
+		@java.lang.SuppressWarnings("all")
 		public static ChildBuilder<?, ?> builder() {
 			return new ChildBuilderImpl();
 		}
 	}
+
 	public static void test() {
 		Child x = Child.builder().field3(0.0).field1(5).item("").build();
 	}

--- a/test/transform/resource/after-delombok/SuperBuilderBasic.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasic.java
@@ -5,22 +5,6 @@ public class SuperBuilderBasic {
 		int field1;
 		List<String> items;
 		@java.lang.SuppressWarnings("all")
-		protected Parent(final ParentBuilder<?, ?> b) {
-			this.field1 = b.field1;
-			java.util.List<String> items;
-			switch (b.items == null ? 0 : b.items.size()) {
-			case 0: 
-				items = java.util.Collections.emptyList();
-				break;
-			case 1: 
-				items = java.util.Collections.singletonList(b.items.get(0));
-				break;
-			default: 
-				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
-			}
-			this.items = items;
-		}
-		@java.lang.SuppressWarnings("all")
 		public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private int field1;
@@ -75,6 +59,22 @@ public class SuperBuilderBasic {
 			}
 		}
 		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<?, ?> b) {
+			this.field1 = b.field1;
+			java.util.List<String> items;
+			switch (b.items == null ? 0 : b.items.size()) {
+			case 0: 
+				items = java.util.Collections.emptyList();
+				break;
+			case 1: 
+				items = java.util.Collections.singletonList(b.items.get(0));
+				break;
+			default: 
+				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+			}
+			this.items = items;
+		}
+		@java.lang.SuppressWarnings("all")
 		public static ParentBuilder<?, ?> builder() {
 			return new ParentBuilderImpl();
 		}
@@ -82,11 +82,6 @@ public class SuperBuilderBasic {
 	@lombok.experimental.SuperBuilder
 	public static class Child extends Parent {
 		double field3;
-		@java.lang.SuppressWarnings("all")
-		protected Child(final ChildBuilder<?, ?> b) {
-			super(b);
-			this.field3 = b.field3;
-		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
@@ -123,6 +118,11 @@ public class SuperBuilderBasic {
 			public Child build() {
 				return new Child(this);
 			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<?, ?> b) {
+			super(b);
+			this.field3 = b.field3;
 		}
 		@java.lang.SuppressWarnings("all")
 		public static ChildBuilder<?, ?> builder() {

--- a/test/transform/resource/after-delombok/SuperBuilderBasic.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasic.java
@@ -1,11 +1,9 @@
 import java.util.List;
-
 public class SuperBuilderBasic {
 	@lombok.experimental.SuperBuilder
 	public static class Parent {
 		int field1;
 		List<String> items;
-
 		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<?, ?> b) {
 			this.field1 = b.field1;
@@ -14,153 +12,123 @@ public class SuperBuilderBasic {
 			case 0: 
 				items = java.util.Collections.emptyList();
 				break;
-
 			case 1: 
 				items = java.util.Collections.singletonList(b.items.get(0));
 				break;
-
 			default: 
 				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
 			}
 			this.items = items;
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private int field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
-
 			@java.lang.SuppressWarnings("all")
 			protected abstract B self();
-
 			@java.lang.SuppressWarnings("all")
 			public abstract C build();
-
 			@java.lang.SuppressWarnings("all")
 			public B field1(final int field1) {
 				this.field1 = field1;
 				return self();
 			}
-
 			@java.lang.SuppressWarnings("all")
 			public B item(final String item) {
 				if (this.items == null) this.items = new java.util.ArrayList<String>();
 				this.items.add(item);
 				return self();
 			}
-
 			@java.lang.SuppressWarnings("all")
 			public B items(final java.util.Collection<? extends String> items) {
 				if (this.items == null) this.items = new java.util.ArrayList<String>();
 				this.items.addAll(items);
 				return self();
 			}
-
 			@java.lang.SuppressWarnings("all")
 			public B clearItems() {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
 				return "SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
 			}
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		private static final class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
 			@java.lang.SuppressWarnings("all")
 			private ParentBuilderImpl() {
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			protected ParentBuilderImpl self() {
 				return this;
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public Parent build() {
 				return new Parent(this);
 			}
 		}
-
 		@java.lang.SuppressWarnings("all")
 		public static ParentBuilder<?, ?> builder() {
 			return new ParentBuilderImpl();
 		}
 	}
-
 	@lombok.experimental.SuperBuilder
 	public static class Child extends Parent {
 		double field3;
-
 		@java.lang.SuppressWarnings("all")
 		protected Child(final ChildBuilder<?, ?> b) {
 			super(b);
 			this.field3 = b.field3;
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			protected abstract B self();
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public abstract C build();
-
 			@java.lang.SuppressWarnings("all")
 			public B field3(final double field3) {
 				this.field3 = field3;
 				return self();
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
 				return "SuperBuilderBasic.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
 			}
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		private static final class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
 			@java.lang.SuppressWarnings("all")
 			private ChildBuilderImpl() {
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			protected ChildBuilderImpl self() {
 				return this;
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public Child build() {
 				return new Child(this);
 			}
 		}
-
 		@java.lang.SuppressWarnings("all")
 		public static ChildBuilder<?, ?> builder() {
 			return new ChildBuilderImpl();
 		}
 	}
-
 	public static void test() {
 		Child x = Child.builder().field3(0.0).field1(5).item("").build();
 	}

--- a/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
@@ -1,6 +1,5 @@
 import java.util.List;
 public class SuperBuilderWithCustomBuilderMethod {
-	@lombok.experimental.SuperBuilder
 	public static class Parent<A> {
 		A field1;
 		List<String> items;
@@ -79,7 +78,6 @@ public class SuperBuilderWithCustomBuilderMethod {
 			return new ParentBuilderImpl<A>();
 		}
 	}
-	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
 		public static <A> ChildBuilder<A, ?, ?> builder() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
@@ -39,7 +39,7 @@ public class SuperBuilderWithCustomBuilderMethod {
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
-				return "SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+				return "SuperBuilderWithCustomBuilderMethod.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
 			}
 		}
 		@java.lang.SuppressWarnings("all")
@@ -82,6 +82,9 @@ public class SuperBuilderWithCustomBuilderMethod {
 	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
+		public static <A> ChildBuilder<A, ?, ?> builder() {
+			return new ChildBuilderImpl<A>().item("default item");
+		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
 			@java.lang.SuppressWarnings("all")
@@ -100,7 +103,7 @@ public class SuperBuilderWithCustomBuilderMethod {
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
-				return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+				return "SuperBuilderWithCustomBuilderMethod.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
 			}
 		}
 		@java.lang.SuppressWarnings("all")
@@ -123,9 +126,6 @@ public class SuperBuilderWithCustomBuilderMethod {
 		protected Child(final ChildBuilder<A, ?, ?> b) {
 			super(b);
 			this.field3 = b.field3;
-		}
-		public static <A> ChildBuilder<A, ?, ?> builder() {
-			return new ChildBuilderImpl<A>().item("default item");
 		}
 	}
 	public static void test() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
@@ -1,0 +1,134 @@
+import java.util.List;
+public class SuperBuilderWithCustomBuilderMethod {
+	@lombok.experimental.SuperBuilder
+	public static class Parent<A> {
+		A field1;
+		List<String> items;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private A field1;
+			@java.lang.SuppressWarnings("all")
+			private java.util.ArrayList<String> items;
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B field1(final A field1) {
+				this.field1 = field1;
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B item(final String item) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.add(item);
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B items(final java.util.Collection<? extends String> items) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.addAll(items);
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B clearItems() {
+				if (this.items != null) this.items.clear();
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent<A> build() {
+				return new Parent<A>(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<A, ?, ?> b) {
+			this.field1 = b.field1;
+			java.util.List<String> items;
+			switch (b.items == null ? 0 : b.items.size()) {
+			case 0: 
+				items = java.util.Collections.emptyList();
+				break;
+			case 1: 
+				items = java.util.Collections.singletonList(b.items.get(0));
+				break;
+			default: 
+				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+			}
+			this.items = items;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static <A> ParentBuilder<A, ?, ?> builder() {
+			return new ParentBuilderImpl<A>();
+		}
+	}
+	@lombok.experimental.SuperBuilder
+	public static class Child<A> extends Parent<A> {
+		double field3;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
+			@java.lang.SuppressWarnings("all")
+			private double field3;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B field3(final double field3) {
+				this.field3 = field3;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child<A> build() {
+				return new Child<A>(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<A, ?, ?> b) {
+			super(b);
+			this.field3 = b.field3;
+		}
+		public static <A> ChildBuilder<A, ?, ?> builder() {
+			return new ChildBuilderImpl<A>().item("default item");
+		}
+	}
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
@@ -1,0 +1,119 @@
+import java.util.List;
+public class SuperBuilderWithDefaults {
+	public static class Parent<N extends Number> {
+		private long millis = System.currentTimeMillis();
+		private N numberField = null;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<N extends Number, C extends Parent<N>, B extends ParentBuilder<N, C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private boolean millis$set;
+			@java.lang.SuppressWarnings("all")
+			private long millis;
+			@java.lang.SuppressWarnings("all")
+			private boolean numberField$set;
+			@java.lang.SuppressWarnings("all")
+			private N numberField;
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B millis(final long millis) {
+				this.millis = millis;
+				millis$set = true;
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B numberField(final N numberField) {
+				this.numberField = numberField;
+				numberField$set = true;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithDefaults.Parent.ParentBuilder(millis=" + this.millis + ", numberField=" + this.numberField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl<N extends Number> extends ParentBuilder<N, Parent<N>, ParentBuilderImpl<N>> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent<N> build() {
+				return new Parent<N>(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<N, ?, ?> b) {
+			if (b.millis$set) this.millis = b.millis;
+			if (b.numberField$set) this.numberField = b.numberField;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static <N extends Number> ParentBuilder<N, ?, ?> builder() {
+			return new ParentBuilderImpl<N>();
+		}
+	}
+	public static class Child extends Parent<Integer> {
+		private double doubleField = Math.PI;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
+			@java.lang.SuppressWarnings("all")
+			private boolean doubleField$set;
+			@java.lang.SuppressWarnings("all")
+			private double doubleField;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B doubleField(final double doubleField) {
+				this.doubleField = doubleField;
+				doubleField$set = true;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithDefaults.Child.ChildBuilder(super=" + super.toString() + ", doubleField=" + this.doubleField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child build() {
+				return new Child(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<?, ?> b) {
+			super(b);
+			if (b.doubleField$set) this.doubleField = b.doubleField;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static ChildBuilder<?, ?> builder() {
+			return new ChildBuilderImpl();
+		}
+	}
+	public static void test() {
+		Child x = Child.builder().doubleField(0.1).numberField(5).millis(1234567890L).build();
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -1,0 +1,166 @@
+import java.util.List;
+
+public class SuperBuilderWithGenerics {
+	public static class Parent<A> {
+		A field1;
+		List<String> items;
+
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<A, ?, ?> b) {
+			this.field1 = b.field1;
+			java.util.List<String> items;
+			switch (b.items == null ? 0 : b.items.size()) {
+			case 0: 
+				items = java.util.Collections.emptyList();
+				break;
+
+			case 1: 
+				items = java.util.Collections.singletonList(b.items.get(0));
+				break;
+
+			default: 
+				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+			}
+			this.items = items;
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private A field1;
+			@java.lang.SuppressWarnings("all")
+			private java.util.ArrayList<String> items;
+
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+
+			@java.lang.SuppressWarnings("all")
+			public B field1(final A field1) {
+				this.field1 = field1;
+				return self();
+			}
+
+			@java.lang.SuppressWarnings("all")
+			public B item(final String item) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.add(item);
+				return self();
+			}
+
+			@java.lang.SuppressWarnings("all")
+			public B items(final java.util.Collection<? extends String> items) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.addAll(items);
+				return self();
+			}
+
+			@java.lang.SuppressWarnings("all")
+			public B clearItems() {
+				if (this.items != null) this.items.clear();
+				return self();
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+			}
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent<A> build() {
+				return new Parent<A>(this);
+			}
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public static <A> ParentBuilder<A, ?, ?> builder() {
+			return new ParentBuilderImpl<A>();
+		}
+	}
+
+
+	public static class Child<A> extends Parent<A> {
+		double field3;
+
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<A, ?, ?> b) {
+			super(b);
+			this.field3 = b.field3;
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
+			@java.lang.SuppressWarnings("all")
+			private double field3;
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+
+			@java.lang.SuppressWarnings("all")
+			public B field3(final double field3) {
+				this.field3 = field3;
+				return self();
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics.Child.ChildBuilder(field3=" + this.field3 + ")";
+			}
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child<A> build() {
+				return new Child<A>(this);
+			}
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public static <A> ChildBuilder<A, ?, ?> builder() {
+			return new ChildBuilderImpl<A>();
+		}
+	}
+
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -1,6 +1,7 @@
 import java.util.List;
 
 public class SuperBuilderWithGenerics {
+	@lombok.experimental.SuperBuilder
 	public static class Parent<A> {
 		A field1;
 		List<String> items;
@@ -97,7 +98,7 @@ public class SuperBuilderWithGenerics {
 		}
 	}
 
-
+	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
 
@@ -130,7 +131,7 @@ public class SuperBuilderWithGenerics {
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
-				return "SuperBuilderWithGenerics.Child.ChildBuilder(field3=" + this.field3 + ")";
+				return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
 			}
 		}
 

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -1,11 +1,9 @@
 import java.util.List;
-
 public class SuperBuilderWithGenerics {
 	@lombok.experimental.SuperBuilder
 	public static class Parent<A> {
 		A field1;
 		List<String> items;
-
 		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<A, ?, ?> b) {
 			this.field1 = b.field1;
@@ -14,153 +12,123 @@ public class SuperBuilderWithGenerics {
 			case 0: 
 				items = java.util.Collections.emptyList();
 				break;
-
 			case 1: 
 				items = java.util.Collections.singletonList(b.items.get(0));
 				break;
-
 			default: 
 				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
 			}
 			this.items = items;
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private A field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
-
 			@java.lang.SuppressWarnings("all")
 			protected abstract B self();
-
 			@java.lang.SuppressWarnings("all")
 			public abstract C build();
-
 			@java.lang.SuppressWarnings("all")
 			public B field1(final A field1) {
 				this.field1 = field1;
 				return self();
 			}
-
 			@java.lang.SuppressWarnings("all")
 			public B item(final String item) {
 				if (this.items == null) this.items = new java.util.ArrayList<String>();
 				this.items.add(item);
 				return self();
 			}
-
 			@java.lang.SuppressWarnings("all")
 			public B items(final java.util.Collection<? extends String> items) {
 				if (this.items == null) this.items = new java.util.ArrayList<String>();
 				this.items.addAll(items);
 				return self();
 			}
-
 			@java.lang.SuppressWarnings("all")
 			public B clearItems() {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
 				return "SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
 			}
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		private static final class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
 			@java.lang.SuppressWarnings("all")
 			private ParentBuilderImpl() {
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			protected ParentBuilderImpl self() {
 				return this;
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public Parent<A> build() {
 				return new Parent<A>(this);
 			}
 		}
-
 		@java.lang.SuppressWarnings("all")
 		public static <A> ParentBuilder<A, ?, ?> builder() {
 			return new ParentBuilderImpl<A>();
 		}
 	}
-
 	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
-
 		@java.lang.SuppressWarnings("all")
 		protected Child(final ChildBuilder<A, ?, ?> b) {
 			super(b);
 			this.field3 = b.field3;
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			protected abstract B self();
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public abstract C build();
-
 			@java.lang.SuppressWarnings("all")
 			public B field3(final double field3) {
 				this.field3 = field3;
 				return self();
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
 				return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
 			}
 		}
-
-
 		@java.lang.SuppressWarnings("all")
 		private static final class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
 			@java.lang.SuppressWarnings("all")
 			private ChildBuilderImpl() {
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			protected ChildBuilderImpl self() {
 				return this;
 			}
-
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public Child<A> build() {
 				return new Child<A>(this);
 			}
 		}
-
 		@java.lang.SuppressWarnings("all")
 		public static <A> ChildBuilder<A, ?, ?> builder() {
 			return new ChildBuilderImpl<A>();
 		}
 	}
-
 	public static void test() {
 		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
 	}

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -1,6 +1,5 @@
 import java.util.List;
 public class SuperBuilderWithGenerics {
-	@lombok.experimental.SuperBuilder
 	public static class Parent<A> {
 		A field1;
 		List<String> items;
@@ -79,7 +78,6 @@ public class SuperBuilderWithGenerics {
 			return new ParentBuilderImpl<A>();
 		}
 	}
-	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
 		@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -5,22 +5,6 @@ public class SuperBuilderWithGenerics {
 		A field1;
 		List<String> items;
 		@java.lang.SuppressWarnings("all")
-		protected Parent(final ParentBuilder<A, ?, ?> b) {
-			this.field1 = b.field1;
-			java.util.List<String> items;
-			switch (b.items == null ? 0 : b.items.size()) {
-			case 0: 
-				items = java.util.Collections.emptyList();
-				break;
-			case 1: 
-				items = java.util.Collections.singletonList(b.items.get(0));
-				break;
-			default: 
-				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
-			}
-			this.items = items;
-		}
-		@java.lang.SuppressWarnings("all")
 		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private A field1;
@@ -75,6 +59,22 @@ public class SuperBuilderWithGenerics {
 			}
 		}
 		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<A, ?, ?> b) {
+			this.field1 = b.field1;
+			java.util.List<String> items;
+			switch (b.items == null ? 0 : b.items.size()) {
+			case 0: 
+				items = java.util.Collections.emptyList();
+				break;
+			case 1: 
+				items = java.util.Collections.singletonList(b.items.get(0));
+				break;
+			default: 
+				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+			}
+			this.items = items;
+		}
+		@java.lang.SuppressWarnings("all")
 		public static <A> ParentBuilder<A, ?, ?> builder() {
 			return new ParentBuilderImpl<A>();
 		}
@@ -82,11 +82,6 @@ public class SuperBuilderWithGenerics {
 	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
-		@java.lang.SuppressWarnings("all")
-		protected Child(final ChildBuilder<A, ?, ?> b) {
-			super(b);
-			this.field3 = b.field3;
-		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
 			@java.lang.SuppressWarnings("all")
@@ -123,6 +118,11 @@ public class SuperBuilderWithGenerics {
 			public Child<A> build() {
 				return new Child<A>(this);
 			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<A, ?, ?> b) {
+			super(b);
+			this.field3 = b.field3;
 		}
 		@java.lang.SuppressWarnings("all")
 		public static <A> ChildBuilder<A, ?, ?> builder() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics2.java
@@ -1,0 +1,133 @@
+import java.util.List;
+public class SuperBuilderWithGenerics2 {
+	public static class Parent<A> {
+		A field1;
+		List<String> items;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private A field1;
+			@java.lang.SuppressWarnings("all")
+			private java.util.ArrayList<String> items;
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B field1(final A field1) {
+				this.field1 = field1;
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B item(final String item) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.add(item);
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B items(final java.util.Collection<? extends String> items) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.addAll(items);
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			public B clearItems() {
+				if (this.items != null) this.items.clear();
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics2.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent<A> build() {
+				return new Parent<A>(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<A, ?, ?> b) {
+			this.field1 = b.field1;
+			java.util.List<String> items;
+			switch (b.items == null ? 0 : b.items.size()) {
+			case 0: 
+				items = java.util.Collections.emptyList();
+				break;
+			case 1: 
+				items = java.util.Collections.singletonList(b.items.get(0));
+				break;
+			default: 
+				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+			}
+			this.items = items;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static <A> ParentBuilder<A, ?, ?> builder() {
+			return new ParentBuilderImpl<A>();
+		}
+	}
+	public static class Child<A> extends Parent<String> {
+		A field3;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<String, C, B> {
+			@java.lang.SuppressWarnings("all")
+			private A field3;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B field3(final A field3) {
+				this.field3 = field3;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics2.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child<A> build() {
+				return new Child<A>(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<A, ?, ?> b) {
+			super(b);
+			this.field3 = b.field3;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static <A> ChildBuilder<A, ?, ?> builder2() {
+			return new ChildBuilderImpl<A>();
+		}
+	}
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder2().field3(1).field1("value").item("").build();
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderAbstract.java
+++ b/test/transform/resource/after-ecj/SuperBuilderAbstract.java
@@ -1,0 +1,102 @@
+public class SuperBuilderAbstract {
+  public static @lombok.experimental.SuperBuilder class Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+      private @java.lang.SuppressWarnings("all") int parentField;
+      public ParentBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B parentField(final int parentField) {
+        this.parentField = parentField;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderAbstract.Parent.ParentBuilder(parentField=" + this.parentField) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+      private ParentBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent build() {
+        return new Parent(this);
+      }
+    }
+    int parentField;
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<?, ?> b) {
+      super();
+      this.parentField = b.parentField;
+    }
+    public static @java.lang.SuppressWarnings("all") ParentBuilder<?, ?> builder() {
+      return new ParentBuilderImpl();
+    }
+  }
+  public static abstract @lombok.experimental.SuperBuilder class Child extends Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+      private @java.lang.SuppressWarnings("all") double childField;
+      public ChildBuilder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B childField(final double childField) {
+        this.childField = childField;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderAbstract.Child.ChildBuilder(super=" + super.toString()) + ", childField=") + this.childField) + ")");
+      }
+    }
+    double childField;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
+      super(b);
+      this.childField = b.childField;
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class GrandChild extends Child {
+    public static abstract @java.lang.SuppressWarnings("all") class GrandChildBuilder<C extends GrandChild, B extends GrandChildBuilder<C, B>> extends Child.ChildBuilder<C, B> {
+      private @java.lang.SuppressWarnings("all") String grandChildField;
+      public GrandChildBuilder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B grandChildField(final String grandChildField) {
+        this.grandChildField = grandChildField;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderAbstract.GrandChild.GrandChildBuilder(super=" + super.toString()) + ", grandChildField=") + this.grandChildField) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class GrandChildBuilderImpl extends GrandChildBuilder<GrandChild, GrandChildBuilderImpl> {
+      private GrandChildBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") GrandChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") GrandChild build() {
+        return new GrandChild(this);
+      }
+    }
+    String grandChildField;
+    protected @java.lang.SuppressWarnings("all") GrandChild(final GrandChildBuilder<?, ?> b) {
+      super(b);
+      this.grandChildField = b.grandChildField;
+    }
+    public static @java.lang.SuppressWarnings("all") GrandChildBuilder<?, ?> builder() {
+      return new GrandChildBuilderImpl();
+    }
+  }
+  public SuperBuilderAbstract() {
+    super();
+  }
+  public static void test() {
+    GrandChild x = GrandChild.builder().grandChildField("").parentField(5).childField(2.5).build();
+  }
+}

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -1,98 +1,62 @@
 import java.util.List;
-
 public class SuperBuilderBasic {
   public static @lombok.experimental.SuperBuilder class Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+      private @java.lang.SuppressWarnings("all") int field1;
+      private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field1(final int field1) {
+        this.field1 = field1;
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B item(final String item) {
+        if (this.items == null) this.items = new java.util.ArrayList<String>();
+        this.items.add(item);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B items(final java.util.Collection<? extends String> items) {
+        if (this.items == null) this.items = new java.util.ArrayList<String>();
+        this.items.addAll(items);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B clearItems() {
+        if (this.items != null) this.items.clear();
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return "SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent build() {
+        return new Parent(this);
+      }
+    }
+    public @java.lang.SuppressWarnings("all") static ParentBuilder<?, ?> builder() {
+      return new ParentBuilderImpl();
+    }
     int field1;
     @lombok.Singular List<String> items;
-
-    protected Parent(final ParentBuilder<?, ?> b) {
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<?, ?> b) {
       this.field1 = b.field1;
       java.util.List<String> items;
       switch (b.items == null ? 0 : b.items.size()) {
       case 0: 
         items = java.util.Collections.emptyList();
         break;
-
       case 1: 
         items = java.util.Collections.singletonList(b.items.get(0));
         break;
-
       default: 
         items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
       }
       this.items = items;
-    }
-
-
-    @java.lang.SuppressWarnings("all")
-    public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
-      @java.lang.SuppressWarnings("all")
-      private int field1;
-      @java.lang.SuppressWarnings("all")
-      private java.util.ArrayList<String> items;
-
-      @java.lang.SuppressWarnings("all")
-      protected abstract B self();
-
-      @java.lang.SuppressWarnings("all")
-      public abstract C build();
-
-      @java.lang.SuppressWarnings("all")
-      public B field1(final int field1) {
-        this.field1 = field1;
-        return self();
-      }
-
-      @java.lang.SuppressWarnings("all")
-      public B item(final String item) {
-        if (this.items == null) this.items = new java.util.ArrayList<String>();
-        this.items.add(item);
-        return self();
-      }
-
-      @java.lang.SuppressWarnings("all")
-      public B items(final java.util.Collection<? extends String> items) {
-        if (this.items == null) this.items = new java.util.ArrayList<String>();
-        this.items.addAll(items);
-        return self();
-      }
-
-      @java.lang.SuppressWarnings("all")
-      public B clearItems() {
-        if (this.items != null) this.items.clear();
-        return self();
-      }
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      public java.lang.String toString() {
-        return "SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
-      }
-    }
-
-
-    @java.lang.SuppressWarnings("all")
-    private static final class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
-      @java.lang.SuppressWarnings("all")
-      private ParentBuilderImpl() {
-      }
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      protected ParentBuilderImpl self() {
-        return this;
-      }
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      public Parent build() {
-        return new Parent(this);
-      }
-    }
-
-    @java.lang.SuppressWarnings("all")
-    public static ParentBuilder<?, ?> builder() {
-      return new ParentBuilderImpl();
     }
   }
 

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -12,27 +12,28 @@ public class SuperBuilderBasic {
       }
       public @java.lang.SuppressWarnings("all") B item(String item) {
         if ((this.items == null))
-          this.items = new java.util.ArrayList<String>();
+            this.items = new java.util.ArrayList<String>();
         this.items.add(item);
         return self();
       }
       public @java.lang.SuppressWarnings("all") B items(java.util.Collection<? extends String> items) {
         if ((this.items == null))
-          this.items = new java.util.ArrayList<String>();
+            this.items = new java.util.ArrayList<String>();
         this.items.addAll(items);
         return self();
       }
       public @java.lang.SuppressWarnings("all") B clearItems() {
         if ((this.items != null))
-          this.items.clear();
+            this.items.clear();
         return self();
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-        return "SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+        return (((("SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
       private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
         return this;
@@ -41,25 +42,26 @@ public class SuperBuilderBasic {
         return new Parent(this);
       }
     }
-    public @java.lang.SuppressWarnings("all") static ParentBuilder<?, ?> builder() {
-      return new ParentBuilderImpl();
-    }
     int field1;
     @lombok.Singular List<String> items;
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<?, ?> b) {
+      super();
       this.field1 = b.field1;
       java.util.List<String> items;
-      switch (b.items == null ? 0 : b.items.size()) {
-      case 0: 
-        items = java.util.Collections.emptyList();
-        break;
-      case 1: 
-        items = java.util.Collections.singletonList(b.items.get(0));
-        break;
-      default: 
-        items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+      switch (((b.items == null) ? 0 : b.items.size())) {
+      case 0 :
+          items = java.util.Collections.emptyList();
+          break;
+      case 1 :
+          items = java.util.Collections.singletonList(b.items.get(0));
+          break;
+      default :
+          items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
       }
       this.items = items;
+    }
+    public static @java.lang.SuppressWarnings("all") ParentBuilder<?, ?> builder() {
+    	return new ParentBuilderImpl();
     }
   }
 

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -61,72 +61,45 @@ public class SuperBuilderBasic {
       this.items = items;
     }
     public static @java.lang.SuppressWarnings("all") ParentBuilder<?, ?> builder() {
-    	return new ParentBuilderImpl();
+      return new ParentBuilderImpl();
     }
   }
-
   public static @lombok.experimental.SuperBuilder class Child extends Parent {
-    double field3;
-
-    @java.lang.SuppressWarnings("all")
-    protected Child(final ChildBuilder<?, ?> b) {
-      super(b);
-      this.field3 = b.field3;
-    }
-
-
-    @java.lang.SuppressWarnings("all")
-    public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
-      @java.lang.SuppressWarnings("all")
-      private double field3;
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      protected abstract B self();
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      public abstract C build();
-
-      @java.lang.SuppressWarnings("all")
-      public B field3(final double field3) {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+      private @java.lang.SuppressWarnings("all") double field3;
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field3(final double field3) {
         this.field3 = field3;
         return self();
       }
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      public java.lang.String toString() {
-        return "SuperBuilderBasic.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderBasic.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }
     }
-
-
-    @java.lang.SuppressWarnings("all")
-    private static final class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
-      @java.lang.SuppressWarnings("all")
-      private ChildBuilderImpl() {
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+        super();
       }
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      protected ChildBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;
       }
-
-      @java.lang.Override
-      @java.lang.SuppressWarnings("all")
-      public Child build() {
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Child build() {
         return new Child(this);
       }
     }
-
-    @java.lang.SuppressWarnings("all")
-    public static ChildBuilder<?, ?> builder() {
+    double field3;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
+      super(b);
+      this.field3 = b.field3;
+    }
+    public static @java.lang.SuppressWarnings("all") ChildBuilder<?, ?> builder() {
       return new ChildBuilderImpl();
     }
   }
-
+  public SuperBuilderBasic() {
+    super();
+  }
   public static void test() {
     Child x = Child.builder().field3(0.0).field1(5).item("").build();
   }

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -10,18 +10,21 @@ public class SuperBuilderBasic {
         this.field1 = field1;
         return self();
       }
-      public @java.lang.SuppressWarnings("all") B item(final String item) {
-        if (this.items == null) this.items = new java.util.ArrayList<String>();
+      public @java.lang.SuppressWarnings("all") B item(String item) {
+        if ((this.items == null))
+          this.items = new java.util.ArrayList<String>();
         this.items.add(item);
         return self();
       }
-      public @java.lang.SuppressWarnings("all") B items(final java.util.Collection<? extends String> items) {
-        if (this.items == null) this.items = new java.util.ArrayList<String>();
+      public @java.lang.SuppressWarnings("all") B items(java.util.Collection<? extends String> items) {
+        if ((this.items == null))
+          this.items = new java.util.ArrayList<String>();
         this.items.addAll(items);
         return self();
       }
       public @java.lang.SuppressWarnings("all") B clearItems() {
-        if (this.items != null) this.items.clear();
+        if ((this.items != null))
+          this.items.clear();
         return self();
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -1,0 +1,164 @@
+import java.util.List;
+
+public class SuperBuilderBasic {
+  public static @lombok.experimental.SuperBuilder class Parent {
+    int field1;
+    @lombok.Singular List<String> items;
+
+    protected Parent(final ParentBuilder<?, ?> b) {
+      this.field1 = b.field1;
+      java.util.List<String> items;
+      switch (b.items == null ? 0 : b.items.size()) {
+      case 0: 
+        items = java.util.Collections.emptyList();
+        break;
+
+      case 1: 
+        items = java.util.Collections.singletonList(b.items.get(0));
+        break;
+
+      default: 
+        items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+      }
+      this.items = items;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+      @java.lang.SuppressWarnings("all")
+      private int field1;
+      @java.lang.SuppressWarnings("all")
+      private java.util.ArrayList<String> items;
+
+      @java.lang.SuppressWarnings("all")
+      protected abstract B self();
+
+      @java.lang.SuppressWarnings("all")
+      public abstract C build();
+
+      @java.lang.SuppressWarnings("all")
+      public B field1(final int field1) {
+        this.field1 = field1;
+        return self();
+      }
+
+      @java.lang.SuppressWarnings("all")
+      public B item(final String item) {
+        if (this.items == null) this.items = new java.util.ArrayList<String>();
+        this.items.add(item);
+        return self();
+      }
+
+      @java.lang.SuppressWarnings("all")
+      public B items(final java.util.Collection<? extends String> items) {
+        if (this.items == null) this.items = new java.util.ArrayList<String>();
+        this.items.addAll(items);
+        return self();
+      }
+
+      @java.lang.SuppressWarnings("all")
+      public B clearItems() {
+        if (this.items != null) this.items.clear();
+        return self();
+      }
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      public java.lang.String toString() {
+        return "SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+      }
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    private static final class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+      @java.lang.SuppressWarnings("all")
+      private ParentBuilderImpl() {
+      }
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      protected ParentBuilderImpl self() {
+        return this;
+      }
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      public Parent build() {
+        return new Parent(this);
+      }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    public static ParentBuilder<?, ?> builder() {
+      return new ParentBuilderImpl();
+    }
+  }
+
+  public static @lombok.experimental.SuperBuilder class Child extends Parent {
+    double field3;
+
+    @java.lang.SuppressWarnings("all")
+    protected Child(final ChildBuilder<?, ?> b) {
+      super(b);
+      this.field3 = b.field3;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+      @java.lang.SuppressWarnings("all")
+      private double field3;
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      protected abstract B self();
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      public abstract C build();
+
+      @java.lang.SuppressWarnings("all")
+      public B field3(final double field3) {
+        this.field3 = field3;
+        return self();
+      }
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      public java.lang.String toString() {
+        return "SuperBuilderBasic.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+      }
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    private static final class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+      @java.lang.SuppressWarnings("all")
+      private ChildBuilderImpl() {
+      }
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      protected ChildBuilderImpl self() {
+        return this;
+      }
+
+      @java.lang.Override
+      @java.lang.SuppressWarnings("all")
+      public Child build() {
+        return new Child(this);
+      }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    public static ChildBuilder<?, ?> builder() {
+      return new ChildBuilderImpl();
+    }
+  }
+
+  public static void test() {
+    Child x = Child.builder().field3(0.0).field1(5).item("").build();
+  }
+}

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -33,6 +33,7 @@ public class SuperBuilderBasic {
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
       private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
         return this;
@@ -44,6 +45,7 @@ public class SuperBuilderBasic {
     int field1;
     @lombok.Singular List<String> items;
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<?, ?> b) {
+      super();
       this.field1 = b.field1;
       java.util.List<String> items;
       switch (((b.items == null) ? 0 : b.items.size())) {
@@ -77,6 +79,7 @@ public class SuperBuilderBasic {
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
       private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -4,6 +4,9 @@ public class SuperBuilderBasic {
     public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
       private @java.lang.SuppressWarnings("all") int field1;
       private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      public ParentBuilder() {
+        super();
+      }
       protected abstract @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field1(final int field1) {
@@ -32,7 +35,7 @@ public class SuperBuilderBasic {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
-      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      private ParentBuilderImpl() {
         super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
@@ -67,6 +70,9 @@ public class SuperBuilderBasic {
   public static @lombok.experimental.SuperBuilder class Child extends Parent {
     public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
       private @java.lang.SuppressWarnings("all") double field3;
+      public ChildBuilder() {
+        super();
+      }
       protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field3(final double field3) {
@@ -78,7 +84,7 @@ public class SuperBuilderBasic {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
-      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+      private ChildBuilderImpl() {
         super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -33,7 +33,6 @@ public class SuperBuilderBasic {
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
       private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
-        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
         return this;
@@ -45,7 +44,6 @@ public class SuperBuilderBasic {
     int field1;
     @lombok.Singular List<String> items;
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<?, ?> b) {
-      super();
       this.field1 = b.field1;
       java.util.List<String> items;
       switch (((b.items == null) ? 0 : b.items.size())) {
@@ -79,7 +77,6 @@ public class SuperBuilderBasic {
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
       private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
-        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;

--- a/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
@@ -28,7 +28,7 @@ public class SuperBuilderWithCustomBuilderMethod {
         return self();
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-        return (((("SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
+        return (((("SuperBuilderWithCustomBuilderMethod.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
@@ -72,7 +72,7 @@ public class SuperBuilderWithCustomBuilderMethod {
         return self();
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-        return (((("SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
+        return (((("SuperBuilderWithCustomBuilderMethod.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
@@ -86,15 +86,15 @@ public class SuperBuilderWithCustomBuilderMethod {
       }
     }
     double field3;
+    public static <A>ChildBuilder<A, ?, ?> builder() {
+      return new ChildBuilderImpl<A>().item("default item");
+    }
     protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<A, ?, ?> b) {
       super(b);
       this.field3 = b.field3;
     }
-    public static @java.lang.SuppressWarnings("all") <A>ChildBuilder<A, ?, ?> builder() {
-      return new ChildBuilderImpl<A>().item("default item");
-    }
   }
-  public SuperBuilderWithGenerics() {
+  public SuperBuilderWithCustomBuilderMethod() {
     super();
   }
   public static void test() {

--- a/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
@@ -1,0 +1,103 @@
+import java.util.List;
+public class SuperBuilderWithCustomBuilderMethod {
+  public static @lombok.experimental.SuperBuilder class Parent<A> {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+      private @java.lang.SuppressWarnings("all") A field1;
+      private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field1(final A field1) {
+        this.field1 = field1;
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B item(String item) {
+        if ((this.items == null))
+            this.items = new java.util.ArrayList<String>();
+        this.items.add(item);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B items(java.util.Collection<? extends String> items) {
+        if ((this.items == null))
+            this.items = new java.util.ArrayList<String>();
+        this.items.addAll(items);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B clearItems() {
+        if ((this.items != null))
+            this.items.clear();
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent<A> build() {
+        return new Parent<A>(this);
+      }
+    }
+    A field1;
+    @lombok.Singular List<String> items;
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
+      this.field1 = b.field1;
+      java.util.List<String> items;
+      switch (((b.items == null) ? 0 : b.items.size())) {
+      case 0 : 
+          items = java.util.Collections.emptyList();
+          break;
+      case 1 : 
+          items = java.util.Collections.singletonList(b.items.get(0));
+          break;
+      default : 
+          items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+      }
+      this.items = items;
+    }
+    public static @java.lang.SuppressWarnings("all") <A>ParentBuilder<A, ?, ?> builder() {
+      return new ParentBuilderImpl<A>();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class Child<A> extends Parent<A> {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
+      private @java.lang.SuppressWarnings("all") double field3;
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field3(final double field3) {
+        this.field3 = field3;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Child<A> build() {
+        return new Child<A>(this);
+      }
+    }
+    double field3;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<A, ?, ?> b) {
+      super(b);
+      this.field3 = b.field3;
+    }
+    public static @java.lang.SuppressWarnings("all") <A>ChildBuilder<A, ?, ?> builder() {
+      return new ChildBuilderImpl<A>().item("default item");
+    }
+  }
+  public SuperBuilderWithGenerics() {
+    super();
+  }
+  public static void test() {
+    Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+  }
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
@@ -4,6 +4,9 @@ public class SuperBuilderWithCustomBuilderMethod {
     public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
       private @java.lang.SuppressWarnings("all") A field1;
       private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      public ParentBuilder() {
+        super();
+      }
       protected abstract @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field1(final A field1) {
@@ -32,7 +35,8 @@ public class SuperBuilderWithCustomBuilderMethod {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
-      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      private ParentBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
         return this;
@@ -44,6 +48,7 @@ public class SuperBuilderWithCustomBuilderMethod {
     A field1;
     @lombok.Singular List<String> items;
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
+      super();
       this.field1 = b.field1;
       java.util.List<String> items;
       switch (((b.items == null) ? 0 : b.items.size())) {
@@ -65,6 +70,9 @@ public class SuperBuilderWithCustomBuilderMethod {
   public static @lombok.experimental.SuperBuilder class Child<A> extends Parent<A> {
     public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
       private @java.lang.SuppressWarnings("all") double field3;
+      public ChildBuilder() {
+        super();
+      }
       protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field3(final double field3) {
@@ -76,7 +84,8 @@ public class SuperBuilderWithCustomBuilderMethod {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
-      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+      private ChildBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;

--- a/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
@@ -1,0 +1,97 @@
+import java.util.List;
+public class SuperBuilderWithDefaults {
+  public static @lombok.experimental.SuperBuilder class Parent<N extends Number> {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<N extends Number, C extends Parent<N>, B extends ParentBuilder<N, C, B>> {
+      private @java.lang.SuppressWarnings("all") long millis;
+      private @java.lang.SuppressWarnings("all") boolean millis$set;
+      private @java.lang.SuppressWarnings("all") N numberField;
+      private @java.lang.SuppressWarnings("all") boolean numberField$set;
+      public ParentBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B millis(final long millis) {
+        this.millis = millis;
+        millis$set = true;
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B numberField(final N numberField) {
+        this.numberField = numberField;
+        numberField$set = true;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithDefaults.Parent.ParentBuilder(millis=" + this.millis) + ", numberField=") + this.numberField) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<N extends Number> extends ParentBuilder<N, Parent<N>, ParentBuilderImpl<N>> {
+      private ParentBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent<N> build() {
+        return new Parent<N>(this);
+      }
+    }
+    private @lombok.Builder.Default long millis = System.currentTimeMillis();
+    private @lombok.Builder.Default N numberField = null;
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<N, ?, ?> b) {
+      super();
+      if (b.millis$set)
+          this.millis = b.millis;
+      if (b.numberField$set)
+          this.numberField = b.numberField;
+    }
+    public static @java.lang.SuppressWarnings("all") <N extends Number>ParentBuilder<N, ?, ?> builder() {
+      return new ParentBuilderImpl<N>();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class Child extends Parent<Integer> {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
+      private @java.lang.SuppressWarnings("all") double doubleField;
+      private @java.lang.SuppressWarnings("all") boolean doubleField$set;
+      public ChildBuilder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B doubleField(final double doubleField) {
+        this.doubleField = doubleField;
+        doubleField$set = true;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithDefaults.Child.ChildBuilder(super=" + super.toString()) + ", doubleField=") + this.doubleField) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+      private ChildBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Child build() {
+        return new Child(this);
+      }
+    }
+    private @lombok.Builder.Default double doubleField = Math.PI;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
+      super(b);
+      if (b.doubleField$set)
+          this.doubleField = b.doubleField;
+    }
+    public static @java.lang.SuppressWarnings("all") ChildBuilder<?, ?> builder() {
+      return new ChildBuilderImpl();
+    }
+  }
+  public SuperBuilderWithDefaults() {
+    super();
+  }
+  public static void test() {
+    Child x = Child.builder().doubleField(0.1).numberField(5).millis(1234567890L).build();
+  }
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
@@ -1,0 +1,166 @@
+import java.util.List;
+
+public class SuperBuilderWithGenerics {
+	public static @lombok.experimental.SuperBuilder class Parent<A> {
+		A field1;
+		List<String> items;
+
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<A, ?, ?> b) {
+			this.field1 = b.field1;
+			java.util.List<String> items;
+			switch (b.items == null ? 0 : b.items.size()) {
+			case 0: 
+				items = java.util.Collections.emptyList();
+				break;
+
+			case 1: 
+				items = java.util.Collections.singletonList(b.items.get(0));
+				break;
+
+			default: 
+				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+			}
+			this.items = items;
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private A field1;
+			@java.lang.SuppressWarnings("all")
+			private java.util.ArrayList<String> items;
+
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+
+			@java.lang.SuppressWarnings("all")
+			public B field1(final A field1) {
+				this.field1 = field1;
+				return self();
+			}
+
+			@java.lang.SuppressWarnings("all")
+			public B item(final String item) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.add(item);
+				return self();
+			}
+
+			@java.lang.SuppressWarnings("all")
+			public B items(final java.util.Collection<? extends String> items) {
+				if (this.items == null) this.items = new java.util.ArrayList<String>();
+				this.items.addAll(items);
+				return self();
+			}
+
+			@java.lang.SuppressWarnings("all")
+			public B clearItems() {
+				if (this.items != null) this.items.clear();
+				return self();
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
+			}
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent<A> build() {
+				return new Parent<A>(this);
+			}
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public static <A> ParentBuilder<A, ?, ?> builder() {
+			return new ParentBuilderImpl<A>();
+		}
+	}
+
+	@lombok.experimental.SuperBuilder
+	public static class Child<A> extends Parent<A> {
+		double field3;
+
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<A, ?, ?> b) {
+			super(b);
+			this.field3 = b.field3;
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
+			@java.lang.SuppressWarnings("all")
+			private double field3;
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+
+			@java.lang.SuppressWarnings("all")
+			public B field3(final double field3) {
+				this.field3 = field3;
+				return self();
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+			}
+		}
+
+
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child<A> build() {
+				return new Child<A>(this);
+			}
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public static <A> ChildBuilder<A, ?, ?> builder() {
+			return new ChildBuilderImpl<A>();
+		}
+	}
+
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
@@ -46,43 +46,37 @@ public class SuperBuilderWithGenerics {
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
       this.field1 = b.field1;
       java.util.List<String> items;
-      switch (b.items == null ? 0 : b.items.size()) {
-      case 0: 
-        items = java.util.Collections.emptyList();
-        break;
-      case 1: 
-        items = java.util.Collections.singletonList(b.items.get(0));
-        break;
-      default: 
-        items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+      switch (((b.items == null) ? 0 : b.items.size())) {
+      case 0 : 
+          items = java.util.Collections.emptyList();
+          break;
+      case 1 : 
+          items = java.util.Collections.singletonList(b.items.get(0));
+          break;
+      default : 
+          items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
       }
       this.items = items;
     }
-    public static @java.lang.SuppressWarnings("all") <A> ParentBuilder<A, ?, ?> builder() {
+    public static @java.lang.SuppressWarnings("all") <A>ParentBuilder<A, ?, ?> builder() {
       return new ParentBuilderImpl<A>();
     }
   }
-  @lombok.experimental.SuperBuilder
-  public static class Child<A> extends Parent<A> {
-    double field3;
-    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<A, ?, ?> b) {
-      super(b);
-      this.field3 = b.field3;
-    }
-    public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
+  public static @lombok.experimental.SuperBuilder class Child<A> extends Parent<A> {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
       private @java.lang.SuppressWarnings("all") double field3;
-      protected @java.lang.Override @java.lang.SuppressWarnings("all") abstract B self();
-      public @java.lang.Override @java.lang.SuppressWarnings("all") abstract C build();
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field3(final double field3) {
         this.field3 = field3;
         return self();
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-        return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+        return (((("SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
-      private ChildBuilderImpl() {
+      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;
@@ -91,9 +85,17 @@ public class SuperBuilderWithGenerics {
         return new Child<A>(this);
       }
     }
-    public static @java.lang.SuppressWarnings("all") <A> ChildBuilder<A, ?, ?> builder() {
+    double field3;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<A, ?, ?> b) {
+      super(b);
+      this.field3 = b.field3;
+    }
+    public static @java.lang.SuppressWarnings("all") <A>ChildBuilder<A, ?, ?> builder() {
       return new ChildBuilderImpl<A>();
     }
+  }
+  public SuperBuilderWithGenerics() {
+    super();
   }
   public static void test() {
     Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
@@ -4,6 +4,9 @@ public class SuperBuilderWithGenerics {
     public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
       private @java.lang.SuppressWarnings("all") A field1;
       private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      public ParentBuilder() {
+        super();
+      }
       protected abstract @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field1(final A field1) {
@@ -32,7 +35,8 @@ public class SuperBuilderWithGenerics {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
-      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      private ParentBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
         return this;
@@ -44,6 +48,7 @@ public class SuperBuilderWithGenerics {
     A field1;
     @lombok.Singular List<String> items;
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
+      super();
       this.field1 = b.field1;
       java.util.List<String> items;
       switch (((b.items == null) ? 0 : b.items.size())) {
@@ -65,6 +70,9 @@ public class SuperBuilderWithGenerics {
   public static @lombok.experimental.SuperBuilder class Child<A> extends Parent<A> {
     public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
       private @java.lang.SuppressWarnings("all") double field3;
+      public ChildBuilder() {
+        super();
+      }
       protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field3(final double field3) {
@@ -76,7 +84,8 @@ public class SuperBuilderWithGenerics {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
-      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+      private ChildBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
@@ -1,166 +1,101 @@
 import java.util.List;
-
 public class SuperBuilderWithGenerics {
-	public static @lombok.experimental.SuperBuilder class Parent<A> {
-		A field1;
-		List<String> items;
-
-		@java.lang.SuppressWarnings("all")
-		protected Parent(final ParentBuilder<A, ?, ?> b) {
-			this.field1 = b.field1;
-			java.util.List<String> items;
-			switch (b.items == null ? 0 : b.items.size()) {
-			case 0: 
-				items = java.util.Collections.emptyList();
-				break;
-
-			case 1: 
-				items = java.util.Collections.singletonList(b.items.get(0));
-				break;
-
-			default: 
-				items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
-			}
-			this.items = items;
-		}
-
-
-		@java.lang.SuppressWarnings("all")
-		public static abstract class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
-			@java.lang.SuppressWarnings("all")
-			private A field1;
-			@java.lang.SuppressWarnings("all")
-			private java.util.ArrayList<String> items;
-
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
-			@java.lang.SuppressWarnings("all")
-			public B field1(final A field1) {
-				this.field1 = field1;
-				return self();
-			}
-
-			@java.lang.SuppressWarnings("all")
-			public B item(final String item) {
-				if (this.items == null) this.items = new java.util.ArrayList<String>();
-				this.items.add(item);
-				return self();
-			}
-
-			@java.lang.SuppressWarnings("all")
-			public B items(final java.util.Collection<? extends String> items) {
-				if (this.items == null) this.items = new java.util.ArrayList<String>();
-				this.items.addAll(items);
-				return self();
-			}
-
-			@java.lang.SuppressWarnings("all")
-			public B clearItems() {
-				if (this.items != null) this.items.clear();
-				return self();
-			}
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public java.lang.String toString() {
-				return "SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1 + ", items=" + this.items + ")";
-			}
-		}
-
-
-		@java.lang.SuppressWarnings("all")
-		private static final class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
-			@java.lang.SuppressWarnings("all")
-			private ParentBuilderImpl() {
-			}
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected ParentBuilderImpl self() {
-				return this;
-			}
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public Parent<A> build() {
-				return new Parent<A>(this);
-			}
-		}
-
-		@java.lang.SuppressWarnings("all")
-		public static <A> ParentBuilder<A, ?, ?> builder() {
-			return new ParentBuilderImpl<A>();
-		}
-	}
-
-	@lombok.experimental.SuperBuilder
-	public static class Child<A> extends Parent<A> {
-		double field3;
-
-		@java.lang.SuppressWarnings("all")
-		protected Child(final ChildBuilder<A, ?, ?> b) {
-			super(b);
-			this.field3 = b.field3;
-		}
-
-
-		@java.lang.SuppressWarnings("all")
-		public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
-			@java.lang.SuppressWarnings("all")
-			private double field3;
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
-			@java.lang.SuppressWarnings("all")
-			public B field3(final double field3) {
-				this.field3 = field3;
-				return self();
-			}
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public java.lang.String toString() {
-				return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
-			}
-		}
-
-
-		@java.lang.SuppressWarnings("all")
-		private static final class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
-			@java.lang.SuppressWarnings("all")
-			private ChildBuilderImpl() {
-			}
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected ChildBuilderImpl self() {
-				return this;
-			}
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public Child<A> build() {
-				return new Child<A>(this);
-			}
-		}
-
-		@java.lang.SuppressWarnings("all")
-		public static <A> ChildBuilder<A, ?, ?> builder() {
-			return new ChildBuilderImpl<A>();
-		}
-	}
-
-	public static void test() {
-		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
-	}
+  public static @lombok.experimental.SuperBuilder class Parent<A> {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+      private @java.lang.SuppressWarnings("all") A field1;
+      private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field1(final A field1) {
+        this.field1 = field1;
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B item(String item) {
+        if ((this.items == null))
+            this.items = new java.util.ArrayList<String>();
+        this.items.add(item);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B items(java.util.Collection<? extends String> items) {
+        if ((this.items == null))
+            this.items = new java.util.ArrayList<String>();
+        this.items.addAll(items);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B clearItems() {
+        if ((this.items != null))
+            this.items.clear();
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent<A> build() {
+        return new Parent<A>(this);
+      }
+    }
+    A field1;
+    @lombok.Singular List<String> items;
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
+      this.field1 = b.field1;
+      java.util.List<String> items;
+      switch (b.items == null ? 0 : b.items.size()) {
+      case 0: 
+        items = java.util.Collections.emptyList();
+        break;
+      case 1: 
+        items = java.util.Collections.singletonList(b.items.get(0));
+        break;
+      default: 
+        items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+      }
+      this.items = items;
+    }
+    public static @java.lang.SuppressWarnings("all") <A> ParentBuilder<A, ?, ?> builder() {
+      return new ParentBuilderImpl<A>();
+    }
+  }
+  @lombok.experimental.SuperBuilder
+  public static class Child<A> extends Parent<A> {
+    double field3;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<A, ?, ?> b) {
+      super(b);
+      this.field3 = b.field3;
+    }
+    public static abstract class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
+      private @java.lang.SuppressWarnings("all") double field3;
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") abstract B self();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") abstract C build();
+      public @java.lang.SuppressWarnings("all") B field3(final double field3) {
+        this.field3 = field3;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return "SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString() + ", field3=" + this.field3 + ")";
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+      private ChildBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Child<A> build() {
+        return new Child<A>(this);
+      }
+    }
+    public static @java.lang.SuppressWarnings("all") <A> ChildBuilder<A, ?, ?> builder() {
+      return new ChildBuilderImpl<A>();
+    }
+  }
+  public static void test() {
+    Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+  }
 }

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
@@ -4,6 +4,9 @@ public class SuperBuilderWithGenerics2 {
     public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
       private @java.lang.SuppressWarnings("all") A field1;
       private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      public ParentBuilder() {
+        super();
+      }
       protected abstract @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field1(final A field1) {
@@ -32,7 +35,8 @@ public class SuperBuilderWithGenerics2 {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
-      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      private ParentBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
         return this;
@@ -44,6 +48,7 @@ public class SuperBuilderWithGenerics2 {
     A field1;
     @lombok.Singular List<String> items;
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
+      super();
       this.field1 = b.field1;
       java.util.List<String> items;
       switch (((b.items == null) ? 0 : b.items.size())) {
@@ -65,6 +70,9 @@ public class SuperBuilderWithGenerics2 {
   public static @lombok.experimental.SuperBuilder(builderMethodName = "builder2") class Child<A> extends Parent<String> {
     public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<String, C, B> {
       private @java.lang.SuppressWarnings("all") A field3;
+      public ChildBuilder() {
+        super();
+      }
       protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B field3(final A field3) {
@@ -76,7 +84,8 @@ public class SuperBuilderWithGenerics2 {
       }
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
-      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+      private ChildBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
         return this;

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
@@ -1,0 +1,103 @@
+import java.util.List;
+public class SuperBuilderWithGenerics2 {
+  public static @lombok.experimental.SuperBuilder class Parent<A> {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<A, C extends Parent<A>, B extends ParentBuilder<A, C, B>> {
+      private @java.lang.SuppressWarnings("all") A field1;
+      private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> items;
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field1(final A field1) {
+        this.field1 = field1;
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B item(String item) {
+        if ((this.items == null))
+            this.items = new java.util.ArrayList<String>();
+        this.items.add(item);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B items(java.util.Collection<? extends String> items) {
+        if ((this.items == null))
+            this.items = new java.util.ArrayList<String>();
+        this.items.addAll(items);
+        return self();
+      }
+      public @java.lang.SuppressWarnings("all") B clearItems() {
+        if ((this.items != null))
+            this.items.clear();
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithGenerics2.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl<A> extends ParentBuilder<A, Parent<A>, ParentBuilderImpl<A>> {
+      private @java.lang.SuppressWarnings("all") ParentBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent<A> build() {
+        return new Parent<A>(this);
+      }
+    }
+    A field1;
+    @lombok.Singular List<String> items;
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<A, ?, ?> b) {
+      this.field1 = b.field1;
+      java.util.List<String> items;
+      switch (((b.items == null) ? 0 : b.items.size())) {
+      case 0 : 
+          items = java.util.Collections.emptyList();
+          break;
+      case 1 : 
+          items = java.util.Collections.singletonList(b.items.get(0));
+          break;
+      default : 
+          items = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(b.items));
+      }
+      this.items = items;
+    }
+    public static @java.lang.SuppressWarnings("all") <A>ParentBuilder<A, ?, ?> builder() {
+      return new ParentBuilderImpl<A>();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder(builderMethodName = "builder2") class Child<A> extends Parent<String> {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<A, C extends Child<A>, B extends ChildBuilder<A, C, B>> extends Parent.ParentBuilder<String, C, B> {
+      private @java.lang.SuppressWarnings("all") A field3;
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B field3(final A field3) {
+        this.field3 = field3;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithGenerics2.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl<A> extends ChildBuilder<A, Child<A>, ChildBuilderImpl<A>> {
+      private @java.lang.SuppressWarnings("all") ChildBuilderImpl() {
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Child<A> build() {
+        return new Child<A>(this);
+      }
+    }
+    A field3;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<A, ?, ?> b) {
+      super(b);
+      this.field3 = b.field3;
+    }
+    public static @java.lang.SuppressWarnings("all") <A>ChildBuilder<A, ?, ?> builder2() {
+      return new ChildBuilderImpl<A>();
+    }
+  }
+  public SuperBuilderWithGenerics2() {
+    super();
+  }
+  public static void test() {
+    Child<Integer> x = Child.<Integer>builder2().field3(1).field1("value").item("").build();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderAbstract.java
+++ b/test/transform/resource/before/SuperBuilderAbstract.java
@@ -1,0 +1,20 @@
+public class SuperBuilderAbstract {
+	@lombok.experimental.SuperBuilder
+	public static class Parent {
+		int parentField;
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public abstract static class Child extends Parent {
+		double childField;
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class GrandChild extends Child {
+		String grandChildField;
+	}
+	
+	public static void test() {
+		GrandChild x = GrandChild.builder().grandChildField("").parentField(5).childField(2.5).build();
+	}
+}

--- a/test/transform/resource/before/SuperBuilderBasic.java
+++ b/test/transform/resource/before/SuperBuilderBasic.java
@@ -1,15 +1,13 @@
-import lombok.experimental.SuperBuilder;
-import lombok.Singular;
 import java.util.List;
 
 public class SuperBuilderBasic {
-	@SuperBuilder
+	@lombok.experimental.SuperBuilder
 	public static class Parent {
 		int field1;
-		@Singular List<String> items;
+		@lombok.Singular List<String> items;
 	}
 	
-	@SuperBuilder
+	@lombok.experimental.SuperBuilder
 	public static class Child extends Parent {
 		double field3;
 	}

--- a/test/transform/resource/before/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/before/SuperBuilderWithCustomBuilderMethod.java
@@ -1,0 +1,21 @@
+import java.util.List;
+
+public class SuperBuilderWithCustomBuilderMethod {
+	@lombok.experimental.SuperBuilder
+	public static class Parent<A> {
+		A field1;
+		@lombok.Singular List<String> items;
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class Child<A> extends Parent<A> {
+		double field3;
+		public static <A> ChildBuilder<A, ?, ?> builder() {
+			return new ChildBuilderImpl<A>().item("default item");
+		}
+	}
+	
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+	}
+}

--- a/test/transform/resource/before/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/before/SuperBuilderWithDefaults.java
@@ -1,0 +1,18 @@
+import java.util.List;
+
+public class SuperBuilderWithDefaults {
+	@lombok.experimental.SuperBuilder
+	public static class Parent<N extends Number> {
+		@lombok.Builder.Default private long millis = System.currentTimeMillis();
+		@lombok.Builder.Default private N numberField = null;
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class Child extends Parent<Integer> {
+		@lombok.Builder.Default private double doubleField = Math.PI;
+	}
+	
+	public static void test() {
+		Child x = Child.builder().doubleField(0.1).numberField(5).millis(1234567890L).build();
+	}
+}

--- a/test/transform/resource/before/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/before/SuperBuilderWithGenerics.java
@@ -1,15 +1,13 @@
-import lombok.experimental.SuperBuilder;
-import lombok.Singular;
 import java.util.List;
 
 public class SuperBuilderWithGenerics {
-	@SuperBuilder
+	@lombok.experimental.SuperBuilder
 	public static class Parent<A> {
 		A field1;
-		@Singular List<String> items;
+		@lombok.Singular List<String> items;
 	}
 	
-	@SuperBuilder
+	@lombok.experimental.SuperBuilder
 	public static class Child<A> extends Parent<A> {
 		double field3;
 	}

--- a/test/transform/resource/before/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/before/SuperBuilderWithGenerics.java
@@ -1,0 +1,20 @@
+import lombok.experimental.SuperBuilder;
+import lombok.Singular;
+import java.util.List;
+
+public class SuperBuilderWithGenerics {
+	@SuperBuilder
+	public static class Parent<A> {
+		A field1;
+		@Singular List<String> items;
+	}
+	
+	@SuperBuilder
+	public static class Child<A> extends Parent<A> {
+		double field3;
+	}
+	
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder().field3(0.0).field1(5).item("").build();
+	}
+}

--- a/test/transform/resource/before/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/before/SuperBuilderWithGenerics2.java
@@ -1,0 +1,18 @@
+import java.util.List;
+
+public class SuperBuilderWithGenerics2 {
+	@lombok.experimental.SuperBuilder
+	public static class Parent<A> {
+		A field1;
+		@lombok.Singular List<String> items;
+	}
+	
+	@lombok.experimental.SuperBuilder(builderMethodName="builder2")
+	public static class Child<A> extends Parent<String> {
+		A field3;
+	}
+	
+	public static void test() {
+		Child<Integer> x = Child.<Integer>builder2().field3(1).field1("value").item("").build();
+	}
+}

--- a/website/templates/features/experimental/SuperBuilder.html
+++ b/website/templates/features/experimental/SuperBuilder.html
@@ -1,0 +1,69 @@
+<#import "_features.html" as f>
+
+<@f.scaffold title="@SuperBuilder" logline="Bob now knows his ancestors: Builders with fields from superclasses, too. ">
+	<@f.history>
+		<p>
+			<code>@SuperBuilder</code> was introduced as experimental feature in lombok v0.16.21.
+		</p>
+	</@f.history>
+	
+	<@f.overview>
+		<p>
+			The <code>@SuperBuilder</code> annotation produces complex builder APIs for your classes.
+			In contrast to <a href="/features/Builder"><code>@Builder</code></a>, <code>@SuperBuilder</code> also works with fields from superclasses.
+			However, it only works for types, and cannot be customized by providing a partial builder implementation.
+			Most importantly, it requires that <em>all superclasses</em> also have the <code>@SuperBuilder</code> annotation.
+		</p><p>
+			<code>@SuperBuilder</code> lets you automatically produce the code required to have your class be instantiable with code such as:<br />
+			<code>Person.builder().name("Adam Savage").city("San Francisco").job("Mythbusters").job("Unchained Reaction").build();</code>
+		</p><p>
+			<code>@SuperBuilder</code> can generate so-called 'singular' methods for collection parameters/fields. For details, see <a href="/features/Builder#singular">the <code>@Singular</code> documentation in <code>@Builder</code></a>.
+		</p><p>
+			As lombok has no access to the fields of superclasses when generating the builder code, the methods for setting those superclass fields can only be in the builder of the superclass.
+			Therefore, a <code>@SuperBuilder</code> must extend the <code>@SuperBuilder</code> of the superclass in order to include those methods.
+			Furthermore, the generated builder code heavily relies on generics to avoid class casting when using the builder. 
+			<code>@SuperBuilder</code> generates a private constructor on the class that takes a builder instances as a parameter. This constructor sets the fields of the new instance to the values from the builder.
+		</p><p>
+			To ensure type-safety, <code>@SuperBuilder</code> generates two inner builder classes for each annotated class, one abstract and one concrete class named <code><em>Foobar</em>Builder</code> and <code><em>Foobar</em>BuilderImpl</code> (where <em>Foobar</em> is the name of the annotated class).
+		</p><p>
+			The configurable aspects of builder are:
+			<ul>
+				<li>
+					The <em>build()</em> method's name (default: <code>"build"</code>)
+				</li><li>
+					The <em>builder()</em> method's name (default: <code>"builder"</code>)
+				</li>
+			</ul>
+			Example usage where all options are changed from their defaults:<br />
+			<code>@SuperBuilder(buildMethodName = "execute", builderMethodName = "helloWorld")</code><br />
+		</p>
+	</@f.overview>
+	
+	<@f.snippets name="Builder" />
+
+	<@f.confKeys>
+		<dt>
+			<code>lombok.builder.flagUsage</code> = [<code>warning</code> | <code>error</code>] (default: not set)
+		</dt><dd>
+			Lombok will flag any usage of <code>@SuperBuilder</code> as a warning or error if configured.
+		</dd><dt>
+			<code>lombok.singular.useGuava</code> = [<code>true</code> | <code>false</code>] (default: false)
+		</dt><dd>
+			If <code>true</code>, lombok will use guava's <code>ImmutableXxx</code> builders and types to implement <code>java.util</code> collection interfaces, instead of creating implementations based on <code>Collections.unmodifiableXxx</code>. You must ensure that guava is actually available on the classpath and buildpath if you use this setting. Guava is used automatically if your field/parameter has one of the guava <code>ImmutableXxx</code> types.
+		</dd><dt>
+			<code>lombok.singular.auto</code> = [<code>true</code> | <code>false</code>] (default: true)
+		</dt><dd>
+			If <code>true</code> (which is the default), lombok automatically tries to singularize your identifier name by assuming that it is a common english plural. If <code>false</code>, you must always explicitly specify the singular name, and lombok will generate an error if you don't (useful if you write your code in a language other than english).
+		</dd>
+	</@f.confKeys>
+
+	<@f.smallPrint>
+		<p>
+			@Singular support for <code>java.util.NavigableMap/Set</code> only works if you are compiling with JDK1.8 or higher.
+		</p><p>
+			The sorted collections (java.util: <code>SortedSet</code>, <code>NavigableSet</code>, <code>SortedMap</code>, <code>NavigableMap</code> and guava: <code>ImmutableSortedSet</code>, <code>ImmutableSortedMap</code>) require that the type argument of the collection has natural order (implements <code>java.util.Comparable</code>). There is no way to pass an explicit <code>Comparator</code> to use in the builder.
+		</p><p>
+			An <code>ArrayList</code> is used to store added elements as call methods of a <code>@Singular</code> marked field, if the target collection is from the <code>java.util</code> package, <em>even if the collection is a set or map</em>. Because lombok ensures that generated collections are compacted, a new backing instance of a set or map must be constructed anyway, and storing the data as an <code>ArrayList</code> during the build process is more efficient that storing it as a map or set. This behaviour is not externally visible, an implementation detail of the current implementation of the <code>java.util</code> recipes for <code>@Singular</code>.
+		</p>
+	</@f.smallPrint>
+</@f.scaffold>

--- a/website/templates/features/experimental/SuperBuilder.html
+++ b/website/templates/features/experimental/SuperBuilder.html
@@ -24,6 +24,8 @@
 			Furthermore, the generated builder code heavily relies on generics to avoid class casting when using the builder. 
 			<code>@SuperBuilder</code> generates a private constructor on the class that takes a builder instances as a parameter. This constructor sets the fields of the new instance to the values from the builder.
 		</p><p>
+			<code>@SuperBuilder</code> is not compatible with <code>@Builder</code>.
+		</p><p>
 			To ensure type-safety, <code>@SuperBuilder</code> generates two inner builder classes for each annotated class, one abstract and one concrete class named <code><em>Foobar</em>Builder</code> and <code><em>Foobar</em>BuilderImpl</code> (where <em>Foobar</em> is the name of the annotated class).
 		</p><p>
 			The configurable aspects of builder are:
@@ -43,7 +45,7 @@
 
 	<@f.confKeys>
 		<dt>
-			<code>lombok.builder.flagUsage</code> = [<code>warning</code> | <code>error</code>] (default: not set)
+			<code>lombok.superBuilder.flagUsage</code> = [<code>warning</code> | <code>error</code>] (default: not set)
 		</dt><dd>
 			Lombok will flag any usage of <code>@SuperBuilder</code> as a warning or error if configured.
 		</dd><dt>

--- a/website/templates/features/experimental/SuperBuilder.html
+++ b/website/templates/features/experimental/SuperBuilder.html
@@ -3,7 +3,7 @@
 <@f.scaffold title="@SuperBuilder" logline="Bob now knows his ancestors: Builders with fields from superclasses, too. ">
 	<@f.history>
 		<p>
-			<code>@SuperBuilder</code> was introduced as experimental feature in lombok v0.16.23.
+			<code>@SuperBuilder</code> was introduced as experimental feature in lombok v1.18.1.
 		</p>
 	</@f.history>
 	

--- a/website/templates/features/experimental/SuperBuilder.html
+++ b/website/templates/features/experimental/SuperBuilder.html
@@ -3,7 +3,7 @@
 <@f.scaffold title="@SuperBuilder" logline="Bob now knows his ancestors: Builders with fields from superclasses, too. ">
 	<@f.history>
 		<p>
-			<code>@SuperBuilder</code> was introduced as experimental feature in lombok v0.16.21.
+			<code>@SuperBuilder</code> was introduced as experimental feature in lombok v0.16.23.
 		</p>
 	</@f.history>
 	

--- a/website/templates/features/experimental/index.html
+++ b/website/templates/features/experimental/index.html
@@ -62,6 +62,10 @@
 			<@main.feature title="@Helper" href="Helper">
 				With a little help from my friends... Helper methods for java.
 			</@main.feature>
+
+			<@main.feature title="@SuperBuilder" href="SuperBuilder">
+				Bob now knows his ancestors: Builders with fields from superclasses, too. 
+			</@main.feature>
 		</div>
 
 		<@f.confKeys>


### PR DESCRIPTION
Based on my initial work on a solution for #853 (and peichhorn/lombok-pg#78) in pull request #1337, I now propose an improved approach.
Core improvement is that the new approach does not require casting any more. To achieve this, it uses generics on the generated builder classes.
This new approach is implemented as a separate experimental annotation called `@SuperBuilder`.

PS: The pull request is based upon the branch `builderParentClass`. However, I could also fix the conflicts with the `master` branch and create another pull request directly to `master`, if that's more convenient for you.

Example usage:

```java
@SuperBuilder
public class Parent {
	@Getter
	private String parentString;
}

@SuperBuilder
public class Child extends Parent {
	@Getter
	private String childString;
}

public class TestBuilder {
	public static void main(String[] args) {
		Child child = Child.builder()
				.childString("childStringValue")
				.parentString("parentStringValue")
				.childString("secondChildStringValue")
				.parentString("secondParentStringValue")
				.build();
		assert("secondChildStringValue".equals(child.getChildString()));
		assert("secondParentStringValue".equals(child.getParentString()));
	}
}
```