### PR TITLE
[Performance] replace Collection<FieldAccess> by FieldAccess[] array 

### DIFF
--- a/src/core/lombok/core/AST.java
+++ b/src/core/lombok/core/AST.java
@@ -216,19 +216,19 @@ public abstract class AST<A extends AST<A, L, N>, L extends LombokNode<A, L, N>,
 		}
 	}
 	
-	private static final ConcurrentMap<Class<?>, Collection<FieldAccess>> fieldsOfASTClasses = new ConcurrentHashMap<Class<?>, Collection<FieldAccess>>();
+	private static final ConcurrentMap<Class<?>, FieldAccess[]> fieldsOfASTClasses = new ConcurrentHashMap<Class<?>, FieldAccess[]>();
 	
 	/** Returns FieldAccess objects for the stated class. Each field that contains objects of the kind returned by
 	 * {@link #getStatementTypes()}, either directly or inside of an array or java.util.collection (or array-of-arrays,
 	 * or collection-of-collections, et cetera), is returned.
 	 */
-	protected Collection<FieldAccess> fieldsOf(Class<?> c) {
-		Collection<FieldAccess> fields = fieldsOfASTClasses.get(c);
+	protected FieldAccess[] fieldsOf(Class<?> c) {
+		FieldAccess[] fields = fieldsOfASTClasses.get(c);
 		if (fields != null) return fields;
 		
-		fields = new ArrayList<FieldAccess>();
-		getFields(c, fields);
-		fieldsOfASTClasses.putIfAbsent(c, fields);
+		List<FieldAccess> fieldList = new ArrayList<FieldAccess>();
+		getFields(c, fieldList);
+		fieldsOfASTClasses.putIfAbsent(c, fieldList.toArray(new FieldAccess[fieldList.size()]));
 		return fieldsOfASTClasses.get(c);
 	}
 	


### PR DESCRIPTION
This is a litte bit faster, because it does not use an iterator in `for( ...)` loops