### PR TITLE
[Perfromance] using map.get instead of searching for entry

### DIFF
--- a/src/core/lombok/core/LombokInternalAliasing.java
+++ b/src/core/lombok/core/LombokInternalAliasing.java
@@ -36,10 +36,8 @@ public class LombokInternalAliasing {
 	 */
 	public static String processAliases(String in) {
 		if (in == null) return null;
-		for (Map.Entry<String, String> e : ALIASES.entrySet()) {
-			if (in.equals(e.getKey())) return e.getValue();
-		}
-		return in;
+		String ret = ALIASES.get(in);
+		return ret == null ? in : ret;
 	}
 	
 	static {


### PR DESCRIPTION
@rzwitserloot Please check this.
I don't understand why iterating over the keys instead of using map.get (maybe due refactoring)
map.get should be faster. 
(before: 17999ms, after 1466ms - 3,7M invocations)
