### PR TITLE
Allow jitpack to use JDK 10 when building lombok

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,6 @@
 jdk:
-- openjdk9
-before_install:
-- export JAVA_HOME=/usr/lib/jvm/java-9-oracle
+- openjdk10
+# before_install:
+# - export JAVA_HOME=/usr/lib/jvm/java-10-oracle
+# - echo "******Ant Version********"
+# - ant -version


### PR DESCRIPTION
Subsequent to #1780 

Sample build outcome:
https://jitpack.io/com/github/mmoayyed/lombok/jitpack11-v1.18.0-gcf9f25a-152/build.log