### PR TITLE
Fix code example for @UtilityClass

### DIFF
--- a/website/usageExamples/experimental/UtilityClassExample_post.jpage
+++ b/website/usageExamples/experimental/UtilityClassExample_post.jpage
@@ -5,7 +5,7 @@ public final class UtilityClassExample {
 		throw new java.lang.UnsupportedOperationException("This is a utility class and cannot be instantiated");
 	}
 
-	public static void addSomething(int in) {
+	public static int addSomething(int in) {
 		return in + CONSTANT;
 	}
 }

--- a/website/usageExamples/experimental/UtilityClassExample_pre.jpage
+++ b/website/usageExamples/experimental/UtilityClassExample_pre.jpage
@@ -4,7 +4,7 @@ import lombok.experimental.UtilityClass;
 public class UtilityClassExample {
 	private final int CONSTANT = 5;
 
-	public void addSomething(int in) {
+	public int addSomething(int in) {
 		return in + CONSTANT;
 	}
 }


### PR DESCRIPTION
Method in code example (https://projectlombok.org/features/experimental/UtilityClass) has `void` return type instead of `int`.