### PR TITLE
SuperBuilder fix for Builder.Default, final, and NonNull fields

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -48,7 +48,6 @@ import org.eclipse.jdt.internal.compiler.ast.FieldReference;
 import org.eclipse.jdt.internal.compiler.ast.IfStatement;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
-import org.eclipse.jdt.internal.compiler.ast.OperatorIds;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedQualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedSingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedNameReference;
@@ -61,7 +60,6 @@ import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
-import org.eclipse.jdt.internal.compiler.ast.UnaryExpression;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
@@ -456,7 +454,6 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		constructor.arguments = new Argument[] {new Argument("b".toCharArray(), p, builderType, Modifier.FINAL)};
 		
 		List<Statement> statements = new ArrayList<Statement>();
-		List<Statement> nullChecks = new ArrayList<Statement>();
 		
 		for (BuilderFieldData fieldNode : builderFields) {
 			char[] fieldName = removePrefixFromField(fieldNode.originalFieldNode);
@@ -475,7 +472,6 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 				assignmentExpr = new QualifiedNameReference(variableInBuilder, positions, s, e);
 			}
 			Statement assignment = new Assignment(fieldInThis, assignmentExpr, (int) p);
-			statements.add(assignment);
 			
 			// In case of @Builder.Default, set the value to the default if it was NOT set in the builder.
 			if (fieldNode.nameOfSetFlag != null) {
@@ -483,29 +479,30 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 				long[] positions = new long[] {p, p};
 				QualifiedNameReference setVariableInBuilderRef = new QualifiedNameReference(setVariableInBuilder, positions, s, e);
 
-				MessageSend inv = new MessageSend();
-				inv.sourceStart = source.sourceStart;
-				inv.sourceEnd = source.sourceEnd;
-				inv.receiver = new SingleNameReference(((TypeDeclaration) typeNode.get()).name, 0L);
-				inv.selector = fieldNode.nameOfDefaultProvider;
-				inv.typeArguments = typeParameterNames(((TypeDeclaration) typeNode.get()).typeParameters);
+				MessageSend defaultMethodCall = new MessageSend();
+				defaultMethodCall.sourceStart = source.sourceStart;
+				defaultMethodCall.sourceEnd = source.sourceEnd;
+				defaultMethodCall.receiver = new SingleNameReference(((TypeDeclaration) typeNode.get()).name, 0L);
+				defaultMethodCall.selector = fieldNode.nameOfDefaultProvider;
+				defaultMethodCall.typeArguments = typeParameterNames(((TypeDeclaration) typeNode.get()).typeParameters);
 				
-				assignment = new Assignment(fieldInThis, inv, (int) p);
-				IfStatement ifBlockForDefault = new IfStatement(new UnaryExpression(setVariableInBuilderRef, OperatorIds.NOT), assignment, s, e);
+				Statement defaultAssignment = new Assignment(fieldInThis, defaultMethodCall, (int) p);
+				IfStatement ifBlockForDefault = new IfStatement(setVariableInBuilderRef, assignment, defaultAssignment, s, e);
 				statements.add(ifBlockForDefault);
+			} else {
+				statements.add(assignment);
 			}
 			
 			Annotation[] nonNulls = findAnnotations((FieldDeclaration)fieldNode.originalFieldNode.get(), NON_NULL_PATTERN);
 			if (nonNulls.length != 0) {
 				Statement nullCheck = generateNullCheck((FieldDeclaration)fieldNode.originalFieldNode.get(), sourceNode);
 				if (nullCheck != null) {
-					nullChecks.add(nullCheck);
+					statements.add(nullCheck);
 				}
 			}
 		}
 		
-		nullChecks.addAll(statements);
-		constructor.statements = nullChecks.isEmpty() ? null : nullChecks.toArray(new Statement[nullChecks.size()]);
+		constructor.statements = statements.isEmpty() ? null : statements.toArray(new Statement[statements.size()]);
 		
 		constructor.traverse(new SetGeneratedByVisitor(source), typeDeclaration.scope);
 		

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -595,7 +595,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), type.toName(buildName), returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), thrownExceptions, body, null);
 	}
 	
-	public JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
+	public static JCMethodDecl generateDefaultProvider(Name methodName, JavacNode fieldNode, List<JCTypeParameter> params) {
 		JavacTreeMaker maker = fieldNode.getTreeMaker();
 		JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 		

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -406,17 +406,10 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		
 		AccessLevel level = AccessLevel.PROTECTED;
 		
-		ListBuffer<JCStatement> nullChecks = new ListBuffer<JCStatement>();
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		
 		Name builderVariableName = typeNode.toName("b");
 		for (BuilderFieldData bfd : builderFields) {
-			List<JCAnnotation> nonNulls = findAnnotations(bfd.originalFieldNode, NON_NULL_PATTERN);
-			if (!nonNulls.isEmpty()) {
-				JCStatement nullCheck = generateNullCheck(maker, bfd.originalFieldNode, source);
-				if (nullCheck != null) nullChecks.append(nullCheck);
-			}
-			
 			JCExpression rhs;
 			if (bfd.singularData != null && bfd.singularData.getSingularizer() != null) {
 				bfd.singularData.getSingularizer().appendBuildCode(bfd.singularData, bfd.originalFieldNode, bfd.type, statements, bfd.name, "b");
@@ -435,6 +428,12 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 				fieldInThis = maker.Select(maker.Ident(typeNode.toName("this")), bfd.rawName);
 				JCAssign assignDefault = maker.Assign(fieldInThis, maker.Apply(typeParameterNames(maker, ((JCClassDecl) typeNode.get()).typarams), maker.Select(maker.Ident(((JCClassDecl) typeNode.get()).name), bfd.nameOfDefaultProvider), List.<JCExpression>nil()));
 				statements.append(maker.If(maker.Unary(CTC_NOT, setField), maker.Exec(assignDefault), null));
+			}
+			
+			List<JCAnnotation> nonNulls = findAnnotations(bfd.originalFieldNode, NON_NULL_PATTERN);
+			if (!nonNulls.isEmpty()) {
+				JCStatement nullCheck = generateNullCheck(maker, bfd.originalFieldNode, source);
+				if (nullCheck != null) statements.append(nullCheck);
 			}
 		}
 		
@@ -465,7 +464,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		
 		JCMethodDecl constr = recursiveSetGeneratedBy(maker.MethodDef(mods, typeNode.toName("<init>"),
 			null, List.<JCTypeParameter>nil(), params.toList(), List.<JCExpression>nil(),
-			maker.Block(0L, nullChecks.appendList(statements).toList()), null), source.get(), typeNode.getContext());
+			maker.Block(0L, statements.toList()), null), source.get(), typeNode.getContext());
 		
 		injectMethod(typeNode, constr, null, Javac.createVoidType(typeNode.getSymbolTable(), CTC_VOID));
 	}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -420,14 +420,15 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			JCFieldAccess fieldInThis = maker.Select(maker.Ident(typeNode.toName("this")), bfd.rawName);
 			
 			JCStatement assign = maker.Exec(maker.Assign(fieldInThis, rhs));
-			statements.append(assign);
 			
-			// In case of @Builder.Default, set the value to the default if it was NOT set in the builder.
+			// In case of @Builder.Default, set the value to the default if it was not set in the builder.
 			if (bfd.nameOfSetFlag != null) {
 				JCFieldAccess setField = maker.Select(maker.Ident(builderVariableName), bfd.nameOfSetFlag);
 				fieldInThis = maker.Select(maker.Ident(typeNode.toName("this")), bfd.rawName);
 				JCAssign assignDefault = maker.Assign(fieldInThis, maker.Apply(typeParameterNames(maker, ((JCClassDecl) typeNode.get()).typarams), maker.Select(maker.Ident(((JCClassDecl) typeNode.get()).name), bfd.nameOfDefaultProvider), List.<JCExpression>nil()));
-				statements.append(maker.If(maker.Unary(CTC_NOT, setField), maker.Exec(assignDefault), null));
+				statements.append(maker.If(setField, assign, maker.Exec(assignDefault)));
+			} else {
+				statements.append(assign);
 			}
 			
 			List<JCAnnotation> nonNulls = findAnnotations(bfd.originalFieldNode, NON_NULL_PATTERN);

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
@@ -61,10 +61,10 @@ public class SuperBuilderWithDefaults {
 		}
 		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<N, ?, ?> b) {
-			this.millis = b.millis;
-			if (!b.millis$set) this.millis = Parent.<N>$default$millis();
-			this.numberField = b.numberField;
-			if (!b.numberField$set) this.numberField = Parent.<N>$default$numberField();
+			if (b.millis$set) this.millis = b.millis;
+			 else this.millis = Parent.<N>$default$millis();
+			if (b.numberField$set) this.numberField = b.numberField; 
+			 else this.numberField = Parent.<N>$default$numberField();
 		}
 		@java.lang.SuppressWarnings("all")
 		public static <N extends Number> ParentBuilder<N, ?, ?> builder() {
@@ -120,8 +120,8 @@ public class SuperBuilderWithDefaults {
 		@java.lang.SuppressWarnings("all")
 		protected Child(final ChildBuilder<?, ?> b) {
 			super(b);
-			this.doubleField = b.doubleField;
-			if (!b.doubleField$set) this.doubleField = Child.$default$doubleField();
+			if (b.doubleField$set) this.doubleField = b.doubleField;
+			 else this.doubleField = Child.$default$doubleField();
 		}
 		@java.lang.SuppressWarnings("all")
 		public static ChildBuilder<?, ?> builder() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
@@ -1,8 +1,16 @@
 import java.util.List;
 public class SuperBuilderWithDefaults {
 	public static class Parent<N extends Number> {
-		private long millis = System.currentTimeMillis();
-		private N numberField = null;
+		private long millis;
+		private N numberField;
+		@java.lang.SuppressWarnings("all")
+		private static <N extends Number> long $default$millis() {
+			return System.currentTimeMillis();
+		}
+		@java.lang.SuppressWarnings("all")
+		private static <N extends Number> N $default$numberField() {
+			return null;
+		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ParentBuilder<N extends Number, C extends Parent<N>, B extends ParentBuilder<N, C, B>> {
 			@java.lang.SuppressWarnings("all")
@@ -53,8 +61,10 @@ public class SuperBuilderWithDefaults {
 		}
 		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<N, ?, ?> b) {
-			if (b.millis$set) this.millis = b.millis;
-			if (b.numberField$set) this.numberField = b.numberField;
+			this.millis = b.millis;
+			if (!b.millis$set) this.millis = Parent.<N>$default$millis();
+			this.numberField = b.numberField;
+			if (!b.numberField$set) this.numberField = Parent.<N>$default$numberField();
 		}
 		@java.lang.SuppressWarnings("all")
 		public static <N extends Number> ParentBuilder<N, ?, ?> builder() {
@@ -62,7 +72,11 @@ public class SuperBuilderWithDefaults {
 		}
 	}
 	public static class Child extends Parent<Integer> {
-		private double doubleField = Math.PI;
+		private double doubleField;
+		@java.lang.SuppressWarnings("all")
+		private static double $default$doubleField() {
+			return Math.PI;
+		}
 		@java.lang.SuppressWarnings("all")
 		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
 			@java.lang.SuppressWarnings("all")
@@ -106,7 +120,8 @@ public class SuperBuilderWithDefaults {
 		@java.lang.SuppressWarnings("all")
 		protected Child(final ChildBuilder<?, ?> b) {
 			super(b);
-			if (b.doubleField$set) this.doubleField = b.doubleField;
+			this.doubleField = b.doubleField;
+			if (!b.doubleField$set) this.doubleField = Child.$default$doubleField();
 		}
 		@java.lang.SuppressWarnings("all")
 		public static ChildBuilder<?, ?> builder() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithNonNull.java
@@ -1,0 +1,117 @@
+import java.util.List;
+public class SuperBuilderWithNonNull {
+	public static class Parent {
+		@lombok.NonNull
+		String nonNullParentField;
+		@java.lang.SuppressWarnings("all")
+		private static String $default$nonNullParentField() {
+			return "default";
+		}
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private boolean nonNullParentField$set;
+			@java.lang.SuppressWarnings("all")
+			private String nonNullParentField;
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B nonNullParentField(final String nonNullParentField) {
+				this.nonNullParentField = nonNullParentField;
+				nonNullParentField$set = true;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithNonNull.Parent.ParentBuilder(nonNullParentField=" + this.nonNullParentField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ParentBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Parent build() {
+				return new Parent(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final ParentBuilder<?, ?> b) {
+			this.nonNullParentField = b.nonNullParentField;
+			if (!b.nonNullParentField$set) this.nonNullParentField = Parent.$default$nonNullParentField();
+			if (nonNullParentField == null) {
+				throw new java.lang.NullPointerException("nonNullParentField is marked @NonNull but is null");
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		public static ParentBuilder<?, ?> builder() {
+			return new ParentBuilderImpl();
+		}
+	}
+	public static class Child extends Parent {
+		@lombok.NonNull
+		String nonNullChildField;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+			@java.lang.SuppressWarnings("all")
+			private String nonNullChildField;
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.SuppressWarnings("all")
+			public B nonNullChildField(final String nonNullChildField) {
+				this.nonNullChildField = nonNullChildField;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithNonNull.Child.ChildBuilder(super=" + super.toString() + ", nonNullChildField=" + this.nonNullChildField + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected ChildBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public Child build() {
+				return new Child(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final ChildBuilder<?, ?> b) {
+			super(b);
+			this.nonNullChildField = b.nonNullChildField;
+			if (nonNullChildField == null) {
+				throw new java.lang.NullPointerException("nonNullChildField is marked @NonNull but is null");
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		public static ChildBuilder<?, ?> builder() {
+			return new ChildBuilderImpl();
+		}
+	}
+	public static void test() {
+		Child x = Child.builder().nonNullChildField("child").nonNullParentField("parent").build();
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithNonNull.java
@@ -2,7 +2,7 @@ import java.util.List;
 public class SuperBuilderWithNonNull {
 	public static class Parent {
 		@lombok.NonNull
-		String nonNullParentField;
+		final String nonNullParentField;
 		@java.lang.SuppressWarnings("all")
 		private static String $default$nonNullParentField() {
 			return "default";
@@ -47,8 +47,8 @@ public class SuperBuilderWithNonNull {
 		}
 		@java.lang.SuppressWarnings("all")
 		protected Parent(final ParentBuilder<?, ?> b) {
-			this.nonNullParentField = b.nonNullParentField;
-			if (!b.nonNullParentField$set) this.nonNullParentField = Parent.$default$nonNullParentField();
+			if (b.nonNullParentField$set) this.nonNullParentField = b.nonNullParentField;
+			 else this.nonNullParentField = Parent.$default$nonNullParentField();
 			if (nonNullParentField == null) {
 				throw new java.lang.NullPointerException("nonNullParentField is marked @NonNull but is null");
 			}

--- a/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
@@ -36,14 +36,22 @@ public class SuperBuilderWithDefaults {
         return new Parent<N>(this);
       }
     }
-    private @lombok.Builder.Default long millis = System.currentTimeMillis();
-    private @lombok.Builder.Default N numberField = null;
+    private @lombok.Builder.Default long millis;
+    private @lombok.Builder.Default N numberField;
+    private static @java.lang.SuppressWarnings("all") <N extends Number>long $default$millis() {
+      return System.currentTimeMillis();
+    }
+    private static @java.lang.SuppressWarnings("all") <N extends Number>N $default$numberField() {
+      return null;
+    }
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<N, ?, ?> b) {
       super();
-      if (b.millis$set)
-          this.millis = b.millis;
-      if (b.numberField$set)
-          this.numberField = b.numberField;
+      this.millis = b.millis;
+      if ((! b.millis$set))
+          this.millis = Parent.<N>$default$millis();
+      this.numberField = b.numberField;
+      if ((! b.numberField$set)) 
+          this.numberField = Parent.<N>$default$numberField();
     }
     public static @java.lang.SuppressWarnings("all") <N extends Number>ParentBuilder<N, ?, ?> builder() {
       return new ParentBuilderImpl<N>();
@@ -78,11 +86,15 @@ public class SuperBuilderWithDefaults {
         return new Child(this);
       }
     }
-    private @lombok.Builder.Default double doubleField = Math.PI;
+    private @lombok.Builder.Default double doubleField;
+    private static @java.lang.SuppressWarnings("all") double $default$doubleField() {
+      return Math.PI;
+    }
     protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
       super(b);
-      if (b.doubleField$set)
-          this.doubleField = b.doubleField;
+      this.doubleField = b.doubleField;
+      if ((! b.doubleField$set)) 
+          this.doubleField = Child.$default$doubleField();
     }
     public static @java.lang.SuppressWarnings("all") ChildBuilder<?, ?> builder() {
       return new ChildBuilderImpl();

--- a/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
@@ -46,11 +46,13 @@ public class SuperBuilderWithDefaults {
     }
     protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<N, ?, ?> b) {
       super();
-      this.millis = b.millis;
-      if ((! b.millis$set))
+      if (b.millis$set)
+          this.millis = b.millis;
+      else
           this.millis = Parent.<N>$default$millis();
-      this.numberField = b.numberField;
-      if ((! b.numberField$set)) 
+      if (b.numberField$set)
+          this.numberField = b.numberField;
+      else
           this.numberField = Parent.<N>$default$numberField();
     }
     public static @java.lang.SuppressWarnings("all") <N extends Number>ParentBuilder<N, ?, ?> builder() {
@@ -92,8 +94,9 @@ public class SuperBuilderWithDefaults {
     }
     protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
       super(b);
-      this.doubleField = b.doubleField;
-      if ((! b.doubleField$set)) 
+      if (b.doubleField$set) 
+          this.doubleField = b.doubleField;
+      else
           this.doubleField = Child.$default$doubleField();
     }
     public static @java.lang.SuppressWarnings("all") ChildBuilder<?, ?> builder() {

--- a/test/transform/resource/after-ecj/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithNonNull.java
@@ -1,0 +1,97 @@
+import java.util.List;
+public class SuperBuilderWithNonNull {
+  public static @lombok.experimental.SuperBuilder class Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<C extends Parent, B extends ParentBuilder<C, B>> {
+      private @java.lang.SuppressWarnings("all") String nonNullParentField;
+      private @java.lang.SuppressWarnings("all") boolean nonNullParentField$set;
+      public ParentBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B nonNullParentField(final String nonNullParentField) {
+        this.nonNullParentField = nonNullParentField;
+        nonNullParentField$set = true;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderWithNonNull.Parent.ParentBuilder(nonNullParentField=" + this.nonNullParentField) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends ParentBuilder<Parent, ParentBuilderImpl> {
+      private ParentBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Parent build() {
+        return new Parent(this);
+      }
+    }
+    final @lombok.NonNull @lombok.Builder.Default String nonNullParentField;
+    private static @java.lang.SuppressWarnings("all") String $default$nonNullParentField() {
+      return "default";
+    }
+    protected @java.lang.SuppressWarnings("all") Parent(final ParentBuilder<?, ?> b) {
+      super();
+      if (b.nonNullParentField$set)
+          this.nonNullParentField = b.nonNullParentField;
+      else
+          this.nonNullParentField = Parent.$default$nonNullParentField();
+      if ((nonNullParentField == null))
+          {
+            throw new java.lang.NullPointerException("nonNullParentField is marked @NonNull but is null");
+          }
+    }
+    public static @java.lang.SuppressWarnings("all") ParentBuilder<?, ?> builder() {
+      return new ParentBuilderImpl();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class Child extends Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<C extends Child, B extends ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+      private @java.lang.SuppressWarnings("all") String nonNullChildField;
+      public ChildBuilder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.SuppressWarnings("all") B nonNullChildField(final String nonNullChildField) {
+        this.nonNullChildField = nonNullChildField;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithNonNull.Child.ChildBuilder(super=" + super.toString()) + ", nonNullChildField=") + this.nonNullChildField) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends ChildBuilder<Child, ChildBuilderImpl> {
+      private ChildBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") Child build() {
+        return new Child(this);
+      }
+    }
+    @lombok.NonNull String nonNullChildField;
+    protected @java.lang.SuppressWarnings("all") Child(final ChildBuilder<?, ?> b) {
+      super(b);
+      this.nonNullChildField = b.nonNullChildField;
+      if ((nonNullChildField == null))
+          {
+            throw new java.lang.NullPointerException("nonNullChildField is marked @NonNull but is null");
+          }
+    }
+    public static @java.lang.SuppressWarnings("all") ChildBuilder<?, ?> builder() {
+      return new ChildBuilderImpl();
+    }
+  }
+  public SuperBuilderWithNonNull() {
+    super();
+  }
+  public static void test() {
+    Child x = Child.builder().nonNullChildField("child").nonNullParentField("parent").build();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/before/SuperBuilderWithNonNull.java
@@ -1,0 +1,20 @@
+import java.util.List;
+
+public class SuperBuilderWithNonNull {
+	@lombok.experimental.SuperBuilder
+	public static class Parent {
+		@lombok.NonNull
+		@lombok.Builder.Default
+		String nonNullParentField = "default";
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class Child extends Parent {
+		@lombok.NonNull
+		String nonNullChildField;
+	}
+	
+	public static void test() {
+		Child x = Child.builder().nonNullChildField("child").nonNullParentField("parent").build();
+	}
+}

--- a/test/transform/resource/before/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/before/SuperBuilderWithNonNull.java
@@ -5,7 +5,7 @@ public class SuperBuilderWithNonNull {
 	public static class Parent {
 		@lombok.NonNull
 		@lombok.Builder.Default
-		String nonNullParentField = "default";
+		final String nonNullParentField = "default";
 	}
 	
 	@lombok.experimental.SuperBuilder


### PR DESCRIPTION
With this change, `@SuperBuilder` works also for fields that are `final` and `@Builder.Default`. Furthermore, the `@NonNull` code also checks the default value for `!= null`.
This fixes #1800.

This PR includes PR #1818, so you may want to review/merge #1818 first (or just review/merge this one to have it all).