### PR TITLE
Allow jitpack to build lombok using JDK 9+

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -162,17 +162,21 @@ the common tasks and can be called on to run the main aspects of all the sub-scr
 	</target>
 	
 	<target name="-ensureJdk9">
+		<echo message="Java version: ${ant.java.version}" />
+		<echo message="Java version: ${java.version}" />
+
 		<condition property="java.version.insufficient">
 			<or>
-				<equals arg1="${ant.java.version}" arg2="1.2" />
-				<equals arg1="${ant.java.version}" arg2="1.3" />
-				<equals arg1="${ant.java.version}" arg2="1.4" />
-				<equals arg1="${ant.java.version}" arg2="1.5" />
-				<equals arg1="${ant.java.version}" arg2="1.6" />
-				<equals arg1="${ant.java.version}" arg2="1.7" />
-				<equals arg1="${ant.java.version}" arg2="1.8" />
+				<equals arg1="${java.version}" arg2="1.2" />
+				<equals arg1="${java.version}" arg2="1.3" />
+				<equals arg1="${java.version}" arg2="1.4" />
+				<equals arg1="${java.version}" arg2="1.5" />
+				<equals arg1="${java.version}" arg2="1.6" />
+				<equals arg1="${java.version}" arg2="1.7" />
+				<equals arg1="${java.version}" arg2="1.8" />
 			</or>
 		</condition>
+		<echo message="Java version insufficient: ${java.version.insufficient}" />
 		<fail if="java.version.insufficient">To compile lombok, you need JDK9 or higher; lombok requires this version because it's rather difficult to produce lombok builds that are compatible on JDK9 without at least building with JDK9. Sorry about that.</fail>
 	</target>
 	

--- a/build.xml
+++ b/build.xml
@@ -162,7 +162,6 @@ the common tasks and can be called on to run the main aspects of all the sub-scr
 	</target>
 	
 	<target name="-ensureJdk9">
-		<echo message="Java version: ${ant.java.version}" />
 		<echo message="Java version: ${java.version}" />
 
 		<condition property="java.version.insufficient">

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk9

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,11 @@
 jdk:
-  - openjdk9
+- openjdk9
+before_install:
+- echo "*******JAVA_HOME*******\n"
+- export JAVA_HOME=/usr/lib/jvm/java-9-oracle
+- echo $JAVA_HOME
+- echo "******Ant Version********"
+- ant -version
+- echo "*****Java Version*********"
+- java -version
+- echo  "****************************"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,11 +1,4 @@
 jdk:
 - openjdk9
 before_install:
-- echo "*******JAVA_HOME*******\n"
 - export JAVA_HOME=/usr/lib/jvm/java-9-oracle
-- echo $JAVA_HOME
-- echo "******Ant Version********"
-- ant -version
-- echo "*****Java Version*********"
-- java -version
-- echo  "****************************"


### PR DESCRIPTION
## Problem

Let lombok build on jitpack.io.

From:
https://jitpack.io/docs/BUILDING/#build-customization

> You can create a jitpack.yml file in the root of your repository and override the build commands:
>
> jdk:
>   -openjdk9

## Current

A sample failing build:
https://jitpack.io/com/github/rzwitserloot/lombok/37434ba0cb/build.log

With current failure:

```
-ensureJdk9:

BUILD FAILED
/home/jitpack/build/build.xml:176: To compile lombok, you need JDK9 or higher; lombok requires this version because it's rather difficult 
to produce lombok builds that are compatible on JDK9 without at least building with JDK9. Sorry about that.
```

## Why

This, once working, should allow access to SNAPSHOT builds of lombok whereby developers can quickly test changes and provided feedback. (Case in point: https://github.com/rzwitserloot/lombok/pull/1718)

## Caveats

I ended up switching the java version insufficiency check to use `java.version` rather than `ant.java.version`. This was done to get around jitpack's behavior:

```
-ensureJdk9:
     [echo] Java version: 1.8
     [echo] Java version: 9.0.4
     [echo] Java version insufficient: true
```

Using the above changes, I was able to successfully build lombok. [Here is a build log](https://jitpack.io/com/github/mmoayyed/lombok/-v1.18.0-gbff1237-99/build.log) that shows the build is successful.

# Usage

See: https://jitpack.io/#rzwitserloot/lombok/-SNAPSHOT

## Maven

```
<repositories>
		<repository>
		    <id>jitpack.io</id>
		    <url>https://jitpack.io</url>
		</repository>
</repositories>
<dependency>
	    <groupId>com.github.rzwitserloot</groupId>
	    <artifactId>lombok</artifactId>
	    <version>-SNAPSHOT</version>
</dependency>
```

## Gradle

```
allprojects {
		repositories {
			...
			maven { url 'https://jitpack.io' }
		}
}
dependencies {
	        implementation 'com.github.rzwitserloot:lombok:-SNAPSHOT'
}
```
