### PR TITLE
[Performance] use declared ast Type instead of generic one 

### DIFF
--- a/src/core/lombok/core/LombokNode.java
+++ b/src/core/lombok/core/LombokNode.java
@@ -40,7 +40,6 @@ import lombok.core.AST.Kind;
  *          For example, JCTree for javac, and ASTNode for Eclipse.
  */
 public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A, L, N>, N> implements DiagnosticsReceiver {
-	protected final A ast;
 	protected final Kind kind;
 	protected final N node;
 	protected LombokImmutableList<L> children;
@@ -59,8 +58,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @param kind The kind of node represented by this object.
 	 */
 	@SuppressWarnings("unchecked")
-	protected LombokNode(A ast, N node, List<L> children, Kind kind) {
-		this.ast = ast;
+	protected LombokNode(N node, List<L> children, Kind kind) {
 		this.kind = kind;
 		this.node = node;
 		this.children = children != null ? LombokImmutableList.copyOf(children) : LombokImmutableList.<L>of();
@@ -72,9 +70,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 		this.isStructurallySignificant = calculateIsStructurallySignificant(null);
 	}
 	
-	public A getAst() {
-		return ast;
-	}
+	public abstract A getAst();
 	
 	/** {@inheritDoc} */
 	@Override public String toString() {
@@ -88,7 +84,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#getPackageDeclaration()
 	 */
 	public String getPackageDeclaration() {
-		return ast.getPackageDeclaration();
+		return getAst().getPackageDeclaration();
 	}
 	
 	/**
@@ -97,7 +93,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#getImportList()
 	 */
 	public ImportList getImportList() {
-		return ast.getImportList();
+		return getAst().getImportList();
 	}
 	
 	/**
@@ -111,7 +107,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#get(Object)
 	 */
 	public L getNodeFor(N obj) {
-		return ast.get(obj);
+		return getAst().get(obj);
 	}
 	
 	/**
@@ -187,7 +183,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#getLatestJavaSpecSupported()
 	 */
 	public int getLatestJavaSpecSupported() {
-		return ast.getLatestJavaSpecSupported();
+		return getAst().getLatestJavaSpecSupported();
 	}
 	
 	/**
@@ -196,7 +192,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#getSourceVersion()
 	 */
 	public int getSourceVersion() {
-		return ast.getSourceVersion();
+		return getAst().getSourceVersion();
 	}
 	
 	/**
@@ -205,7 +201,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#top()
 	 */
 	public L top() {
-		return ast.top();
+		return getAst().top();
 	}
 	
 	/**
@@ -214,7 +210,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * @see AST#getFileName()
 	 */
 	public String getFileName() {
-		return ast.getFileName();
+		return getAst().getFileName();
 	}
 	
 	/**
@@ -224,8 +220,8 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 */
 	@SuppressWarnings({"unchecked"})
 	public L add(N newChild, Kind newChildKind) {
-		ast.setChanged();
-		L n = ast.buildTree(newChild, newChildKind);
+		getAst().setChanged();
+		L n = getAst().buildTree(newChild, newChildKind);
 		if (n == null) return null;
 		n.parent = (L) this;
 		children = children.append(n);
@@ -242,20 +238,20 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 		Map<N, L> oldNodes = new IdentityHashMap<N, L>();
 		gatherAndRemoveChildren(oldNodes);
 		
-		L newNode = ast.buildTree(get(), kind);
+		L newNode = getAst().buildTree(get(), kind);
 		
-		ast.setChanged();
+		getAst().setChanged();
 		
-		ast.replaceNewWithExistingOld(oldNodes, newNode);
+		getAst().replaceNewWithExistingOld(oldNodes, newNode);
 	}
 	
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private void gatherAndRemoveChildren(Map<N, L> map) {
 		for (LombokNode child : children) child.gatherAndRemoveChildren(map);
-		ast.identityDetector.remove(get());
+		getAst().identityDetector.remove(get());
 		map.put(get(), (L) this);
 		children = LombokImmutableList.of();
-		ast.getNodeMap().remove(get());
+		getAst().getNodeMap().remove(get());
 	}
 	
 	/**
@@ -264,7 +260,7 @@ public abstract class LombokNode<A extends AST<A, L, N>, L extends LombokNode<A,
 	 * Does not change the underlying (javac/Eclipse) AST, only the wrapped view.
 	 */
 	public void removeChild(L child) {
-		ast.setChanged();
+		getAst().setChanged();
 		children = children.removeElement(child);
 	}
 	

--- a/src/core/lombok/eclipse/EclipseNode.java
+++ b/src/core/lombok/eclipse/EclipseNode.java
@@ -44,11 +44,17 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
  * Eclipse specific version of the LombokNode class.
  */
 public class EclipseNode extends lombok.core.LombokNode<EclipseAST, EclipseNode, ASTNode> {
+	private EclipseAST ast;
 	/** {@inheritDoc} */
 	EclipseNode(EclipseAST ast, ASTNode node, List<EclipseNode> children, Kind kind) {
-		super(ast, node, children, kind);
+		super(node, children, kind);
+		this.ast = ast;
 	}
 	
+	@Override 
+	public EclipseAST getAst() {
+		return ast;
+	}
 	/**
 	 * Visits this node and all child nodes depth-first, calling the provided visitor's visit methods.
 	 */

--- a/src/core/lombok/javac/JavacNode.java
+++ b/src/core/lombok/javac/JavacNode.java
@@ -50,11 +50,18 @@ import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
  * Javac specific version of the LombokNode class.
  */
 public class JavacNode extends lombok.core.LombokNode<JavacAST, JavacNode, JCTree> {
+	private JavacAST ast;
 	/**
 	 * Passes through to the parent constructor.
 	 */
 	public JavacNode(JavacAST ast, JCTree node, List<JavacNode> children, Kind kind) {
-		super(ast, node, children, kind);
+		super(node, children, kind);
+		this.ast = ast;
+	}
+	
+	@Override 
+	public JavacAST getAst() {
+		return ast;
 	}
 	
 	public Element getElement() {


### PR DESCRIPTION
There are many calls like `ast.traverseChildren` - due type erasue, ast was internally stored as object, which leads to a "checkcast" before each "invokevirtual" in the byte code.

This PR and #1763 reduces the total time spent in the `traverse` method (30M calls) from 52276ms to 51246ms.
