### PR TITLE
FIX: omit warning about IncrementalProcessingEnvironment

### DIFF
--- a/src/core/lombok/core/AnnotationProcessor.java
+++ b/src/core/lombok/core/AnnotationProcessor.java
@@ -110,6 +110,8 @@ public class AnnotationProcessor extends AbstractProcessor {
 		}
 		
 		@Override boolean want(ProcessingEnvironment procEnv, List<String> delayedWarnings) {
+			if (procEnv.getClass().getName().equals("org.eclipse.jdt.internal.compiler.apt.dispatch.BatchProcessingEnvImpl")) return false;
+			
 			ProcessingEnvironment javacProcEnv = getJavacProcessingEnvironment(procEnv, delayedWarnings);
 
 			if (javacProcEnv == null) return false;

--- a/src/core/lombok/core/AnnotationProcessor.java
+++ b/src/core/lombok/core/AnnotationProcessor.java
@@ -110,7 +110,7 @@ public class AnnotationProcessor extends AbstractProcessor {
 		}
 		
 		@Override boolean want(ProcessingEnvironment procEnv, List<String> delayedWarnings) {
-			if (procEnv.getClass().getName().equals("org.eclipse.jdt.internal.compiler.apt.dispatch.BatchProcessingEnvImpl")) return false;
+			if (procEnv.getClass().getName().startsWith("org.eclipse.jdt.")) return false; // do not run on ECJ
 			
 			ProcessingEnvironment javacProcEnv = getJavacProcessingEnvironment(procEnv, delayedWarnings);
 
@@ -211,7 +211,7 @@ public class AnnotationProcessor extends AbstractProcessor {
 		for (TypeElement elem : annotations) {
 			zeroElems = false;
 			Name n = elem.getQualifiedName();
-			if (n.length() > 7 && n.subSequence(0, 7).toString().equals("lombok.")) continue;
+			if (n.toString().startsWith("lombok.")) continue;
 			onlyLombok = false;
 		}
 		


### PR DESCRIPTION
I use lombok with the ecj and I get this warning 
"Can't get the delegate of the gradle IncrementalProcessingEnvironment."
since 1.18.1