### PR TITLE
[Performance] Optimize the ShadowClassLoader when determining isPartOfShadow

### DIFF
--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -92,7 +92,7 @@ final class PatchFixesHider {
 						shadowLoader = Util.class.getClassLoader();
 					} catch (ClassNotFoundException e) {
 						// If we get here, it isn't, and we should use the shadowloader.
-						shadowLoader = Main.createShadowClassLoader();
+						shadowLoader = Main.getShadowClassLoader();
 					}
 				}
 				

--- a/src/launch/lombok/launch/Agent.java
+++ b/src/launch/lombok/launch/Agent.java
@@ -35,7 +35,7 @@ final class Agent {
 	}
 	
 	private static void runLauncher(String agentArgs, Instrumentation instrumentation, boolean injected) throws Throwable {
-		ClassLoader cl = Main.createShadowClassLoader();
+		ClassLoader cl = Main.getShadowClassLoader();
 		try {
 			Class<?> c = cl.loadClass("lombok.core.AgentLauncher");
 			Method m = c.getDeclaredMethod("runAgents", String.class, Instrumentation.class, boolean.class, Class.class);

--- a/src/launch/lombok/launch/AnnotationProcessor.java
+++ b/src/launch/lombok/launch/AnnotationProcessor.java
@@ -104,7 +104,7 @@ class AnnotationProcessorHider {
 		}
 		
 		private static AbstractProcessor createWrappedInstance() {
-			ClassLoader cl = Main.createShadowClassLoader();
+			ClassLoader cl = Main.getShadowClassLoader();
 			try {
 				Class<?> mc = cl.loadClass("lombok.core.AnnotationProcessor");
 				return (AbstractProcessor) mc.getDeclaredConstructor().newInstance();

--- a/src/launch/lombok/launch/Main.java
+++ b/src/launch/lombok/launch/Main.java
@@ -25,12 +25,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
 class Main {
-	static ClassLoader createShadowClassLoader() {
-		return new ShadowClassLoader(Main.class.getClassLoader(), "lombok", null, Arrays.<String>asList(), Arrays.asList("lombok.patcher.Symbols"));
+	
+	private static ShadowClassLoader classLoader;
+
+	static synchronized ClassLoader getShadowClassLoader() {
+		if (classLoader == null) {
+			classLoader = new ShadowClassLoader(Main.class.getClassLoader(), "lombok", null, Arrays.<String>asList(), Arrays.asList("lombok.patcher.Symbols"));
+		}
+		return classLoader;
 	}
 	
 	public static void main(String[] args) throws Throwable {
-		ClassLoader cl = createShadowClassLoader();
+		ClassLoader cl = getShadowClassLoader();
 		Class<?> mc = cl.loadClass("lombok.core.Main");
 		try {
 			mc.getMethod("main", String[].class).invoke(null, new Object[] {args});


### PR DESCRIPTION
This PR tries to restore the main performance drop on 1.18.1

**issue:**
I have a multi module maven project with 20 modules using ecj. 
With 1.18.1 the build time increased ~7 seconds compared to 1.18.0

The bottleneck was, that each compile task per maven module scans the complete rt.jar if "java/lang/Object" is extended. I also noticed, that every task creates a new ClassLoader (which is unneccessary IMHO)