### PR TITLE
Copy Javadoc to builder setters

### DIFF
--- a/src/core/lombok/javac/JavacAugments.java
+++ b/src/core/lombok/javac/JavacAugments.java
@@ -21,9 +21,11 @@
  */
 package lombok.javac;
 
+import java.util.Set;
 import lombok.core.FieldAugment;
 
 import com.sun.tools.javac.tree.JCTree;
+import lombok.javac.handlers.JavacHandlerUtil.CopyJavadoc;
 
 public final class JavacAugments {
 	private JavacAugments() {
@@ -32,4 +34,5 @@ public final class JavacAugments {
 	
 	public static final FieldAugment<JCTree, Boolean> JCTree_handled = FieldAugment.augment(JCTree.class, boolean.class, "lombok$handled");
 	public static final FieldAugment<JCTree, JCTree> JCTree_generatedNode = FieldAugment.circularSafeAugment(JCTree.class, JCTree.class, "lombok$generatedNode");
+	public static final FieldAugment<JCTree, Set<CopyJavadoc>> JCTree_javadocCleanups = FieldAugment.augment(JCTree.class, Set.class, "lombok#javadocCleanups");
 }

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -701,13 +701,13 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 	public void makeSetterMethodsForBuilder(JavacNode builderType, BuilderFieldData fieldNode, JavacNode source, boolean fluent, boolean chain) {
 		boolean deprecate = isFieldDeprecated(fieldNode.originalFieldNode);
 		if (fieldNode.singularData == null || fieldNode.singularData.getSingularizer() == null) {
-			makeSimpleSetterMethodForBuilder(builderType, deprecate, fieldNode.createdFields.get(0), fieldNode.nameOfSetFlag, source, fluent, chain, fieldNode.annotations);
+			makeSimpleSetterMethodForBuilder(builderType, deprecate, fieldNode.createdFields.get(0), fieldNode.nameOfSetFlag, source, fluent, chain, fieldNode.annotations, fieldNode.originalFieldNode);
 		} else {
 			fieldNode.singularData.getSingularizer().generateMethods(fieldNode.singularData, deprecate, builderType, source.get(), fluent, chain);
 		}
 	}
 	
-	private void makeSimpleSetterMethodForBuilder(JavacNode builderType, boolean deprecate, JavacNode fieldNode, Name nameOfSetFlag, JavacNode source, boolean fluent, boolean chain, List<JCAnnotation> annosOnParam) {
+	private void makeSimpleSetterMethodForBuilder(JavacNode builderType, boolean deprecate, JavacNode fieldNode, Name nameOfSetFlag, JavacNode source, boolean fluent, boolean chain, List<JCAnnotation> annosOnParam, JavacNode originalFieldNode) {
 		Name fieldName = ((JCVariableDecl) fieldNode.get()).name;
 		
 		for (JavacNode child : builderType.down()) {
@@ -723,6 +723,8 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		
 		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, deprecate, fieldNode, maker, setterName, nameOfSetFlag, chain, source, List.<JCAnnotation>nil(), annosOnParam);
 		recursiveSetGeneratedBy(newMethod, source.get(), builderType.getContext());
+		copyJavadoc(originalFieldNode, newMethod, CopyJavadoc.SETTER);
+
 		injectMethod(builderType, newMethod);
 	}
 	

--- a/src/core/lombok/javac/handlers/HandleCleanupFieldJavadoc.java
+++ b/src/core/lombok/javac/handlers/HandleCleanupFieldJavadoc.java
@@ -22,6 +22,7 @@
 package lombok.javac.handlers;
 
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import java.util.Set;
 import lombok.core.HandlerPriority;
 import lombok.javac.JavacASTAdapter;
 import lombok.javac.JavacASTVisitor;
@@ -40,16 +41,15 @@ public class HandleCleanupFieldJavadoc extends JavacASTAdapter {
 
     @Override
     public void endVisitField(JavacNode fieldNode, JCVariableDecl field) {
-        final String originalJavadoc = JavacHandlerUtil.getJavadoc(fieldNode);
+        Set<CopyJavadoc> cleanups = JavacHandlerUtil.getJavadocCleanups(fieldNode.get());
+        if (cleanups != null) {
+            String javadoc = JavacHandlerUtil.getJavadoc(fieldNode);
 
-        if (originalJavadoc != null) {
-            String reduced = originalJavadoc;
-
-            for (CopyJavadoc copyMode : CopyJavadoc.values()) {
-                reduced = JavacHandlerUtil.filterJavadocString(fieldNode, copyMode, reduced)[1];
+            for (CopyJavadoc copyMode : cleanups) {
+                javadoc = JavacHandlerUtil.filterJavadocString(fieldNode, copyMode, javadoc)[1];
             }
 
-            JavacHandlerUtil.putJavadoc(fieldNode, reduced);
+            JavacHandlerUtil.putJavadoc(fieldNode, javadoc);
         }
     }
 

--- a/src/core/lombok/javac/handlers/HandleCleanupFieldJavadoc.java
+++ b/src/core/lombok/javac/handlers/HandleCleanupFieldJavadoc.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2010-2018 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import lombok.core.HandlerPriority;
+import lombok.javac.JavacASTAdapter;
+import lombok.javac.JavacASTVisitor;
+import lombok.javac.JavacNode;
+import lombok.javac.handlers.JavacHandlerUtil.CopyJavadoc;
+import org.mangosdk.spi.ProviderFor;
+
+
+/**
+ * Replaces the javadoc on each field with itself run through each copy mode, keeping the "remaining" part in each step.
+ * In particular, this removes @return and @param tags as well as GETTER/SETTER/WITHER sections.
+ */
+@ProviderFor(JavacASTVisitor.class)
+@HandlerPriority(268435456) // 2^28; run this as late as possible but before HandlePrintAST which is at 2^29.
+public class HandleCleanupFieldJavadoc extends JavacASTAdapter {
+
+    @Override
+    public void endVisitField(JavacNode fieldNode, JCVariableDecl field) {
+        final String originalJavadoc = JavacHandlerUtil.getJavadoc(fieldNode);
+
+        if (originalJavadoc != null) {
+            String reduced = originalJavadoc;
+
+            for (CopyJavadoc copyMode : CopyJavadoc.values()) {
+                reduced = JavacHandlerUtil.filterJavadocString(fieldNode, copyMode, reduced)[1];
+            }
+
+            JavacHandlerUtil.putJavadoc(fieldNode, reduced);
+        }
+    }
+
+}

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1840,15 +1840,16 @@ public class JavacHandlerUtil {
 	public static enum CopyJavadoc {
 		VERBATIM,
 		GETTER {
-			@Override public String[] split(final String original) {
+			@Override public String[] split(String javadoc) {
 				// step 1: Check if there is a 'GETTER' section. If yes, that becomes the new method's javadoc and we strip that from the original.
-				String[] out = splitJavadocOnSectionIfPresent(original, "GETTER");
+				String[] out = splitJavadocOnSectionIfPresent(javadoc, "GETTER");
 				if (out != null) return out;
 				// failing that, create a copy, but strip @return from the original and @param from the copy, as well as other sections.
-				final String reduced = stripLinesWithTagFromJavadoc(original, "@returns?\\s+.*");
-				String copy = stripLinesWithTagFromJavadoc(original, "@param(?:eter)?\\s+.*");
+				String copy = javadoc;
+				javadoc = stripLinesWithTagFromJavadoc(javadoc, "@returns?\\s+.*");
+				copy = stripLinesWithTagFromJavadoc(copy, "@param(?:eter)?\\s+.*");
 				copy = stripSectionsFromJavadoc(copy);
-				return new String[] {copy, reduced};
+				return new String[] {copy, javadoc};
 			}
 		},
 		SETTER {
@@ -1862,15 +1863,16 @@ public class JavacHandlerUtil {
 			}
 		};
 		
-		private static String[] splitForSetters(final String original, String sectionName) {
+		private static String[] splitForSetters(String javadoc, String sectionName) {
 			// step 1: Check if there is a 'SETTER' section. If yes, that becomes the new one and we strip that from the original.
-			String[] out = splitJavadocOnSectionIfPresent(original, sectionName);
+			String[] out = splitJavadocOnSectionIfPresent(javadoc, sectionName);
 			if (out != null) return out;
 			// failing that, create a copy, but strip @param from the original and @return from the copy.
-			final String reduced = stripLinesWithTagFromJavadoc(original, "@param(?:eter)?\\s+.*");
-			String copy = stripLinesWithTagFromJavadoc(original, "@returns?\\s+.*");
+			String copy = javadoc;
+			javadoc = stripLinesWithTagFromJavadoc(javadoc, "@param(?:eter)?\\s+.*");
+			copy = stripLinesWithTagFromJavadoc(copy, "@returns?\\s+.*");
 			copy = stripSectionsFromJavadoc(copy);
-			return new String[] {copy, reduced};
+			return new String[] {copy, javadoc};
 		}
 		
 		/** Splits the javadoc into the section to be copied (ret[0]) and the section to replace the original with (ret[1]) */

--- a/test/transform/resource/after-delombok/BuilderJavadoc.java
+++ b/test/transform/resource/after-delombok/BuilderJavadoc.java
@@ -11,22 +11,51 @@ class BuilderJavadoc<T> {
 	 * @return tag is removed from the setter.
 	 */
 	private final int yes;
+	/**
+	 * getset gets a builder setter and an instance getter and setter.
+	 */
+	private int getset;
+	/**
+	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
+	 * @param tag remains on the field.
+	 * @return tag remains on the field.
+	 */
+	private final int predef;
+	/**
+	 * predefWithJavadoc has a predefined builder setter with javadoc, so it keeps that one untouched.
+	 * @param tag is removed from the field.
+	 * @return tag remains on the field.
+	 */
+	private final int predefWithJavadoc;
 	private List<T> also;
 	/**
 	 * But this one doesn't.
 	 */
 	private int $butNotMe;
-	@java.lang.SuppressWarnings("all")
-	BuilderJavadoc(final int yes, final List<T> also) {
-		this.yes = yes;
-		this.also = also;
-	}
-	@java.lang.SuppressWarnings("all")
 	public static class BuilderJavadocBuilder<T> {
 		@java.lang.SuppressWarnings("all")
 		private int yes;
 		@java.lang.SuppressWarnings("all")
+		private int getset;
+		@java.lang.SuppressWarnings("all")
+		private int predef;
+		@java.lang.SuppressWarnings("all")
+		private int predefWithJavadoc;
+		@java.lang.SuppressWarnings("all")
 		private List<T> also;
+		public BuilderJavadocBuilder<T> predef(final int x) {
+			this.predef = x * 10;
+			return this;
+		}
+		/**
+		 * This javadoc remains untouched.
+		 * @param x 1/100 of the thing
+		 * @return the updated builder
+		 */
+		public BuilderJavadocBuilder<T> predefWithJavadoc(final int x) {
+			this.predefWithJavadoc = x * 100;
+			return this;
+		}
 		@java.lang.SuppressWarnings("all")
 		BuilderJavadocBuilder() {
 		}
@@ -40,6 +69,15 @@ class BuilderJavadoc<T> {
 			this.yes = yes;
 			return this;
 		}
+		/**
+		 * getset gets a builder setter and an instance getter and setter.
+		 * @param tag is moved to the setters.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderJavadocBuilder<T> getset(final int getset) {
+			this.getset = getset;
+			return this;
+		}
 		@java.lang.SuppressWarnings("all")
 		public BuilderJavadocBuilder<T> also(final List<T> also) {
 			this.also = also;
@@ -47,16 +85,41 @@ class BuilderJavadoc<T> {
 		}
 		@java.lang.SuppressWarnings("all")
 		public BuilderJavadoc<T> build() {
-			return new BuilderJavadoc<T>(yes, also);
+			return new BuilderJavadoc<T>(yes, getset, predef, predefWithJavadoc, also);
 		}
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {
-			return "BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes + ", also=" + this.also + ")";
+			return "BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes + ", getset=" + this.getset + ", predef=" + this.predef + ", predefWithJavadoc=" + this.predefWithJavadoc + ", also=" + this.also + ")";
 		}
+	}
+	@java.lang.SuppressWarnings("all")
+	BuilderJavadoc(final int yes, final int getset, final int predef, final int predefWithJavadoc, final List<T> also) {
+		this.yes = yes;
+		this.getset = getset;
+		this.predef = predef;
+		this.predefWithJavadoc = predefWithJavadoc;
+		this.also = also;
 	}
 	@java.lang.SuppressWarnings("all")
 	public static <T> BuilderJavadocBuilder<T> builder() {
 		return new BuilderJavadocBuilder<T>();
+	}
+	/**
+	 * getset gets a builder setter and an instance getter and setter.
+	 *
+	 * @return tag is moved to the getter.
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getGetset() {
+		return this.getset;
+	}
+	/**
+	 * getset gets a builder setter and an instance getter and setter.
+	 * @param tag is moved to the setters.
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setGetset(final int getset) {
+		this.getset = getset;
 	}
 }

--- a/test/transform/resource/after-delombok/BuilderJavadoc.java
+++ b/test/transform/resource/after-delombok/BuilderJavadoc.java
@@ -1,0 +1,62 @@
+import java.util.List;
+class BuilderJavadoc<T> {
+	/**
+	 * Will not get a setter on the builder.
+	 */
+	private final int noshow = 0;
+	/**
+	 * Yes, yes gets a setter.
+	 * @see #also
+	 *
+	 * @return tag is removed from the setter.
+	 */
+	private final int yes;
+	private List<T> also;
+	/**
+	 * But this one doesn't.
+	 */
+	private int $butNotMe;
+	@java.lang.SuppressWarnings("all")
+	BuilderJavadoc(final int yes, final List<T> also) {
+		this.yes = yes;
+		this.also = also;
+	}
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderJavadocBuilder<T> {
+		@java.lang.SuppressWarnings("all")
+		private int yes;
+		@java.lang.SuppressWarnings("all")
+		private List<T> also;
+		@java.lang.SuppressWarnings("all")
+		BuilderJavadocBuilder() {
+		}
+		/**
+		 * Yes, yes gets a setter.
+		 * @see #also
+		 * @param tag is moved to the setter.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderJavadocBuilder<T> yes(final int yes) {
+			this.yes = yes;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderJavadocBuilder<T> also(final List<T> also) {
+			this.also = also;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderJavadoc<T> build() {
+			return new BuilderJavadoc<T>(yes, also);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes + ", also=" + this.also + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	public static <T> BuilderJavadocBuilder<T> builder() {
+		return new BuilderJavadocBuilder<T>();
+	}
+}

--- a/test/transform/resource/after-delombok/BuilderJavadoc.java
+++ b/test/transform/resource/after-delombok/BuilderJavadoc.java
@@ -12,9 +12,9 @@ class BuilderJavadoc<T> {
 	 */
 	private final int yes;
 	/**
-	 * getset gets a builder setter and an instance getter and setter.
+	 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
 	 */
-	private int getset;
+	private int getsetwith;
 	/**
 	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
 	 * @param tag remains on the field.
@@ -36,7 +36,7 @@ class BuilderJavadoc<T> {
 		@java.lang.SuppressWarnings("all")
 		private int yes;
 		@java.lang.SuppressWarnings("all")
-		private int getset;
+		private int getsetwith;
 		@java.lang.SuppressWarnings("all")
 		private int predef;
 		@java.lang.SuppressWarnings("all")
@@ -70,12 +70,12 @@ class BuilderJavadoc<T> {
 			return this;
 		}
 		/**
-		 * getset gets a builder setter and an instance getter and setter.
-		 * @param tag is moved to the setters.
+		 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
+		 * @param tag is moved to the setters and wither.
 		 */
 		@java.lang.SuppressWarnings("all")
-		public BuilderJavadocBuilder<T> getset(final int getset) {
-			this.getset = getset;
+		public BuilderJavadocBuilder<T> getsetwith(final int getsetwith) {
+			this.getsetwith = getsetwith;
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
@@ -85,18 +85,18 @@ class BuilderJavadoc<T> {
 		}
 		@java.lang.SuppressWarnings("all")
 		public BuilderJavadoc<T> build() {
-			return new BuilderJavadoc<T>(yes, getset, predef, predefWithJavadoc, also);
+			return new BuilderJavadoc<T>(yes, getsetwith, predef, predefWithJavadoc, also);
 		}
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {
-			return "BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes + ", getset=" + this.getset + ", predef=" + this.predef + ", predefWithJavadoc=" + this.predefWithJavadoc + ", also=" + this.also + ")";
+			return "BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes + ", getsetwith=" + this.getsetwith + ", predef=" + this.predef + ", predefWithJavadoc=" + this.predefWithJavadoc + ", also=" + this.also + ")";
 		}
 	}
 	@java.lang.SuppressWarnings("all")
-	BuilderJavadoc(final int yes, final int getset, final int predef, final int predefWithJavadoc, final List<T> also) {
+	BuilderJavadoc(final int yes, final int getsetwith, final int predef, final int predefWithJavadoc, final List<T> also) {
 		this.yes = yes;
-		this.getset = getset;
+		this.getsetwith = getsetwith;
 		this.predef = predef;
 		this.predefWithJavadoc = predefWithJavadoc;
 		this.also = also;
@@ -106,20 +106,28 @@ class BuilderJavadoc<T> {
 		return new BuilderJavadocBuilder<T>();
 	}
 	/**
-	 * getset gets a builder setter and an instance getter and setter.
+	 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
 	 *
 	 * @return tag is moved to the getter.
 	 */
 	@java.lang.SuppressWarnings("all")
-	public int getGetset() {
-		return this.getset;
+	public int getGetsetwith() {
+		return this.getsetwith;
 	}
 	/**
-	 * getset gets a builder setter and an instance getter and setter.
-	 * @param tag is moved to the setters.
+	 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
+	 * @param tag is moved to the setters and wither.
 	 */
 	@java.lang.SuppressWarnings("all")
-	public void setGetset(final int getset) {
-		this.getset = getset;
+	public void setGetsetwith(final int getsetwith) {
+		this.getsetwith = getsetwith;
+	}
+	/**
+	 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
+	 * @param tag is moved to the setters and wither.
+	 */
+	@java.lang.SuppressWarnings("all")
+	public BuilderJavadoc<T> withGetsetwith(final int getsetwith) {
+		return this.getsetwith == getsetwith ? this : new BuilderJavadoc<T>(this.yes, getsetwith, this.predef, this.predefWithJavadoc, this.also);
 	}
 }

--- a/test/transform/resource/after-delombok/BuilderJavadoc.java
+++ b/test/transform/resource/after-delombok/BuilderJavadoc.java
@@ -7,8 +7,6 @@ class BuilderJavadoc<T> {
 	/**
 	 * Yes, yes gets a setter.
 	 * @see #also
-	 *
-	 * @return tag is removed from the setter.
 	 */
 	private final int yes;
 	/**
@@ -17,14 +15,10 @@ class BuilderJavadoc<T> {
 	private int getsetwith;
 	/**
 	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
-	 * @param tag remains on the field.
-	 * @return tag remains on the field.
 	 */
 	private final int predef;
 	/**
 	 * predefWithJavadoc has a predefined builder setter with javadoc, so it keeps that one untouched.
-	 * @param tag is removed from the field.
-	 * @return tag remains on the field.
 	 */
 	private final int predefWithJavadoc;
 	private List<T> also;

--- a/test/transform/resource/after-delombok/BuilderJavadoc.java
+++ b/test/transform/resource/after-delombok/BuilderJavadoc.java
@@ -7,6 +7,8 @@ class BuilderJavadoc<T> {
 	/**
 	 * Yes, yes gets a setter.
 	 * @see #also
+	 *
+	 * @return tag is removed from the setter.
 	 */
 	private final int yes;
 	/**
@@ -15,10 +17,14 @@ class BuilderJavadoc<T> {
 	private int getsetwith;
 	/**
 	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
+	 * @param tag remains on the field.
+	 * @return tag remains on the field.
 	 */
 	private final int predef;
 	/**
 	 * predefWithJavadoc has a predefined builder setter with javadoc, so it keeps that one untouched.
+	 * @param tag is removed from the field.
+	 * @return tag remains on the field.
 	 */
 	private final int predefWithJavadoc;
 	private List<T> also;

--- a/test/transform/resource/after-delombok/BuilderWithDeprecated.java
+++ b/test/transform/resource/after-delombok/BuilderWithDeprecated.java
@@ -1,7 +1,7 @@
 import com.google.common.collect.ImmutableList;
 public class BuilderWithDeprecated {
 	/**
-	 * @deprecated
+	 * @deprecated since always
 	 */
 	String dep1;
 	@Deprecated

--- a/test/transform/resource/after-delombok/BuilderWithDeprecated.java
+++ b/test/transform/resource/after-delombok/BuilderWithDeprecated.java
@@ -30,6 +30,9 @@ public class BuilderWithDeprecated {
 		@java.lang.SuppressWarnings("all")
 		BuilderWithDeprecatedBuilder() {
 		}
+		/**
+		 * @deprecated since always
+		 */
 		@java.lang.Deprecated
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithDeprecatedBuilder dep1(final String dep1) {

--- a/test/transform/resource/after-delombok/WitherAndSetterJavadoc.java
+++ b/test/transform/resource/after-delombok/WitherAndSetterJavadoc.java
@@ -1,0 +1,46 @@
+class WitherAndSetterJavadoc {
+	/**
+	 * Some value.
+	 */
+	int i;
+	/**
+	 * Some other value.
+	 */
+	int j;
+	WitherAndSetterJavadoc(int i, int j) {
+		this.i = i;
+		this.j = j;
+	}
+	/**
+	 * Some value.
+	 * @param the new value
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setI(final int i) {
+		this.i = i;
+	}
+	/**
+	 * Some value.
+	 * @param the new value
+	 */
+	@java.lang.SuppressWarnings("all")
+	public WitherAndSetterJavadoc withI(final int i) {
+		return this.i == i ? this : new WitherAndSetterJavadoc(i, this.j);
+	}
+	/**
+	 * Set some other value.
+	 * @param the new other value
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setJ(final int j) {
+		this.j = j;
+	}
+	/**
+	 * Reinstantiate with some other value.
+	 * @param the new other value
+	 */
+	@java.lang.SuppressWarnings("all")
+	public WitherAndSetterJavadoc withJ(final int j) {
+		return this.j == j ? this : new WitherAndSetterJavadoc(this.i, j);
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderJavadoc.java
+++ b/test/transform/resource/after-ecj/BuilderJavadoc.java
@@ -1,0 +1,36 @@
+import java.util.List;
+@lombok.Builder class BuilderJavadoc<T> {
+  public static @java.lang.SuppressWarnings("all") class BuilderJavadocBuilder<T> {
+    private @java.lang.SuppressWarnings("all") int yes;
+    private @java.lang.SuppressWarnings("all") List<T> also;
+    @java.lang.SuppressWarnings("all") BuilderJavadocBuilder() {
+      super();
+    }
+    public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> yes(final int yes) {
+      this.yes = yes;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> also(final List<T> also) {
+      this.also = also;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderJavadoc<T> build() {
+      return new BuilderJavadoc<T>(yes, also);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((("BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes) + ", also=") + this.also) + ")");
+    }
+  }
+  private final int noshow = 0;
+  private final int yes;
+  private List<T> also;
+  private int $butNotMe;
+  @java.lang.SuppressWarnings("all") BuilderJavadoc(final int yes, final List<T> also) {
+    super();
+    this.yes = yes;
+    this.also = also;
+  }
+  public static @java.lang.SuppressWarnings("all") <T>BuilderJavadocBuilder<T> builder() {
+    return new BuilderJavadocBuilder<T>();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderJavadoc.java
+++ b/test/transform/resource/after-ecj/BuilderJavadoc.java
@@ -2,7 +2,7 @@ import java.util.List;
 @lombok.Builder class BuilderJavadoc<T> {
   public static class BuilderJavadocBuilder<T> {
     private @java.lang.SuppressWarnings("all") int yes;
-    private @java.lang.SuppressWarnings("all") int getset;
+    private @java.lang.SuppressWarnings("all") int getsetwith;
     private @java.lang.SuppressWarnings("all") int predef;
     private @java.lang.SuppressWarnings("all") int predefWithJavadoc;
     private @java.lang.SuppressWarnings("all") List<T> also;
@@ -21,8 +21,8 @@ import java.util.List;
       this.yes = yes;
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> getset(final int getset) {
-      this.getset = getset;
+    public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> getsetwith(final int getsetwith) {
+      this.getsetwith = getsetwith;
       return this;
     }
     public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> also(final List<T> also) {
@@ -30,23 +30,23 @@ import java.util.List;
       return this;
     }
     public @java.lang.SuppressWarnings("all") BuilderJavadoc<T> build() {
-      return new BuilderJavadoc<T>(yes, getset, predef, predefWithJavadoc, also);
+      return new BuilderJavadoc<T>(yes, getsetwith, predef, predefWithJavadoc, also);
     }
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-      return (((((((((("BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes) + ", getset=") + this.getset) + ", predef=") + this.predef) + ", predefWithJavadoc=") + this.predefWithJavadoc) + ", also=") + this.also) + ")");
+      return (((((((((("BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes) + ", getsetwith=") + this.getsetwith) + ", predef=") + this.predef) + ", predefWithJavadoc=") + this.predefWithJavadoc) + ", also=") + this.also) + ")");
     }
   }
   private final int noshow = 0;
   private final int yes;
-  private @lombok.Getter @lombok.Setter int getset;
+  private @lombok.Getter @lombok.Setter @lombok.experimental.Wither int getsetwith;
   private final int predef;
   private final int predefWithJavadoc;
   private List<T> also;
   private int $butNotMe;
-  @java.lang.SuppressWarnings("all") BuilderJavadoc(final int yes, final int getset, final int predef, final int predefWithJavadoc, final List<T> also) {
+  @java.lang.SuppressWarnings("all") BuilderJavadoc(final int yes, final int getsetwith, final int predef, final int predefWithJavadoc, final List<T> also) {
     super();
     this.yes = yes;
-    this.getset = getset;
+    this.getsetwith = getsetwith;
     this.predef = predef;
     this.predefWithJavadoc = predefWithJavadoc;
     this.also = also;
@@ -54,10 +54,13 @@ import java.util.List;
   public static @java.lang.SuppressWarnings("all") <T>BuilderJavadocBuilder<T> builder() {
     return new BuilderJavadocBuilder<T>();
   }
-  public @java.lang.SuppressWarnings("all") int getGetset() {
-    return this.getset;
+  public @java.lang.SuppressWarnings("all") int getGetsetwith() {
+    return this.getsetwith;
   }
-  public @java.lang.SuppressWarnings("all") void setGetset(final int getset) {
-    this.getset = getset;
+  public @java.lang.SuppressWarnings("all") void setGetsetwith(final int getsetwith) {
+    this.getsetwith = getsetwith;
+  }
+  public @java.lang.SuppressWarnings("all") BuilderJavadoc<T> withGetsetwith(final int getsetwith) {
+    return ((this.getsetwith == getsetwith) ? this : new BuilderJavadoc<T>(this.yes, getsetwith, this.predef, this.predefWithJavadoc, this.also));
   }
 }

--- a/test/transform/resource/after-ecj/BuilderJavadoc.java
+++ b/test/transform/resource/after-ecj/BuilderJavadoc.java
@@ -1,8 +1,19 @@
 import java.util.List;
 @lombok.Builder class BuilderJavadoc<T> {
-  public static @java.lang.SuppressWarnings("all") class BuilderJavadocBuilder<T> {
+  public static class BuilderJavadocBuilder<T> {
     private @java.lang.SuppressWarnings("all") int yes;
+    private @java.lang.SuppressWarnings("all") int getset;
+    private @java.lang.SuppressWarnings("all") int predef;
+    private @java.lang.SuppressWarnings("all") int predefWithJavadoc;
     private @java.lang.SuppressWarnings("all") List<T> also;
+    public BuilderJavadocBuilder<T> predef(final int x) {
+      this.predef = (x * 10);
+      return this;
+    }
+    public BuilderJavadocBuilder<T> predefWithJavadoc(final int x) {
+      this.predefWithJavadoc = (x * 100);
+      return this;
+    }
     @java.lang.SuppressWarnings("all") BuilderJavadocBuilder() {
       super();
     }
@@ -10,27 +21,43 @@ import java.util.List;
       this.yes = yes;
       return this;
     }
+    public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> getset(final int getset) {
+      this.getset = getset;
+      return this;
+    }
     public @java.lang.SuppressWarnings("all") BuilderJavadocBuilder<T> also(final List<T> also) {
       this.also = also;
       return this;
     }
     public @java.lang.SuppressWarnings("all") BuilderJavadoc<T> build() {
-      return new BuilderJavadoc<T>(yes, also);
+      return new BuilderJavadoc<T>(yes, getset, predef, predefWithJavadoc, also);
     }
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-      return (((("BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes) + ", also=") + this.also) + ")");
+      return (((((((((("BuilderJavadoc.BuilderJavadocBuilder(yes=" + this.yes) + ", getset=") + this.getset) + ", predef=") + this.predef) + ", predefWithJavadoc=") + this.predefWithJavadoc) + ", also=") + this.also) + ")");
     }
   }
   private final int noshow = 0;
   private final int yes;
+  private @lombok.Getter @lombok.Setter int getset;
+  private final int predef;
+  private final int predefWithJavadoc;
   private List<T> also;
   private int $butNotMe;
-  @java.lang.SuppressWarnings("all") BuilderJavadoc(final int yes, final List<T> also) {
+  @java.lang.SuppressWarnings("all") BuilderJavadoc(final int yes, final int getset, final int predef, final int predefWithJavadoc, final List<T> also) {
     super();
     this.yes = yes;
+    this.getset = getset;
+    this.predef = predef;
+    this.predefWithJavadoc = predefWithJavadoc;
     this.also = also;
   }
   public static @java.lang.SuppressWarnings("all") <T>BuilderJavadocBuilder<T> builder() {
     return new BuilderJavadocBuilder<T>();
+  }
+  public @java.lang.SuppressWarnings("all") int getGetset() {
+    return this.getset;
+  }
+  public @java.lang.SuppressWarnings("all") void setGetset(final int getset) {
+    this.getset = getset;
   }
 }

--- a/test/transform/resource/after-ecj/WitherAndSetterJavadoc.java
+++ b/test/transform/resource/after-ecj/WitherAndSetterJavadoc.java
@@ -1,0 +1,22 @@
+import lombok.experimental.Wither;
+class WitherAndSetterJavadoc {
+  @lombok.Setter @lombok.experimental.Wither int i;
+  @lombok.Setter @lombok.experimental.Wither int j;
+  WitherAndSetterJavadoc(int i, int j) {
+    super();
+    this.i = i;
+    this.j = j;
+  }
+  public @java.lang.SuppressWarnings("all") void setI(final int i) {
+    this.i = i;
+  }
+  public @java.lang.SuppressWarnings("all") WitherAndSetterJavadoc withI(final int i) {
+    return ((this.i == i) ? this : new WitherAndSetterJavadoc(i, this.j));
+  }
+  public @java.lang.SuppressWarnings("all") void setJ(final int j) {
+    this.j = j;
+  }
+  public @java.lang.SuppressWarnings("all") WitherAndSetterJavadoc withJ(final int j) {
+    return ((this.j == j) ? this : new WitherAndSetterJavadoc(this.i, j));
+  }
+}

--- a/test/transform/resource/before/BuilderJavadoc.java
+++ b/test/transform/resource/before/BuilderJavadoc.java
@@ -11,7 +11,7 @@ class BuilderJavadoc<T> {
 	 * Yes, yes gets a setter.
      * @see #also
 	 * @param tag is moved to the setter.
-	 * @return tag is removed from the setter and from the field.
+	 * @return tag is removed from the setter.
 	 */
 	private final int yes;
 
@@ -27,15 +27,15 @@ class BuilderJavadoc<T> {
 
 	/**
 	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
-	 * @param tag is removed from the field.
-	 * @return tag is removed from the field.
+	 * @param tag remains on the field.
+	 * @return tag remains on the field.
 	 */
 	private final int predef;
 
 	/**
 	 * predefWithJavadoc has a predefined builder setter with javadoc, so it keeps that one untouched.
 	 * @param tag is removed from the field.
-	 * @return tag is removed from the field.
+	 * @return tag remains on the field.
 	 */
 	private final int predefWithJavadoc;
 

--- a/test/transform/resource/before/BuilderJavadoc.java
+++ b/test/transform/resource/before/BuilderJavadoc.java
@@ -16,13 +16,14 @@ class BuilderJavadoc<T> {
 	private final int yes;
 
 	/**
-	 * getset gets a builder setter and an instance getter and setter.
-	 * @param tag is moved to the setters.
+	 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
+	 * @param tag is moved to the setters and wither.
 	 * @return tag is moved to the getter.
 	 */
 	@lombok.Getter
 	@lombok.Setter
-	private int getset;
+	@lombok.experimental.Wither
+	private int getsetwith;
 
 	/**
 	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.

--- a/test/transform/resource/before/BuilderJavadoc.java
+++ b/test/transform/resource/before/BuilderJavadoc.java
@@ -15,10 +15,51 @@ class BuilderJavadoc<T> {
 	 */
 	private final int yes;
 
+	/**
+	 * getset gets a builder setter and an instance getter and setter.
+	 * @param tag is moved to the setters.
+	 * @return tag is moved to the getter.
+	 */
+	@lombok.Getter
+	@lombok.Setter
+	private int getset;
+
+	/**
+	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
+	 * @param tag remains on the field.
+	 * @return tag remains on the field.
+	 */
+	private final int predef;
+
+	/**
+	 * predefWithJavadoc has a predefined builder setter with javadoc, so it keeps that one untouched.
+	 * @param tag is removed from the field.
+	 * @return tag remains on the field.
+	 */
+	private final int predefWithJavadoc;
+
 	private List<T> also;
 
 	/**
 	 * But this one doesn't.
 	 */
 	private int $butNotMe;
+
+	public static class BuilderJavadocBuilder<T> {
+		public BuilderJavadocBuilder<T> predef(final int x) {
+			this.predef = x * 10;
+			return this;
+		}
+
+		/**
+		 * This javadoc remains untouched.
+		 * @param x 1/100 of the thing
+		 * @return the updated builder
+		 */
+		public BuilderJavadocBuilder<T> predefWithJavadoc(final int x) {
+			this.predefWithJavadoc = x * 100;
+			return this;
+		}
+    }
+
 }

--- a/test/transform/resource/before/BuilderJavadoc.java
+++ b/test/transform/resource/before/BuilderJavadoc.java
@@ -11,7 +11,7 @@ class BuilderJavadoc<T> {
 	 * Yes, yes gets a setter.
      * @see #also
 	 * @param tag is moved to the setter.
-	 * @return tag is removed from the setter.
+	 * @return tag is removed from the setter and from the field.
 	 */
 	private final int yes;
 
@@ -27,15 +27,15 @@ class BuilderJavadoc<T> {
 
 	/**
 	 * Predef has a predefined builder setter with no javadoc, and the builder setter does not get this one.
-	 * @param tag remains on the field.
-	 * @return tag remains on the field.
+	 * @param tag is removed from the field.
+	 * @return tag is removed from the field.
 	 */
 	private final int predef;
 
 	/**
 	 * predefWithJavadoc has a predefined builder setter with javadoc, so it keeps that one untouched.
 	 * @param tag is removed from the field.
-	 * @return tag remains on the field.
+	 * @return tag is removed from the field.
 	 */
 	private final int predefWithJavadoc;
 

--- a/test/transform/resource/before/BuilderJavadoc.java
+++ b/test/transform/resource/before/BuilderJavadoc.java
@@ -1,0 +1,24 @@
+import java.util.List;
+
+@lombok.Builder
+class BuilderJavadoc<T> {
+	/**
+	 * Will not get a setter on the builder.
+	 */
+	private final int noshow = 0;
+
+	/**
+	 * Yes, yes gets a setter.
+     * @see #also
+	 * @param tag is moved to the setter.
+	 * @return tag is removed from the setter.
+	 */
+	private final int yes;
+
+	private List<T> also;
+
+	/**
+	 * But this one doesn't.
+	 */
+	private int $butNotMe;
+}

--- a/test/transform/resource/before/BuilderWithDeprecated.java
+++ b/test/transform/resource/before/BuilderWithDeprecated.java
@@ -4,7 +4,7 @@ import lombok.Singular;
 
 @Builder
 public class BuilderWithDeprecated {
-	/** @deprecated */ String dep1;
+	/** @deprecated since always */ String dep1;
 	@Deprecated int dep2;
 	@Singular @Deprecated java.util.List<String> strings;
 	@Singular @Deprecated ImmutableList<Integer> numbers;

--- a/test/transform/resource/before/WitherAndSetterJavadoc.java
+++ b/test/transform/resource/before/WitherAndSetterJavadoc.java
@@ -1,0 +1,26 @@
+import lombok.experimental.Wither;
+class WitherAndSetterJavadoc {
+	/**
+	 * Some value.
+	 * @param the new value
+	 */
+	@lombok.Setter @lombok.experimental.Wither int i;
+
+	/**
+	 * Some other value.
+	 *
+	 * --- SETTER ---
+	 * Set some other value.
+	 * @param the new other value
+	 *
+	 * --- WITHER ---
+	 * Reinstantiate with some other value.
+	 * @param the new other value
+	 */
+	@lombok.Setter @lombok.experimental.Wither int j;
+
+	WitherAndSetterJavadoc(int i, int j) {
+		this.i = i;
+		this.j = j;
+	}
+}


### PR DESCRIPTION
Fixes #1033. Fixes #1445.

This causes Javadoc to be copied to `@Builder` setters using SETTER copy mode. See the added tests for an example.

Notes:
- The change is currently only made in the `makeSimpleSetterMethodForBuilder` method, so I don't think this will apply to "singular" setters or other special cases - I haven't quite been able to grok how the `else` branch in `makeSetterMethodsForBuilder` method works.
- It looked like the ECJ variant strips Javadoc altogether, so I didn't apply the same change there.
- The tests currently do not cover interactions such as between `@Builder` and `@Value`/`@Getter`. I'll try to add some for that.