### PR TITLE
Make Javac9BaseFileObjectWrapper implement JavaFileObject instead of extending PathFileObject

### DIFF
--- a/src/core/lombok/javac/apt/Javac9BaseFileObjectWrapper.java
+++ b/src/core/lombok/javac/apt/Javac9BaseFileObjectWrapper.java
@@ -28,18 +28,14 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URI;
-import java.nio.file.Path;
 
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.NestingKind;
 
-import com.sun.tools.javac.file.BaseFileManager;
-
-class Javac9BaseFileObjectWrapper extends com.sun.tools.javac.file.PathFileObject {
+class Javac9BaseFileObjectWrapper implements javax.tools.JavaFileObject {
 	private final LombokFileObject delegate;
 	
-	public Javac9BaseFileObjectWrapper(BaseFileManager fileManager, Path path, LombokFileObject delegate) {
-		super(fileManager, path);
+	public Javac9BaseFileObjectWrapper(LombokFileObject delegate) {
 		this.delegate = delegate;
 	}
 	

--- a/src/core/lombok/javac/apt/LombokFileObjects.java
+++ b/src/core/lombok/javac/apt/LombokFileObjects.java
@@ -24,9 +24,6 @@ package lombok.javac.apt;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -168,25 +165,13 @@ final class LombokFileObjects {
 		}
 		
 		@Override public JavaFileObject wrap(LombokFileObject fileObject) {
-			return new Javac9BaseFileObjectWrapper(fileManager, toPath(fileObject), fileObject);
+			return new Javac9BaseFileObjectWrapper(fileObject);
 		}
 		
 		@Override public Method getDecoderMethod() {
 			return null;
 		}
-		
-		private static Path toPath(LombokFileObject fileObject) {
-			URI uri = fileObject.toUri();
-			if (uri.getScheme() == null) {
-				uri = URI.create("file:///" + uri);
-			}
-			try {
-				return Paths.get(uri);
-			} catch (IllegalArgumentException e) {
-				throw new IllegalArgumentException("Problems in URI '" + uri + "' (" + fileObject.toUri() + ")", e);
-			}
-		}
-		
+
 		private static BaseFileManager asBaseFileManager(JavaFileManager jfm) {
 			if (jfm instanceof BaseFileManager) {
 				return (BaseFileManager) jfm;


### PR DESCRIPTION
- `Javac9BaseFileObjectWrapper` doesn’t use any `PathFileObject` api’s instead it just calls the delegate
- `PathFileObject` requires a path object during initialization which is unnecessary. 
- Using lombok + errorprone + buck works but fails for `jar_spool_mode` (https://buckbuild.com/files-and-dirs/buckconfig.html#java.jar_spool_mode) as `direct_to_jar`. This is because buck doesn’t materialize class files to disk causing the below exception.
```
Build failed: Command failed with exit code 1.
stderr: An exception has occurred in the compiler ((version info not available)). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program and the following diagnostic in your report. Thank you.
java.nio.file.FileSystemNotFoundException
	at com.sun.nio.zipfs.ZipFileSystemProvider.getFileSystem(ZipFileSystemProvider.java:171)
	at com.sun.nio.zipfs.ZipFileSystemProvider.getPath(ZipFileSystemProvider.java:157)
	at java.nio.file.Paths.get(Paths.java:143)
	at lombok.javac.apt.LombokFileObjects$Java9Compiler.toPath(LombokFileObjects.java:185)
	at lombok.javac.apt.LombokFileObjects$Java9Compiler.wrap(LombokFileObjects.java:172)
	at lombok.javac.apt.LombokFileObjects.createIntercepting(LombokFileObjects.java:161)
	at lombok.javac.apt.InterceptingJavaFileManager.getJavaFileForOutput(InterceptingJavaFileManager.java:53)
	at com.sun.tools.javac.jvm.ClassWriter.writeClass(ClassWriter.java:1673)
	at com.sun.tools.javac.main.JavaCompiler.genCode(JavaCompiler.java:743)
	at com.sun.tools.javac.main.JavaCompiler.generate(JavaCompiler.java:1641)
	at com.sun.tools.javac.main.JavaCompiler.generate(JavaCompiler.java:1609)
	at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:952)
	at com.sun.tools.javac.api.JavacTaskImpl.lambda$doCall$0(JavacTaskImpl.java:100)
	at com.sun.tools.javac.api.JavacTaskImpl.handleExceptions(JavacTaskImpl.java:142)
	at com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:96)
	at com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:90)
	at com.facebook.buck.jvm.java.plugin.adapter.JavacTaskWrapper.call(JavacTaskWrapper.java:96)
	at com.facebook.buck.jvm.java.plugin.adapter.BuckJavacTask.call(BuckJavacTask.java:53)
	at com.facebook.buck.jvm.java.plugin.adapter.BuckJavacTaskProxyImpl.call(BuckJavacTaskProxyImpl.java:131)
	at com.facebook.buck.jvm.java.Jsr199JavacInvocation$CompilerWorker.lambda$startCompiler$2(Jsr199JavacInvocation.java:420)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:127)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:57)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

    When running <javac_jar>.
    When building rule //vanilla:src_main.
```

- Repro case:
-- Clone `git@github.com:raviagarwal7/lombok-ep-minimal.git`
-- `./buckw build //vanilla/...` works
-- `./buckw build //vanilla/... --config java.jar_spool_mode=direct_to_jar` fails