### PR TITLE
SuperBuilder self() method signature generics fix

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -338,7 +338,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		}
 		
 		// Create the self() and build() methods in the BuilderImpl.
-		injectMethod(builderImplType, generateSelfMethod(builderImplType));
+		injectMethod(builderImplType, generateSelfMethod(builderImplType, typeParams, p));
 		injectMethod(builderImplType, generateBuildMethod(tdParent, buildMethodName, returnType, ast));
 		
 		// Add the builder() method to the annotated class.
@@ -536,13 +536,13 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		return out;
 	}
 	
-	private MethodDeclaration generateSelfMethod(EclipseNode builderImplType) {
+	private MethodDeclaration generateSelfMethod(EclipseNode builderImplType, TypeParameter[] typeParams, long p) {
 		MethodDeclaration out = new MethodDeclaration(((CompilationUnitDeclaration) builderImplType.top().get()).compilationResult);
 		out.selector = SELF_METHOD_NAME;
 		out.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 		out.modifiers = ClassFileConstants.AccProtected;
 		out.annotations = new Annotation[] {makeMarkerAnnotation(TypeConstants.JAVA_LANG_OVERRIDE, builderImplType.get())};
-		out.returnType = new SingleTypeReference(builderImplType.getName().toCharArray(), 0);
+		out.returnType = namePlusTypeParamsToTypeReference(builderImplType.getName().toCharArray(), typeParams, p);
 		out.statements = new Statement[] {new ReturnStatement(new ThisReference(0, 0), 0, 0)};
 		return out;
 	}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -289,7 +289,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			if (cd != null) injectMethod(builderImplType, cd);
 			
 			// Create the self() and build() methods in the BuilderImpl.
-			injectMethod(builderImplType, generateSelfMethod(builderImplType));
+			injectMethod(builderImplType, generateSelfMethod(builderImplType, typeParams));
 			injectMethod(builderImplType, generateBuildMethod(buildMethodName, returnType, builderImplType, thrownExceptions));
 			
 			recursiveSetGeneratedBy(builderImplType.get(), ast, annotationNode.getContext());
@@ -512,14 +512,14 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), null, null);
 	}
 	
-	private JCMethodDecl generateSelfMethod(JavacNode builderImplType) {
+	private JCMethodDecl generateSelfMethod(JavacNode builderImplType, List<JCTypeParameter> typeParams) {
 		JavacTreeMaker maker = builderImplType.getTreeMaker();
 		
 		JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(builderImplType, "Override"), List.<JCExpression>nil());
 		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED, List.of(overrideAnnotation));
 		Name name = builderImplType.toName(SELF_METHOD);
-		JCExpression returnType = maker.Ident(builderImplType.toName(builderImplType.getName()));
 		
+		JCExpression returnType = namePlusTypeParamsToTypeReference(maker, builderImplType.toName(builderImplType.getName()), typeParams);
 		JCStatement statement = maker.Return(maker.Ident(builderImplType.toName("this")));
 		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
 		

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -48,7 +48,7 @@ public class SuperBuilderWithGenerics {
 			}
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected ParentBuilderImpl self() {
+			protected ParentBuilderImpl<A> self() {
 				return this;
 			}
 			@java.lang.Override
@@ -108,7 +108,7 @@ public class SuperBuilderWithGenerics {
 			}
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected ChildBuilderImpl self() {
+			protected ChildBuilderImpl<A> self() {
 				return this;
 			}
 			@java.lang.Override

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics2.java
@@ -48,7 +48,7 @@ public class SuperBuilderWithGenerics2 {
 			}
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected ParentBuilderImpl self() {
+			protected ParentBuilderImpl<A> self() {
 				return this;
 			}
 			@java.lang.Override
@@ -108,7 +108,7 @@ public class SuperBuilderWithGenerics2 {
 			}
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected ChildBuilderImpl self() {
+			protected ChildBuilderImpl<A> self() {
 				return this;
 			}
 			@java.lang.Override

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
@@ -38,7 +38,7 @@ public class SuperBuilderWithGenerics {
       private ParentBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl<A> self() {
         return this;
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") Parent<A> build() {
@@ -87,7 +87,7 @@ public class SuperBuilderWithGenerics {
       private ChildBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl<A> self() {
         return this;
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") Child<A> build() {

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
@@ -38,7 +38,7 @@ public class SuperBuilderWithGenerics2 {
       private ParentBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ParentBuilderImpl<A> self() {
         return this;
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") Parent<A> build() {
@@ -87,7 +87,7 @@ public class SuperBuilderWithGenerics2 {
       private ChildBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") ChildBuilderImpl<A> self() {
         return this;
       }
       public @java.lang.Override @java.lang.SuppressWarnings("all") Child<A> build() {


### PR DESCRIPTION
The `self()` method in the `@SuperBuilder` implementation class lacked generics on the return type. As the implementation class is private and only the abstract class is visible to users, this did not affect user experience, but resulted in a compiler warning when using the delomboked code.

This fix adds the generics to the methods, avoiding the (typically suppressed) compiler warning.
