### PR TITLE
[fixes #1759] ‘flag usage’ check on builder for eclipse

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -146,6 +146,8 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 	}
 	
 	@Override public void handle(AnnotationValues<Builder> annotation, Annotation ast, EclipseNode annotationNode) {
+		handleFlagUsage(annotationNode, ConfigurationKeys.BUILDER_FLAG_USAGE, "@Builder");
+
 		long p = (long) ast.sourceStart << 32 | ast.sourceEnd;
 		
 		Builder builderInstance = annotation.getInstance();


### PR DESCRIPTION
The fix for #1759 in commit 5ec61bb only fixed the flagUsage handling for javac, not Eclipse.