### PR TITLE
SuperBuilder uses Builder's behavior for default

### DIFF
--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -595,7 +595,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName(buildName), returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), thrownExceptions, body, null);
 	}
 	
-	public JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
+	public static JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
 		JavacTreeMaker maker = fieldNode.getTreeMaker();
 		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 		

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
@@ -1,8 +1,16 @@
 import java.util.List;
 public class SuperBuilderWithDefaults {
 	public static class Parent<N extends Number> {
-		private long millis = System.currentTimeMillis();
-		private N numberField = null;
+		private long millis;
+		private N numberField;
+		@java.lang.SuppressWarnings("all")
+		private static <N extends Number> long $default$millis() {
+			return System.currentTimeMillis();
+		}
+		@java.lang.SuppressWarnings("all")
+		private static <N extends Number> N $default$numberField() {
+			return null;
+		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ParentBuilder<N extends Number, C extends Parent<N>, B extends ParentBuilder<N, C, B>> {
 			@java.lang.SuppressWarnings("all")
@@ -53,8 +61,10 @@ public class SuperBuilderWithDefaults {
 		}
 		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<N, ?, ?> b) {
-			if (b.millis$set) this.millis = b.millis;
-			if (b.numberField$set) this.numberField = b.numberField;
+			this.millis = b.millis;
+			if (!b.millis$set) this.millis = Parent.<N>$default$millis();
+			this.numberField = b.numberField;
+			if (!b.numberField$set) this.numberField = Parent.<N>$default$numberField();
 		}
 		@java.lang.SuppressWarnings("all")
 		public static <N extends Number> ParentBuilder<N, ?, ?> builder() {
@@ -62,7 +72,11 @@ public class SuperBuilderWithDefaults {
 		}
 	}
 	public static class Child extends Parent<Integer> {
-		private double doubleField = Math.PI;
+		private double doubleField;
+		@java.lang.SuppressWarnings("all")
+		private static double $default$doubleField() {
+			return Math.PI;
+		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
 			@java.lang.SuppressWarnings("all")
@@ -106,7 +120,8 @@ public class SuperBuilderWithDefaults {
 		@java.lang.SuppressWarnings("all")
 		protected Child(final ChildBuilder<?, ?> b) {
 			super(b);
-			if (b.doubleField$set) this.doubleField = b.doubleField;
+			this.doubleField = b.doubleField;
+			if (!b.doubleField$set) this.doubleField = Child.$default$doubleField();
 		}
 		@java.lang.SuppressWarnings("all")
 		public static ChildBuilder<?, ?> builder() {

--- a/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
@@ -36,14 +36,22 @@ public class SuperBuilderWithDefaults {
         return new Parent<N>(this);
       }
     }
-    private @lombok.Builder.Default long millis = System.currentTimeMillis();
-    private @lombok.Builder.Default N numberField = null;
+    private @lombok.Builder.Default long millis;
+    private @lombok.Builder.Default N numberField;
+    private static @java.lang.SuppressWarnings("all") <N extends Number>long $default$millis() {
+      return System.currentTimeMillis();
+    }
+    private static @java.lang.SuppressWarnings("all") <N extends Number>N $default$numberField() {
+      return null;
+    }
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<N, ?, ?> b) {
       super();
-      if (b.millis$set)
-          this.millis = b.millis;
-      if (b.numberField$set)
-          this.numberField = b.numberField;
+      this.millis = b.millis;
+      if ((! b.millis$set))
+          this.millis = Parent.<N>$default$millis();
+      this.numberField = b.numberField;
+      if ((! b.numberField$set)) 
+          this.numberField = Parent.<N>$default$numberField();
     }
     public static @java.lang.SuppressWarnings("all") <N extends Number>ParentBuilder<N, ?, ?> builder() {
       return new ParentBuilderImpl<N>();
@@ -78,11 +86,15 @@ public class SuperBuilderWithDefaults {
         return new Child(this);
       }
     }
-    private @lombok.Builder.Default double doubleField = Math.PI;
+    private @lombok.Builder.Default double doubleField;
+    private static @java.lang.SuppressWarnings("all") double $default$doubleField() {
+      return Math.PI;
+    }
     protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
       super(b);
-      if (b.doubleField$set)
-          this.doubleField = b.doubleField;
+      this.doubleField = b.doubleField;
+      if ((! b.doubleField$set)) 
+          this.doubleField = Child.$default$doubleField();
     }
     public static @java.lang.SuppressWarnings("all") ChildBuilder<?, ?> builder() {
       return new ChildBuilderImpl();


### PR DESCRIPTION
With this change, `@SuperBuilder` uses the same behavior as `@Builder` for fields annotated with `@Builder.Default`. In particular, it generates a `$default$field()` method that is called if there was no explicit set of the respective field. The initializing expression is moved from the field into this method.
See also issue #1347.