### PR TITLE
[Performance] Do not use reflection to check if annotation is present

### DIFF
--- a/src/core/lombok/eclipse/EclipseASTAdapter.java
+++ b/src/core/lombok/eclipse/EclipseASTAdapter.java
@@ -36,6 +36,9 @@ import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
  * has been implemented with an empty body. Override whichever methods you need.
  */
 public abstract class EclipseASTAdapter implements EclipseASTVisitor {
+	
+	private final boolean deferUntilPostDiet = getClass().isAnnotationPresent(DeferUntilPostDiet.class);
+
 	/** {@inheritDoc} */
 	public void visitCompilationUnit(EclipseNode top, CompilationUnitDeclaration unit) {}
 	
@@ -98,4 +101,8 @@ public abstract class EclipseASTAdapter implements EclipseASTVisitor {
 	
 	/** {@inheritDoc} */
 	public void endVisitStatement(EclipseNode statementNode, Statement statement) {}
+	
+	public boolean isDeferUntilPostDiet() {
+		return deferUntilPostDiet ;
+	}
 }

--- a/src/core/lombok/eclipse/EclipseASTVisitor.java
+++ b/src/core/lombok/eclipse/EclipseASTVisitor.java
@@ -325,5 +325,11 @@ public interface EclipseASTVisitor {
 			int end = node.get().sourceEnd();
 			return String.format(" [%d, %d]", start, end);
 		}
+
+		public boolean isDeferUntilPostDiet() {
+			return false;
+		}
 	}
+
+	boolean isDeferUntilPostDiet();
 }

--- a/src/core/lombok/eclipse/EclipseNode.java
+++ b/src/core/lombok/eclipse/EclipseNode.java
@@ -53,7 +53,7 @@ public class EclipseNode extends lombok.core.LombokNode<EclipseAST, EclipseNode,
 	 * Visits this node and all child nodes depth-first, calling the provided visitor's visit methods.
 	 */
 	public void traverse(EclipseASTVisitor visitor) {
-		if (!this.isCompleteParse() && visitor.getClass().isAnnotationPresent(DeferUntilPostDiet.class)) return;
+		if (visitor.isDeferUntilPostDiet() && !isCompleteParse()) return;
 		
 		switch (getKind()) {
 		case COMPILATION_UNIT:


### PR DESCRIPTION
Cache the DeferUntilPostDiet flag instead of using reflection to check