### PR TITLE
Reduced the AST traverse calls to improve ECJ performance

### DIFF
--- a/src/core/lombok/core/AST.java
+++ b/src/core/lombok/core/AST.java
@@ -216,19 +216,19 @@ public abstract class AST<A extends AST<A, L, N>, L extends LombokNode<A, L, N>,
 		}
 	}
 	
-	private static final ConcurrentMap<Class<?>, Collection<FieldAccess>> fieldsOfASTClasses = new ConcurrentHashMap<Class<?>, Collection<FieldAccess>>();
+	private static final ConcurrentMap<Class<?>, FieldAccess[]> fieldsOfASTClasses = new ConcurrentHashMap<Class<?>, FieldAccess[]>();
 	
 	/** Returns FieldAccess objects for the stated class. Each field that contains objects of the kind returned by
 	 * {@link #getStatementTypes()}, either directly or inside of an array or java.util.collection (or array-of-arrays,
 	 * or collection-of-collections, et cetera), is returned.
 	 */
-	protected Collection<FieldAccess> fieldsOf(Class<?> c) {
-		Collection<FieldAccess> fields = fieldsOfASTClasses.get(c);
+	protected FieldAccess[] fieldsOf(Class<?> c) {
+		FieldAccess[] fields = fieldsOfASTClasses.get(c);
 		if (fields != null) return fields;
 		
-		fields = new ArrayList<FieldAccess>();
-		getFields(c, fields);
-		fieldsOfASTClasses.putIfAbsent(c, fields);
+		List<FieldAccess> fieldList = new ArrayList<FieldAccess>();
+		getFields(c, fieldList);
+		fieldsOfASTClasses.putIfAbsent(c, fieldList.toArray(new FieldAccess[fieldList.size()]));
 		return fieldsOfASTClasses.get(c);
 	}
 	

--- a/src/core/lombok/core/AnnotationProcessor.java
+++ b/src/core/lombok/core/AnnotationProcessor.java
@@ -110,6 +110,9 @@ public class AnnotationProcessor extends AbstractProcessor {
 		}
 		
 		@Override boolean want(ProcessingEnvironment procEnv, List<String> delayedWarnings) {
+			// do not run on ECJ as it may print warnings
+			if (procEnv.getClass().getName().startsWith("org.eclipse.jdt.")) return false;
+			
 			ProcessingEnvironment javacProcEnv = getJavacProcessingEnvironment(procEnv, delayedWarnings);
 
 			if (javacProcEnv == null) return false;
@@ -209,7 +212,7 @@ public class AnnotationProcessor extends AbstractProcessor {
 		for (TypeElement elem : annotations) {
 			zeroElems = false;
 			Name n = elem.getQualifiedName();
-			if (n.length() > 7 && n.subSequence(0, 7).toString().equals("lombok.")) continue;
+			if (n.toString().startsWith("lombok.")) continue;
 			onlyLombok = false;
 		}
 		

--- a/src/core/lombok/core/LombokInternalAliasing.java
+++ b/src/core/lombok/core/LombokInternalAliasing.java
@@ -36,10 +36,8 @@ public class LombokInternalAliasing {
 	 */
 	public static String processAliases(String in) {
 		if (in == null) return null;
-		for (Map.Entry<String, String> e : ALIASES.entrySet()) {
-			if (in.equals(e.getKey())) return e.getValue();
-		}
-		return in;
+		String ret = ALIASES.get(in);
+		return ret == null ? in : ret;
 	}
 	
 	static {

--- a/src/core/lombok/eclipse/EclipseASTAdapter.java
+++ b/src/core/lombok/eclipse/EclipseASTAdapter.java
@@ -36,6 +36,9 @@ import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
  * has been implemented with an empty body. Override whichever methods you need.
  */
 public abstract class EclipseASTAdapter implements EclipseASTVisitor {
+	
+	private final boolean deferUntilPostDiet = getClass().isAnnotationPresent(DeferUntilPostDiet.class);
+
 	/** {@inheritDoc} */
 	public void visitCompilationUnit(EclipseNode top, CompilationUnitDeclaration unit) {}
 	
@@ -98,4 +101,8 @@ public abstract class EclipseASTAdapter implements EclipseASTVisitor {
 	
 	/** {@inheritDoc} */
 	public void endVisitStatement(EclipseNode statementNode, Statement statement) {}
+	
+	public boolean isDeferUntilPostDiet() {
+		return deferUntilPostDiet ;
+	}
 }

--- a/src/core/lombok/eclipse/EclipseASTVisitor.java
+++ b/src/core/lombok/eclipse/EclipseASTVisitor.java
@@ -325,5 +325,11 @@ public interface EclipseASTVisitor {
 			int end = node.get().sourceEnd();
 			return String.format(" [%d, %d]", start, end);
 		}
+
+		public boolean isDeferUntilPostDiet() {
+			return false;
+		}
 	}
+
+	boolean isDeferUntilPostDiet();
 }

--- a/src/core/lombok/eclipse/EclipseNode.java
+++ b/src/core/lombok/eclipse/EclipseNode.java
@@ -53,7 +53,7 @@ public class EclipseNode extends lombok.core.LombokNode<EclipseAST, EclipseNode,
 	 * Visits this node and all child nodes depth-first, calling the provided visitor's visit methods.
 	 */
 	public void traverse(EclipseASTVisitor visitor) {
-		if (!this.isCompleteParse() && visitor.getClass().isAnnotationPresent(DeferUntilPostDiet.class)) return;
+		if (visitor.isDeferUntilPostDiet() && !isCompleteParse()) return;
 		
 		switch (getKind()) {
 		case COMPILATION_UNIT:

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -92,7 +92,7 @@ final class PatchFixesHider {
 						shadowLoader = Util.class.getClassLoader();
 					} catch (ClassNotFoundException e) {
 						// If we get here, it isn't, and we should use the shadowloader.
-						shadowLoader = Main.createShadowClassLoader();
+						shadowLoader = Main.getShadowClassLoader();
 					}
 				}
 				

--- a/src/launch/lombok/launch/Agent.java
+++ b/src/launch/lombok/launch/Agent.java
@@ -35,7 +35,7 @@ final class Agent {
 	}
 	
 	private static void runLauncher(String agentArgs, Instrumentation instrumentation, boolean injected) throws Throwable {
-		ClassLoader cl = Main.createShadowClassLoader();
+		ClassLoader cl = Main.getShadowClassLoader();
 		try {
 			Class<?> c = cl.loadClass("lombok.core.AgentLauncher");
 			Method m = c.getDeclaredMethod("runAgents", String.class, Instrumentation.class, boolean.class, Class.class);

--- a/src/launch/lombok/launch/AnnotationProcessor.java
+++ b/src/launch/lombok/launch/AnnotationProcessor.java
@@ -104,7 +104,7 @@ class AnnotationProcessorHider {
 		}
 		
 		private static AbstractProcessor createWrappedInstance() {
-			ClassLoader cl = Main.createShadowClassLoader();
+			ClassLoader cl = Main.getShadowClassLoader();
 			try {
 				Class<?> mc = cl.loadClass("lombok.core.AnnotationProcessor");
 				return (AbstractProcessor) mc.getDeclaredConstructor().newInstance();

--- a/src/launch/lombok/launch/Main.java
+++ b/src/launch/lombok/launch/Main.java
@@ -25,12 +25,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
 class Main {
-	static ClassLoader createShadowClassLoader() {
-		return new ShadowClassLoader(Main.class.getClassLoader(), "lombok", null, Arrays.<String>asList(), Arrays.asList("lombok.patcher.Symbols"));
+	
+	private static ShadowClassLoader classLoader;
+
+	static synchronized ClassLoader getShadowClassLoader() {
+		if (classLoader == null) {
+			classLoader = new ShadowClassLoader(Main.class.getClassLoader(), "lombok", null, Arrays.<String>asList(), Arrays.asList("lombok.patcher.Symbols"));
+		}
+		return classLoader;
 	}
 	
 	public static void main(String[] args) throws Throwable {
-		ClassLoader cl = createShadowClassLoader();
+		ClassLoader cl = getShadowClassLoader();
 		Class<?> mc = cl.loadClass("lombok.core.Main");
 		try {
 			mc.getMethod("main", String[].class).invoke(null, new Object[] {args});

--- a/src/utils/lombok/eclipse/Eclipse.java
+++ b/src/utils/lombok/eclipse/Eclipse.java
@@ -56,6 +56,8 @@ public class Eclipse {
 	 */
 	public static final int ECLIPSE_DO_NOT_TOUCH_FLAG = ASTNode.Bit24;
 	
+	private static final Pattern SPLIT_AT_DOT = Pattern.compile("\\.");
+	
 	private Eclipse() {
 		//Prevent instantiation
 	}
@@ -65,19 +67,25 @@ public class Eclipse {
 	 * but we need to deal with it. This turns [[java][lang][String]] into "java.lang.String".
 	 */
 	public static String toQualifiedName(char[][] typeName) {
-		int len = typeName.length - 1;
+		int len = typeName.length - 1; // number of dots
+		if (len == 0) return new String(typeName[0]);
+		
 		for (char[] c : typeName) len += c.length;
-		StringBuilder sb = new StringBuilder(len);
-		boolean first = true;
-		for (char[] c : typeName) {
-			sb.append(first ? "" : ".").append(c);
-			first = false;
+		char[] ret = new char[len];
+		char[] part = typeName[0];
+		System.arraycopy(part, 0, ret, 0, part.length);
+		int pos = part.length;
+		for (int i = 1; i < typeName.length; i++) {
+			ret[pos++] = '.';
+			part = typeName[i];
+			System.arraycopy(part, 0, ret, pos, part.length);
+			pos += part.length;
 		}
-		return sb.toString();
+		return new String(ret);
 	}
 	
 	public static char[][] fromQualifiedName(String typeName) {
-		String[] split = typeName.split("\\.");
+		String[] split = SPLIT_AT_DOT.split(typeName);
 		char[][] result = new char[split.length][];
 		for (int i = 0; i < split.length; i++) {
 			result[i] = split[i].toCharArray();


### PR DESCRIPTION
This PR brings several optimizations for the ECJ, especially when using it in a multi module maven build (as I do) - also the eclipse performance should be better, especially on modules that do not use lombok.

**So: some numbers:**
 1. Single maven project, not using lombok ~ 1200 class files:

|Type of build |Total maven build time | Est. compile time| Note |
|--------------|------------------------|------------------|------|
| No lombok   | ~8.5 sec                      |     5.0 sec  | this is the 'reference' build time, as this project can be built without lombok|
| 1.18.0 - original | ~12.5 sec | 9.0 sec | just adding lombok (as eclipse does by default for all projects) will nearly double the compile time, because lombok tries to enhance EVERY class. I tried ti scan for "interesting imports" which nearly restored the original performance, but the discussion showed, that this approach cannot detect FQNs. Maybe it is possible to add a switch to disable lombok for certain projects|
| 1.18.1 - original | ~ 13 sec | 9.5 sec | With 1.18.1 there was a change in the class loader that tries to detect if a type is part of the shadow. This scans every jar, also the RT jar which takes 300-500ms milliseconds. I tried to optimize this for "java" and "sun" packages to skip at least the rt.jar. In the multi module build, these 300ms were added to each module (20 Modules * 300ms = 6sec)
| 1.18.1 - modified | ~ 10 sec | 6.5 sec | So the patched version adds only 1.5 sec overhead instead of 4 sec to a project where no (or only a few classes) are using lombok annotations. This is done by tracking the next interesting priority. The old version performed 40M traverse calls, the new one has only 3,7M traverse calls on the same project. There are also some minor other changes like using char arrays instead of StringBuilders, which saves also some milliseconds|

2. Multi Module project 20 modules ~ 4000 class files

|Type of build |Total maven build time | Est. compile time| Note |
|--------------|------------------------|------------------|------|
| No lombok   |                                   |                            | Project requires lombok, so it is not testable |
| 1.18.0 - original | ~39 sec | 21 sec | This is the 'reference' |
| 1.18.1 - original | ~46 sec | 28 sec | the change in the class loader adds ~300ms to each module. See above |
| 1.18.1 - patched | ~46 sec | 17 sec | this is a noticeable performance improvement I would say. As most of the classes uses only @Getter and @Setter, most of the priorities can be skipped. The traverse calls were reduced from 31M to 4.5M. You can also see that lombok is no longer the time consumer in the profiler results |

**result on 1.18.1 - original**
![grafik](https://user-images.githubusercontent.com/5530228/42472952-74576c32-83c3-11e8-9d70-3782da96077d.png)

**result on 1.18.1 - with this PR**
![grafik](https://user-images.githubusercontent.com/5530228/42472978-887cd9a4-83c3-11e8-910d-e0118bfbe046.png)

I will close the other PRs and I would be happy if this can be merged in

BTW: I had a problem to run the integration tests, because they do not run on java 1.8 or 10 (and java 9 is no longer officially downloadable)