### PR TITLE
java.util.logging.Logger does not have an error method.

### DIFF
--- a/website/usageExamples/LogExample_post.jpage
+++ b/website/usageExamples/LogExample_post.jpage
@@ -2,7 +2,7 @@ public class LogExample {
 	private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LogExample.class.getName());
 	
 	public static void main(String... args) {
-		log.error("Something's wrong here");
+		log.severe("Something's wrong here");
 	}
 }
 

--- a/website/usageExamples/LogExample_pre.jpage
+++ b/website/usageExamples/LogExample_pre.jpage
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 public class LogExample {
 	
 	public static void main(String... args) {
-		log.error("Something's wrong here");
+		log.severe("Something's wrong here");
 	}
 }
 


### PR DESCRIPTION
I replaced the `error` method invocation in the `@Log` examples with `severe`, because `java.util.logging.Logger` does not have an `error` method (as per https://docs.oracle.com/javase/10/docs/api/java/util/logging/Logger.html)