### PR TITLE
correct issueManagement declaration in maven POM

### DIFF
--- a/doc/utils-maven-pom.xml
+++ b/doc/utils-maven-pom.xml
@@ -21,8 +21,8 @@
 		<url>http://github.com/rzwitserloot/lombok</url>
 	</scm>
 	<issueManagement>
-		<system>Google Code</system>
-		<url>http://code.google.com/p/projectlombok/issues</url>
+		<system>GitHub Issues</system>
+		<url>https://github.com/rzwitserloot/lombok/issues</url>
 	</issueManagement>
 	<developers>
 		<developer>


### PR DESCRIPTION
Motivation

The published maven POM for lombok refers to Google Code for issue
management (see [here](https://search.maven.org/artifact/org.projectlombok/lombok/1.18.2/pom)). Google code is no longer active.

Changes
- replace with github issues for issue management