### PR TITLE
Reduce code duplication in singularizers

### DIFF
--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -788,7 +788,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			name = type.toString();
 			
 			String targetFqn = JavacSingularsRecipes.get().toQualified(name);
-			JavacSingularizer singularizer = JavacSingularsRecipes.get().getSingularizer(targetFqn);
+			JavacSingularizer singularizer = JavacSingularsRecipes.get().getSingularizer(targetFqn, node);
 			if (singularizer == null) {
 				node.addError("Lombok does not know how to create the singular-form builder methods for type '" + name + "'; they won't be generated.");
 				return null;

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -919,7 +919,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			name = type.toString();
 			
 			String targetFqn = JavacSingularsRecipes.get().toQualified(name);
-			JavacSingularizer singularizer = JavacSingularsRecipes.get().getSingularizer(targetFqn);
+			JavacSingularizer singularizer = JavacSingularsRecipes.get().getSingularizer(targetFqn, node);
 			if (singularizer == null) {
 				node.addError("Lombok does not know how to create the singular-form builder methods for type '" + name + "'; they won't be generated.");
 				return null;

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -24,6 +24,8 @@ package lombok.javac.handlers;
 import static lombok.javac.Javac.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +35,7 @@ import java.util.Map;
 import lombok.core.LombokImmutableList;
 import lombok.core.SpiLoadUtil;
 import lombok.core.TypeLibrary;
+import lombok.core.handlers.HandlerUtil;
 import lombok.javac.JavacNode;
 import lombok.javac.JavacTreeMaker;
 
@@ -239,6 +242,14 @@ public class JavacSingularsRecipes {
 		}
 
 		protected abstract void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source);
+
+		protected void finishGenerateClearMethod(JavacTreeMaker maker, JCExpression returnType, SingularData data, JavacNode builderType, JCTree source, JCModifiers mods, List<JCTypeParameter> typeParams, List<JCExpression> thrown, List<JCVariableDecl> params, List<JCStatement> statements) {
+			JCBlock body = maker.Block(0, statements);
+			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
+			JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params, thrown, body, null);
+			recursiveSetGeneratedBy(method, source, builderType.getContext());
+			injectMethod(builderType, method);
+		}
 
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -252,10 +252,12 @@ public class JavacSingularsRecipes {
 
 		void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
-			List<JCStatement> statements = returnStatement != null ? List.of(clearStatement, returnStatement) : List.of(clearStatement);
+			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+			statements.add(clearStatement);
+			if (returnStatement != null) statements.append(returnStatement);
 
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			JCBlock body = maker.Block(0, statements);
+			JCBlock body = maker.Block(0, statements.toList());
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.<JCVariableDecl>nil());
 		}
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -281,6 +281,15 @@ public class JavacSingularsRecipes {
 			return maker.Exec(invokeAdd);
 		}
 
+		protected void finishAndInjectSingularMethod(JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, JCModifiers mods, ListBuffer<JCStatement> statements, List<JCVariableDecl> params, String addMethodName) {
+			if (returnStatement != null) statements.append(returnStatement);
+			JCBlock body = maker.Block(0, statements.toList());
+			Name name = data.getSingularName();
+			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, name.toString()));
+
+			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
+		}
+
 		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -101,8 +101,8 @@ public class JavacSingularsRecipes {
 		return singularizableTypes.toQualified(typeReference);
 	}
 	
-	public JavacSingularizer getSingularizer(String fqn) {
-		return singularizers.get(fqn);
+	public JavacSingularizer getSingularizer(String fqn, JavacNode node) {
+		return singularizers.get(fqn).getGuavaInsteadIfNeeded(node);
 	}
 	
 	public static final class SingularData {
@@ -154,6 +154,10 @@ public class JavacSingularsRecipes {
 	
 	public static abstract class JavacSingularizer {
 		public abstract LombokImmutableList<String> getSupportedTypes();
+
+		protected JavacSingularizer getGuavaInsteadIfNeeded(JavacNode node) {
+			return this;
+		}
 		
 		protected JCModifiers makeMods(JavacTreeMaker maker, JavacNode node, boolean deprecate) {
 			if (deprecate) return maker.Modifiers(Flags.PUBLIC, List.<JCAnnotation>of(maker.Annotation(genJavaLangTypeRef(node, "Deprecated"), List.<JCExpression>nil())));

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -266,6 +266,14 @@ public class JavacSingularsRecipes {
 
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
+		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name, long flags) {
+			JCExpression type = cloneParamType(typeIndex, maker, data.getTypeArgs(), builderType, source);
+			List<JCAnnotation> typeUseAnns = getTypeUseAnnotations(type);
+			type = removeTypeUseAnnotations(type);
+			JCModifiers mods = typeUseAnns.isEmpty() ? maker.Modifiers(flags) : maker.Modifiers(flags, typeUseAnns);
+			return maker.VarDef(mods, name, type, null);
+		}
+
 		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -281,7 +281,8 @@ public class JavacSingularsRecipes {
 			return maker.Exec(invokeAdd);
 		}
 
-		protected void finishAndInjectSingularMethod(JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, JCModifiers mods, ListBuffer<JCStatement> statements, List<JCVariableDecl> params, String addMethodName) {
+		protected void finishAndInjectSingularMethod(JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, boolean deprecate, ListBuffer<JCStatement> statements, List<JCVariableDecl> params, String addMethodName) {
+			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getSingularName();

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,6 +241,12 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
+		protected void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, List<JCTypeParameter> typeParams, List<JCExpression> thrown, JCModifiers mods, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+			JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, jcVariableDecls, thrown, body, null);
+			recursiveSetGeneratedBy(method, source, builderType.getContext());
+			injectMethod(builderType, method);
+		}
+
 		protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 			JCModifiers mods = makeMods(maker, builderType, deprecate);
 
@@ -253,9 +259,7 @@ public class JavacSingularsRecipes {
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params, thrown, body, null);
-			recursiveSetGeneratedBy(method, source, builderType.getContext());
-			injectMethod(builderType, method);
+			finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, params);
 		}
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -264,7 +264,11 @@ public class JavacSingularsRecipes {
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);
 
-		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
+		void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+			ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
+			List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
+			finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, getAddMethodName());
+		}
 
 		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name) {
 			long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
@@ -290,6 +294,10 @@ public class JavacSingularsRecipes {
 
 			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 		}
+
+		protected abstract ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
+
+		protected abstract List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
 
 		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,7 +241,7 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		protected void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, boolean deprecate, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+		void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, boolean deprecate, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
 			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			List<JCTypeParameter> typeParams = List.nil();
 			List<JCExpression> thrown = List.nil();
@@ -301,6 +301,10 @@ public class JavacSingularsRecipes {
 			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
 			statements.append(maker.Exec(invokeAdd));
 
+			finishAndInjectPluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent, statements);
+		}
+
+		protected void finishAndInjectPluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, ListBuffer<JCStatement> statements) {
 			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getPluralName();

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -248,7 +248,8 @@ public class JavacSingularsRecipes {
 			List<JCExpression> thrown = List.nil();
 			List<JCVariableDecl> params = List.nil();
 
-			List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
+			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
+			List<JCStatement> statements = returnStatement != null ? List.of(clearStatement, returnStatement) : List.of(clearStatement);
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
@@ -257,7 +258,7 @@ public class JavacSingularsRecipes {
 			injectMethod(builderType, method);
 		}
 
-		protected abstract List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType);
+		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);
 
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,9 +241,15 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		protected abstract void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source);
+		protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
+			JCModifiers mods = makeMods(maker, builderType, deprecate);
 
-		protected void finishGenerateClearMethod(JavacTreeMaker maker, JCExpression returnType, SingularData data, JavacNode builderType, JCTree source, JCModifiers mods, List<JCTypeParameter> typeParams, List<JCExpression> thrown, List<JCVariableDecl> params, List<JCStatement> statements) {
+			List<JCTypeParameter> typeParams = List.nil();
+			List<JCExpression> thrown = List.nil();
+			List<JCVariableDecl> params = List.nil();
+
+			List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
+
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
 			JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params, thrown, body, null);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -294,7 +294,25 @@ public class JavacSingularsRecipes {
 
 		protected abstract List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
 
-		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
+		protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+			statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
+			JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
+			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
+			statements.append(maker.Exec(invokeAdd));
+
+			if (returnStatement != null) statements.append(returnStatement);
+			JCBlock body = maker.Block(0, statements.toList());
+			Name name = data.getPluralName();
+			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
+			JCExpression paramType = getPluralMethodParamType(builderType);
+			paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
+			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
+			JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
+		}
+
+		protected abstract JCExpression getPluralMethodParamType(JavacNode builderType);
 
 		protected abstract JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
 
@@ -411,5 +429,7 @@ public class JavacSingularsRecipes {
 		}
 
 		protected abstract String getAddMethodName();
+
+		protected abstract int getTypeArgumentsCount();
 	}
 }

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -231,6 +231,8 @@ public class JavacSingularsRecipes {
 		 */
 		public abstract void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker);
 
+		protected abstract void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source);
+
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -296,19 +296,6 @@ public class JavacSingularsRecipes {
 
 		void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generatePluralMethodStatements(maker, data, builderType, source);
-			finishAndInjectPluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent, statements);
-		}
-
-		protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
-			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-			statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
-			JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
-			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
-			statements.append(maker.Exec(invokeAdd));
-			return statements;
-		}
-
-		void finishAndInjectPluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, ListBuffer<JCStatement> statements) {
 			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getPluralName();
@@ -318,6 +305,15 @@ public class JavacSingularsRecipes {
 			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
+		}
+
+		protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
+			statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
+			JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
+			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
+			statements.append(maker.Exec(invokeAdd));
+			return statements;
 		}
 
 		protected abstract JCExpression getPluralMethodParamType(JavacNode builderType);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -404,5 +404,7 @@ public class JavacSingularsRecipes {
 				}
 			}
 		}
+
+		protected abstract String getAddMethodName();
 	}
 }

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -294,17 +294,21 @@ public class JavacSingularsRecipes {
 
 		protected abstract List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
 
-		protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+		void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+			ListBuffer<JCStatement> statements = generatePluralMethodStatements(maker, data, builderType, source);
+			finishAndInjectPluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent, statements);
+		}
+
+		protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 			statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 			JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
 			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
 			statements.append(maker.Exec(invokeAdd));
-
-			finishAndInjectPluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent, statements);
+			return statements;
 		}
 
-		protected void finishAndInjectPluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, ListBuffer<JCStatement> statements) {
+		void finishAndInjectPluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent, ListBuffer<JCStatement> statements) {
 			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getPluralName();

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -230,7 +230,9 @@ public class JavacSingularsRecipes {
 		 * Uses the given {@code returnTypeMaker} and {@code returnStatementMaker} for the generated methods.
 		 */
 		public abstract void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker);
-		
+
+		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
+
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);
 		
 		public boolean requiresCleaning() {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,7 +241,8 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		protected void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, JCModifiers mods, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+		protected void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, boolean deprecate, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			List<JCTypeParameter> typeParams = List.nil();
 			List<JCExpression> thrown = List.nil();
 			JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, jcVariableDecls, thrown, body, null);
@@ -258,8 +259,7 @@ public class JavacSingularsRecipes {
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			JCModifiers mods = makeMods(maker, builderType, deprecate);
-			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params);
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, params);
 		}
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);
@@ -272,8 +272,7 @@ public class JavacSingularsRecipes {
 			Name name = data.getSingularName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), name.toString()));
 
-			JCModifiers mods = makeMods(maker, builderType, deprecate);
-			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, params);
 		}
 
 		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name) {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,7 +241,9 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		protected void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, List<JCTypeParameter> typeParams, List<JCExpression> thrown, JCModifiers mods, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+		protected void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, JCModifiers mods, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+			List<JCTypeParameter> typeParams = List.nil();
+			List<JCExpression> thrown = List.nil();
 			JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, jcVariableDecls, thrown, body, null);
 			recursiveSetGeneratedBy(method, source, builderType.getContext());
 			injectMethod(builderType, method);
@@ -257,9 +259,7 @@ public class JavacSingularsRecipes {
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			List<JCTypeParameter> typeParams = List.nil();
-			List<JCExpression> thrown = List.nil();
-			finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, params);
+			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params);
 		}
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.ConfigurationKeys;
 import lombok.core.LombokImmutableList;
 import lombok.core.SpiLoadUtil;
 import lombok.core.TypeLibrary;
@@ -102,7 +103,9 @@ public class JavacSingularsRecipes {
 	}
 	
 	public JavacSingularizer getSingularizer(String fqn, JavacNode node) {
-		return singularizers.get(fqn).getGuavaInsteadIfNeeded(node);
+		final JavacSingularizer singularizer = singularizers.get(fqn);
+		final boolean useGuavaInstead = Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.SINGULAR_USE_GUAVA));
+		return useGuavaInstead ? singularizer.getGuavaInstead(node) : singularizer;
 	}
 	
 	public static final class SingularData {
@@ -155,7 +158,7 @@ public class JavacSingularsRecipes {
 	public static abstract class JavacSingularizer {
 		public abstract LombokImmutableList<String> getSupportedTypes();
 
-		protected JavacSingularizer getGuavaInsteadIfNeeded(JavacNode node) {
+		protected JavacSingularizer getGuavaInstead(JavacNode node) {
 			return this;
 		}
 		

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,7 +241,7 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, JavacNode builderType, JCTree source, boolean deprecate, ListBuffer<JCStatement> statements, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+		private void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, JavacNode builderType, JCTree source, boolean deprecate, ListBuffer<JCStatement> statements, Name methodName, List<JCVariableDecl> jcVariableDecls) {
 			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			JCModifiers mods = makeMods(maker, builderType, deprecate);
@@ -252,7 +252,7 @@ public class JavacSingularsRecipes {
 			injectMethod(builderType, method);
 		}
 
-		void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
+		private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
 			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 			statements.add(clearStatement);
@@ -263,7 +263,7 @@ public class JavacSingularsRecipes {
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);
 
-		void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+		private void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
 			List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
 			Name name = data.getSingularName();
@@ -291,7 +291,7 @@ public class JavacSingularsRecipes {
 
 		protected abstract List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
 
-		void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+		private void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generatePluralMethodStatements(maker, data, builderType, source);
 			Name name = data.getPluralName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -251,15 +251,12 @@ public class JavacSingularsRecipes {
 		}
 
 		void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
-
-			List<JCVariableDecl> params = List.nil();
-
 			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
 			List<JCStatement> statements = returnStatement != null ? List.of(clearStatement, returnStatement) : List.of(clearStatement);
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, params);
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.<JCVariableDecl>nil());
 		}
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -250,7 +250,7 @@ public class JavacSingularsRecipes {
 			injectMethod(builderType, method);
 		}
 
-		protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
+		void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 
 			List<JCVariableDecl> params = List.nil();
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -254,8 +254,8 @@ public class JavacSingularsRecipes {
 			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
 			List<JCStatement> statements = returnStatement != null ? List.of(clearStatement, returnStatement) : List.of(clearStatement);
 
-			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
+			JCBlock body = maker.Block(0, statements);
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.<JCVariableDecl>nil());
 		}
 
@@ -265,10 +265,10 @@ public class JavacSingularsRecipes {
 			ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
 			List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
 			if (returnStatement != null) statements.append(returnStatement);
-			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getSingularName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), name.toString()));
 
+			JCBlock body = maker.Block(0, statements.toList());
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, params);
 		}
 
@@ -294,13 +294,13 @@ public class JavacSingularsRecipes {
 		void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generatePluralMethodStatements(maker, data, builderType, source);
 			if (returnStatement != null) statements.append(returnStatement);
-			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getPluralName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
 			JCExpression paramType = getPluralMethodParamType(builderType);
 			paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+			JCBlock body = maker.Block(0, statements.toList());
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 		}
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -231,6 +231,13 @@ public class JavacSingularsRecipes {
 		 */
 		public abstract void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker);
 
+		protected void doGenerateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker) {
+			JavacTreeMaker maker = builderType.getTreeMaker();
+			generateSingularMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
+			generatePluralMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
+			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
+		}
+
 		protected abstract void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source);
 
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -251,6 +251,8 @@ public class JavacSingularsRecipes {
 			injectMethod(builderType, method);
 		}
 
+		protected abstract List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType);
+
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
 		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -266,7 +266,8 @@ public class JavacSingularsRecipes {
 
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
-		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name, long flags) {
+		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name) {
+			long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			JCExpression type = cloneParamType(typeIndex, maker, data.getTypeArgs(), builderType, source);
 			List<JCAnnotation> typeUseAnns = getTypeUseAnnotations(type);
 			type = removeTypeUseAnnotations(type);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -275,6 +275,12 @@ public class JavacSingularsRecipes {
 			return maker.VarDef(mods, name, type, null);
 		}
 
+		protected JCStatement generateSingularMethodAddStatement(JavacTreeMaker maker, JavacNode builderType, Name argumentName, String builderFieldName) {
+			JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", builderFieldName, "add");
+			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(argumentName)));
+			return maker.Exec(invokeAdd);
+		}
+
 		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,7 +241,8 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, boolean deprecate, JCBlock body, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+		void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, boolean deprecate, ListBuffer<JCStatement> statements, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+			JCBlock body = maker.Block(0, statements.toList());
 			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			List<JCTypeParameter> typeParams = List.nil();
 			List<JCExpression> thrown = List.nil();
@@ -257,8 +258,7 @@ public class JavacSingularsRecipes {
 			if (returnStatement != null) statements.append(returnStatement);
 
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			JCBlock body = maker.Block(0, statements.toList());
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.<JCVariableDecl>nil());
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, methodName, List.<JCVariableDecl>nil());
 		}
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);
@@ -270,8 +270,7 @@ public class JavacSingularsRecipes {
 			Name name = data.getSingularName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), name.toString()));
 
-			JCBlock body = maker.Block(0, statements.toList());
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, params);
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, name, params);
 		}
 
 		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name) {
@@ -302,8 +301,7 @@ public class JavacSingularsRecipes {
 			paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-			JCBlock body = maker.Block(0, statements.toList());
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
+			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, name, List.of(param));
 		}
 
 		protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -250,7 +250,6 @@ public class JavacSingularsRecipes {
 		}
 
 		protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
-			JCModifiers mods = makeMods(maker, builderType, deprecate);
 
 			List<JCVariableDecl> params = List.nil();
 
@@ -259,6 +258,7 @@ public class JavacSingularsRecipes {
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
+			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params);
 		}
 
@@ -267,12 +267,12 @@ public class JavacSingularsRecipes {
 		void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
 			List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			Name name = data.getSingularName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), name.toString()));
 
+			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 		}
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -235,6 +235,8 @@ public class JavacSingularsRecipes {
 
 		protected abstract void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
+		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
+
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);
 		
 		public boolean requiresCleaning() {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -255,9 +255,9 @@ public class JavacSingularsRecipes {
 			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
 			ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 			statements.add(clearStatement);
-			if (returnStatement != null) statements.append(returnStatement);
 
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
+			if (returnStatement != null) statements.append(returnStatement);
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, methodName, List.<JCVariableDecl>nil());
 		}
 
@@ -266,10 +266,10 @@ public class JavacSingularsRecipes {
 		void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
 			List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-			if (returnStatement != null) statements.append(returnStatement);
 			Name name = data.getSingularName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), name.toString()));
 
+			if (returnStatement != null) statements.append(returnStatement);
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, name, params);
 		}
 
@@ -294,13 +294,13 @@ public class JavacSingularsRecipes {
 
 		void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 			ListBuffer<JCStatement> statements = generatePluralMethodStatements(maker, data, builderType, source);
-			if (returnStatement != null) statements.append(returnStatement);
 			Name name = data.getPluralName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
 			JCExpression paramType = getPluralMethodParamType(builderType);
 			paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+			if (returnStatement != null) statements.append(returnStatement);
 			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, name, List.of(param));
 		}
 

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -296,6 +296,8 @@ public class JavacSingularsRecipes {
 
 		protected abstract void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent);
 
+		protected abstract JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source);
+
 		public abstract void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable);
 		
 		public boolean requiresCleaning() {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -241,7 +241,8 @@ public class JavacSingularsRecipes {
 			generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 		}
 
-		void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JavacNode builderType, JCTree source, boolean deprecate, ListBuffer<JCStatement> statements, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+		void finishAndInjectMethod(JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, JavacNode builderType, JCTree source, boolean deprecate, ListBuffer<JCStatement> statements, Name methodName, List<JCVariableDecl> jcVariableDecls) {
+			if (returnStatement != null) statements.append(returnStatement);
 			JCBlock body = maker.Block(0, statements.toList());
 			JCModifiers mods = makeMods(maker, builderType, deprecate);
 			List<JCTypeParameter> typeParams = List.nil();
@@ -257,8 +258,7 @@ public class JavacSingularsRecipes {
 			statements.add(clearStatement);
 
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-			if (returnStatement != null) statements.append(returnStatement);
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, methodName, List.<JCVariableDecl>nil());
+			finishAndInjectMethod(maker, returnType, returnStatement, builderType, source, deprecate, statements, methodName, List.<JCVariableDecl>nil());
 		}
 
 		protected abstract JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType);
@@ -269,8 +269,7 @@ public class JavacSingularsRecipes {
 			Name name = data.getSingularName();
 			if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), name.toString()));
 
-			if (returnStatement != null) statements.append(returnStatement);
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, name, params);
+			finishAndInjectMethod(maker, returnType, returnStatement, builderType, source, deprecate, statements, name, params);
 		}
 
 		protected JCVariableDecl generateSingularMethodParameter(int typeIndex, JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, Name name) {
@@ -300,8 +299,7 @@ public class JavacSingularsRecipes {
 			paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-			if (returnStatement != null) statements.append(returnStatement);
-			finishAndInjectMethod(maker, returnType, builderType, source, deprecate, statements, name, List.of(param));
+			finishAndInjectMethod(maker, returnType, returnStatement, builderType, source, deprecate, statements, name, List.of(param));
 		}
 
 		protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -250,8 +250,6 @@ public class JavacSingularsRecipes {
 		protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 			JCModifiers mods = makeMods(maker, builderType, deprecate);
 
-			List<JCTypeParameter> typeParams = List.nil();
-			List<JCExpression> thrown = List.nil();
 			List<JCVariableDecl> params = List.nil();
 
 			JCStatement clearStatement = generateClearStatements(maker, data, builderType);
@@ -259,6 +257,8 @@ public class JavacSingularsRecipes {
 
 			JCBlock body = maker.Block(0, statements);
 			Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
+			List<JCTypeParameter> typeParams = List.nil();
+			List<JCExpression> thrown = List.nil();
 			finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, params);
 		}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -84,17 +84,17 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		LombokImmutableList<String> suffixes = getArgumentSuffixes();
 		Name[] names = new Name[suffixes.size()];
-		for (int i = 0; i < suffixes.size(); i++) {
+		for (int i = 0; i < names.length; i++) {
 			String s = suffixes.get(i);
 			Name n = data.getSingularName();
 			names[i] = s.isEmpty() ? n : builderType.toName(s);
 		}
-		
+
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName());
 		ListBuffer<JCExpression> invokeAddExprBuilder = new ListBuffer<JCExpression>();
-		for (int i = 0; i < suffixes.size(); i++) {
+		for (int i = 0; i < names.length; i++) {
 			invokeAddExprBuilder.append(maker.Ident(names[i]));
 		}
 		List<JCExpression> invokeAddExpr = invokeAddExprBuilder.toList();
@@ -103,7 +103,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		statements.append(st);
 
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
-		for (int i = 0; i < suffixes.size(); i++) {
+		for (int i = 0; i < names.length; i++) {
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -80,13 +80,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 
 	@Override
-	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
-		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, getAddMethodName());
-	}
-
-	private List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		Name[] names = generateSingularMethodParameterNames(data, builderType);
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < names.length; i++) {
@@ -95,7 +89,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		return params.toList();
 	}
 
-	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		Name[] names = generateSingularMethodParameterNames(data, builderType);
 

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -119,25 +119,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 
 	@Override
-	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
-		JCExpression thisDotFieldDotAddAll = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
-		JCExpression invokeAddAll = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAddAll, List.<JCExpression>of(maker.Ident(data.getPluralName())));
-		statements.append(maker.Exec(invokeAddAll));
-
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name methodName = data.getPluralName();
-		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", methodName.toString()));
-		JCExpression paramType = getPluralMethodParamType(builderType);
-		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.of(param));
-    }
-
-	private JCExpression getPluralMethodParamType(JavacNode builderType) {
+	protected JCExpression getPluralMethodParamType(JavacNode builderType) {
 		JCExpression paramType;
 		String aaTypeName = getAddAllTypeName();
 		if (aaTypeName.startsWith("java.lang.") && aaTypeName.indexOf('.', 11) == -1) {
@@ -196,7 +178,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	protected abstract LombokImmutableList<String> getArgumentSuffixes();
 
 	protected abstract String getAddAllTypeName();
-	
+
+	@Override
 	protected int getTypeArgumentsCount() {
 		return getArgumentSuffixes().size();
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -103,14 +103,15 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		JCStatement st = maker.Exec(invokeAdd);
 		statements.append(st);
 
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name methodName = data.getSingularName();
-		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < suffixes.size(); i++) {
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
+
+		if (returnStatement != null) statements.append(returnStatement);
+		JCBlock body = maker.Block(0, statements.toList());
+		Name methodName = data.getSingularName();
+		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
 
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params.toList());
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -90,7 +90,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			names[i] = s.isEmpty() ? n : builderType.toName(s);
 		}
 		
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName());
@@ -108,6 +107,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
 
+		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params.toList(), getAddMethodName());
 	}
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -91,7 +91,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		Name[] names = generateSingularMethodParameterNames(data, builderType);
 
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName());
 		ListBuffer<JCExpression> invokeAddExprBuilder = new ListBuffer<JCExpression>();
 		for (Name name : names) {

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -104,10 +104,10 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name methodName = data.getSingularName();
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < suffixes.size(); i++) {
+			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i], paramFlags));
 		}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -128,7 +128,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name methodName = data.getPluralName();
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", methodName.toString()));
 		JCExpression paramType;
 		String aaTypeName = getAddAllTypeName();
@@ -138,6 +137,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			paramType = chainDotsString(builderType, aaTypeName);
 		}
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
+		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.of(param));
     }

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -86,12 +86,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
 		JCStatement clearField = maker.Exec(maker.Assign(thisDotField, maker.Literal(CTC_BOT, null)));
 		List<JCStatement> statements = returnStatement != null ? List.of(clearField, returnStatement) : List.of(clearField);
-		
-		JCBlock body = maker.Block(0, statements);
-		Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-		JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params, thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+
+		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -108,10 +108,11 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
 
+		String addMethodName = getAddMethodName();
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name methodName = data.getSingularName();
-		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
+		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, methodName.toString()));
 
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params.toList());
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -42,7 +42,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
@@ -120,10 +119,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			JCVariableDecl p = maker.VarDef(paramMods, names[i], pt, null);
 			params.append(p);
 		}
-		
-		JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params.toList(), thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+
+		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, params.toList());
 	}
 	
 	@Override
@@ -150,10 +147,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		}
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, List.of(param), thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
-	}
+        finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, List.of(param));
+    }
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
 		JavacTreeMaker maker = builderType.getTreeMaker();

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -82,12 +82,18 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		List<JCVariableDecl> params = List.nil();
-		
-		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
-		JCStatement clearField = maker.Exec(maker.Assign(thisDotField, maker.Literal(CTC_BOT, null)));
-		List<JCStatement> statements = returnStatement != null ? List.of(clearField, returnStatement) : List.of(clearField);
+
+		List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
 
 		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
+	}
+
+	@Override
+	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
+		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
+
+		JCStatement clearField = maker.Exec(maker.Assign(thisDotField, maker.Literal(CTC_BOT, null)));
+		return returnStatement != null ? List.of(clearField, returnStatement) : List.of(clearField);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -107,8 +107,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < suffixes.size(); i++) {
-			long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i], paramFlags));
+			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
 
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params.toList());

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 
 import lombok.core.GuavaTypeMap;
 import lombok.core.LombokImmutableList;
-import lombok.core.handlers.HandlerUtil;
 import lombok.javac.JavacNode;
 import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacHandlerUtil;
@@ -39,9 +38,7 @@ import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -82,13 +82,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		LombokImmutableList<String> suffixes = getArgumentSuffixes();
-		Name[] names = new Name[suffixes.size()];
-		for (int i = 0; i < names.length; i++) {
-			String s = suffixes.get(i);
-			Name n = data.getSingularName();
-			names[i] = s.isEmpty() ? n : builderType.toName(s);
-		}
+		Name[] names = generateSingularMethodParameterNames(data, builderType);
 
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
@@ -109,7 +103,18 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 
 		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params.toList(), getAddMethodName());
 	}
-	
+
+	private Name[] generateSingularMethodParameterNames(SingularData data, JavacNode builderType) {
+		LombokImmutableList<String> suffixes = getArgumentSuffixes();
+		Name[] names = new Name[suffixes.size()];
+		for (int i = 0; i < names.length; i++) {
+			String s = suffixes.get(i);
+			Name n = data.getSingularName();
+			names[i] = s.isEmpty() ? n : builderType.toName(s);
+		}
+		return names;
+	}
+
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		JCModifiers mods = makeMods(maker, builderType, deprecate);

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -100,7 +100,9 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		}
 		List<JCExpression> invokeAddExpr = invokeAddExprBuilder.toList();
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, invokeAddExpr);
-		statements.append(maker.Exec(invokeAdd));
+		JCStatement st = maker.Exec(invokeAdd);
+		statements.append(st);
+
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name methodName = data.getSingularName();

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -117,9 +117,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			params.append(p);
 		}
 
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, params.toList());
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params.toList());
 	}
 	
 	@Override
@@ -144,9 +142,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		}
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-        finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, List.of(param));
     }
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -77,18 +77,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 	
 	@Override
-	protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		List<JCVariableDecl> params = List.nil();
-
-		List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
-
-		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
-	}
-
-	@Override
 	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
 		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
 

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -73,10 +73,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 	
 	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker) {
-		JavacTreeMaker maker = builderType.getTreeMaker();
-		generateSingularMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
-		generatePluralMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
-		generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
+		doGenerateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 	}
 	
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -94,8 +94,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName());
 		ListBuffer<JCExpression> invokeAddExprBuilder = new ListBuffer<JCExpression>();
-		for (int i = 0; i < names.length; i++) {
-			invokeAddExprBuilder.append(maker.Ident(names[i]));
+		for (Name name : names) {
+			invokeAddExprBuilder.append(maker.Ident(name));
 		}
 		List<JCExpression> invokeAddExpr = invokeAddExprBuilder.toList();
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, invokeAddExpr);

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -79,7 +79,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 	}
 	
-	private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -108,13 +108,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
 
-		String addMethodName = getAddMethodName();
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name methodName = data.getSingularName();
-		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, methodName.toString()));
-
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params.toList());
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params.toList(), getAddMethodName());
 	}
 	
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -95,8 +95,9 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		recursiveSetGeneratedBy(method, source, builderType.getContext());
 		injectMethod(builderType, method);
 	}
-	
-	void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+
+	@Override
+	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -108,8 +108,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < suffixes.size(); i++) {
-			JCVariableDecl p = generateSingularMethodParameter(i, maker, data, builderType, source, names[i], paramFlags);
-			params.append(p);
+			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i], paramFlags));
 		}
 
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, params.toList());

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -139,8 +139,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		}
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, methodName, List.of(param));
     }
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -77,11 +77,9 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 	
 	@Override
-	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
+	protected JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType) {
 		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
-
-		JCStatement clearField = maker.Exec(maker.Assign(thisDotField, maker.Literal(CTC_BOT, null)));
-		return returnStatement != null ? List.of(clearField, returnStatement) : List.of(clearField);
+		return maker.Exec(maker.Assign(thisDotField, maker.Literal(CTC_BOT, null)));
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -107,8 +107,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			params.append(generateSingularMethodParameter(i, maker, data, builderType, source, names[i]));
 		}
 
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params.toList(), getAddMethodName());
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params.toList(), getAddMethodName());
 	}
 	
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -193,7 +193,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 	
 	protected abstract LombokImmutableList<String> getArgumentSuffixes();
-	protected abstract String getAddMethodName();
+
 	protected abstract String getAddAllTypeName();
 	
 	protected int getTypeArgumentsCount() {

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -83,9 +83,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		
 		LombokImmutableList<String> suffixes = getArgumentSuffixes();
 		Name[] names = new Name[suffixes.size()];
 		for (int i = 0; i < suffixes.size(); i++) {
@@ -120,13 +117,13 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 			params.append(p);
 		}
 
+		List<JCTypeParameter> typeParams = List.nil();
+		List<JCExpression> thrown = List.nil();
 		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, params.toList());
 	}
 	
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
@@ -147,6 +144,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		}
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+		List<JCTypeParameter> typeParams = List.nil();
+		List<JCExpression> thrown = List.nil();
         finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, methodName, List.of(param));
     }
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -120,7 +120,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		JCExpression thisDotFieldDotAddAll = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
@@ -140,6 +139,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		}
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, methodName, List.of(param));
     }
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -88,7 +88,6 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 
 	@Override
 	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		Name[] names = generateSingularMethodParameterNames(data, builderType);
 
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName());
@@ -99,8 +98,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		List<JCExpression> invokeAddExpr = invokeAddExprBuilder.toList();
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, invokeAddExpr);
 		JCStatement st = maker.Exec(invokeAdd);
-		statements.append(st);
-		return statements;
+
+		return new ListBuffer<JCStatement>().append(st);
 	}
 
 	private Name[] generateSingularMethodParameterNames(SingularData data, JavacNode builderType) {

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -141,6 +141,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		injectMethod(builderType, method);
 	}
 	
+	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -44,7 +44,6 @@ import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
-import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
@@ -109,11 +108,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		if (!fluent) methodName = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName(), methodName.toString()));
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < suffixes.size(); i++) {
-			JCExpression pt = cloneParamType(i, maker, data.getTypeArgs(), builderType, source);
-			List<JCAnnotation> typeUseAnns = getTypeUseAnnotations(pt);
-			pt = removeTypeUseAnnotations(pt);
-			JCModifiers paramMods = typeUseAnns.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnns);
-			JCVariableDecl p = maker.VarDef(paramMods, names[i], pt, null);
+			JCVariableDecl p = generateSingularMethodParameter(i, maker, data, builderType, source, names[i], paramFlags);
 			params.append(p);
 		}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -178,7 +178,8 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		JCStatement jcs = maker.VarDef(maker.Modifiers(0), data.getPluralName(), varType, init);
 		statements.append(jcs);
 	}
-	
+
+	@Override
 	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		List<JCExpression> jceBlank = List.nil();
 		

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -101,12 +101,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression cond = maker.Binary(CTC_NOT_EQUAL, thisDotField, maker.Literal(CTC_BOT, null));
 		JCStatement ifSetCallClear = maker.If(cond, clearCall, null);
 		List<JCStatement> statements = returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
-		
-		JCBlock body = maker.Block(0, statements);
-		Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-		JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params, thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+
+		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -26,7 +26,6 @@ import static lombok.javac.handlers.JavacHandlerUtil.*;
 
 import java.util.Collections;
 
-import lombok.core.handlers.HandlerUtil;
 import lombok.javac.JavacNode;
 import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacHandlerUtil;
@@ -36,9 +35,7 @@ import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -105,8 +105,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		List<JCVariableDecl> params = List.of(param);
 
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params, "add");
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "add");
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -45,12 +45,8 @@ import com.sun.tools.javac.util.Name;
 
 abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularizer {
 
-	@Override
-	protected JavacSingularizer getGuavaInsteadIfNeeded(JavacNode node) {
-		if (useGuavaInstead(node)) {
-			return guavaListSetSingularizer;
-		}
-		return this;
+	@Override protected JavacSingularizer getGuavaInstead(JavacNode node) {
+		return guavaListSetSingularizer;
 	}
 
 	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -88,18 +88,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 
 	@Override
-	protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		List<JCVariableDecl> params = List.nil();
-
-		List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
-
-		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
-	}
-
-	@Override
 	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
 		List<JCExpression> jceBlank = List.nil();
 		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -98,14 +98,21 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
+		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "add");
+	}
+
+	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
 		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
+		return statements;
+	}
 
+	private List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
-		List<JCVariableDecl> params = List.of(param);
-
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "add");
+		return List.of(param);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -110,8 +110,9 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		recursiveSetGeneratedBy(method, source, builderType.getContext());
 		injectMethod(builderType, method);
 	}
-	
-	void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+
+	@Override
+	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -134,7 +134,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 
-	private String getAddMethodName() {
+	@Override
+	protected String getAddMethodName() {
 		return "add";
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -98,7 +98,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
 		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
@@ -106,6 +105,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		List<JCVariableDecl> params = List.of(param);
 
+		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params, "add");
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -85,7 +85,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	@Override
 	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 		return statements;
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -108,9 +108,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getSingularName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
-		Name paramName = data.getSingularName();
 
-		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, paramName);
+		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -123,7 +123,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		Name name = data.getPluralName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("addAll", name.toString()));
 		JCExpression paramType = getPluralMethodParamType(builderType);
-		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
+		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
@@ -136,5 +136,9 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	@Override
 	protected String getAddMethodName() {
 		return "add";
+	}
+
+	private int getTypeArgumentsCount() {
+		return 1;
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -106,13 +106,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		List<JCVariableDecl> params = List.of(param);
 
-		String addMethodName = "add";
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name name = data.getSingularName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, name.toString()));
-
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params, "add");
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -99,7 +99,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	@Override
 	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
+		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 		return statements;
 	}
@@ -113,7 +113,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
+		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
 		statements.append(maker.Exec(invokeAdd));
@@ -131,6 +131,10 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 
 	private JCExpression getPluralMethodParamType(JavacNode builderType) {
 		return chainDots(builderType, "java", "util", "Collection");
+	}
+
+	private JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+		return createConstructBuilderVarIfNeeded(maker, data, builderType, false, source);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -106,10 +106,11 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		List<JCVariableDecl> params = List.of(param);
 
+		String addMethodName = "add";
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getSingularName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
+		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, name.toString()));
 
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -103,13 +103,14 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
 		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 
+		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
+		List<JCVariableDecl> params = List.of(param);
+
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getSingularName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
 
-		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
-		List<JCVariableDecl> params = List.of(param);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -122,11 +122,15 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getPluralName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("addAll", name.toString()));
-		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
+		JCExpression paramType = getPluralMethodParamType(builderType);
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
+	}
+
+	private JCExpression getPluralMethodParamType(JavacNode builderType) {
+		return chainDots(builderType, "java", "util", "Collection");
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -136,8 +136,9 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		recursiveSetGeneratedBy(method, source, builderType.getContext());
 		injectMethod(builderType, method);
 	}
-	
-	void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+
+	@Override
+	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -88,7 +88,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 
 	@Override
-	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
+	protected JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType) {
 		List<JCExpression> jceBlank = List.nil();
 		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
 		JCExpression thisDotFieldDotClear = maker.Select(maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName()), builderType.toName("clear"));
@@ -96,8 +96,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCStatement clearCall = maker.Exec(maker.Apply(jceBlank, thisDotFieldDotClear, jceBlank));
 		JCExpression cond = maker.Binary(CTC_NOT_EQUAL, thisDotField, maker.Literal(CTC_BOT, null));
 
-		JCStatement ifSetCallClear = maker.If(cond, clearCall, null);
-		return returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
+		return maker.If(cond, clearCall, null);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -111,11 +111,12 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		Name name = data.getSingularName();
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
+		Name paramName = data.getSingularName();
 		JCExpression paramType = cloneParamType(0, maker, data.getTypeArgs(), builderType, source);
 		List<JCAnnotation> typeUseAnns = getTypeUseAnnotations(paramType);
 		paramType = removeTypeUseAnnotations(paramType);
 		JCModifiers paramMods = typeUseAnns.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnns);
-		JCVariableDecl param = maker.VarDef(paramMods, data.getSingularName(), paramType, null);
+		JCVariableDecl param = maker.VarDef(paramMods, paramName, paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -93,16 +93,23 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		List<JCVariableDecl> params = List.nil();
-		List<JCExpression> jceBlank = List.nil();
-		
-		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
-		JCExpression thisDotFieldDotClear = maker.Select(maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName()), builderType.toName("clear"));
-		JCStatement clearCall = maker.Exec(maker.Apply(jceBlank, thisDotFieldDotClear, jceBlank));
-		JCExpression cond = maker.Binary(CTC_NOT_EQUAL, thisDotField, maker.Literal(CTC_BOT, null));
-		JCStatement ifSetCallClear = maker.If(cond, clearCall, null);
-		List<JCStatement> statements = returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
+
+		List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
 
 		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
+	}
+
+	@Override
+	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
+		List<JCExpression> jceBlank = List.nil();
+		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());
+		JCExpression thisDotFieldDotClear = maker.Select(maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName()), builderType.toName("clear"));
+
+		JCStatement clearCall = maker.Exec(maker.Apply(jceBlank, thisDotFieldDotClear, jceBlank));
+		JCExpression cond = maker.Binary(CTC_NOT_EQUAL, thisDotField, maker.Literal(CTC_BOT, null));
+
+		JCStatement ifSetCallClear = maker.If(cond, clearCall, null);
+		return returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -89,8 +89,9 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		generatePluralMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
 		generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 	}
-	
-	private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
+
+	@Override
+	protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -109,7 +109,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
 
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
+		List<JCVariableDecl> params = List.of(param);
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -114,14 +114,14 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
-		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), "addAll");
+		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
 		statements.append(maker.Exec(invokeAdd));
 
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getPluralName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("addAll", name.toString()));
+		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
 		JCExpression paramType = getPluralMethodParamType(builderType);
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -100,8 +100,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
@@ -118,13 +116,13 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		paramType = removeTypeUseAnnotations(paramType);
 		JCModifiers paramMods = typeUseAnns.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnns);
 		JCVariableDecl param = maker.VarDef(paramMods, data.getSingularName(), paramType, null);
+		List<JCTypeParameter> typeParams = List.nil();
+		List<JCExpression> thrown = List.nil();
 		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(param));
 	}
 
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
@@ -139,6 +137,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+		List<JCTypeParameter> typeParams = List.nil();
+		List<JCExpression> thrown = List.nil();
 		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(param));
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -110,8 +110,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
 		Name paramName = data.getSingularName();
 
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, paramName, paramFlags);
+		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, paramName);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -112,7 +112,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), "addAll");
@@ -126,6 +125,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -44,6 +44,7 @@ import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
 
 abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularizer {
+	private final JavacSingularizer guavaListSetSingularizer = new JavacGuavaSetListSingularizer();
 
 	@Override protected JavacSingularizer getGuavaInstead(JavacNode node) {
 		return guavaListSetSingularizer;

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -103,7 +103,9 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), "add");
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getSingularName())));
-		statements.append(maker.Exec(invokeAdd));
+		JCStatement st = maker.Exec(invokeAdd);
+		statements.append(st);
+
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getSingularName();

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -117,13 +117,14 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), "addAll");
 		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
 		statements.append(maker.Exec(invokeAdd));
+
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getPluralName();
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("addAll", name.toString()));
 		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
+		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -44,10 +44,9 @@ import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
 
 abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularizer {
-	private final JavacSingularizer guavaListSetSingularizer = new JavacGuavaSetListSingularizer();
 
 	@Override protected JavacSingularizer getGuavaInstead(JavacNode node) {
-		return guavaListSetSingularizer;
+		return new JavacGuavaSetListSingularizer();
 	}
 
 	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -101,8 +101,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
-		JCStatement st = generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString());
-		statements.append(st);
+		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -133,7 +133,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		return chainDots(builderType, "java", "util", "Collection");
 	}
 
-	private JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		return createConstructBuilderVarIfNeeded(maker, data, builderType, false, source);
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -125,8 +125,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -116,9 +116,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		paramType = removeTypeUseAnnotations(paramType);
 		JCModifiers paramMods = typeUseAnns.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnns);
 		JCVariableDecl param = maker.VarDef(paramMods, data.getSingularName(), paramType, null);
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 
 	@Override
@@ -137,8 +135,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -107,9 +107,10 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getSingularName();
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
 		Name paramName = data.getSingularName();
+
+		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, paramName, paramFlags);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -84,9 +84,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 
 	@Override
 	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
-		return statements;
+		return new ListBuffer<JCStatement>()
+			.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -83,11 +83,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 			return;
 		}
-		
-		JavacTreeMaker maker = builderType.getTreeMaker();
-		generateSingularMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
-		generatePluralMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
-		generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
+
+		doGenerateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -39,7 +39,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
@@ -119,9 +118,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		paramType = removeTypeUseAnnotations(paramType);
 		JCModifiers paramMods = typeUseAnns.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnns);
 		JCVariableDecl param = maker.VarDef(paramMods, data.getSingularName(), paramType, null);
-		JCMethodDecl method = maker.MethodDef(mods, name, returnType, typeParams, List.of(param), thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(param));
 	}
 
 	@Override
@@ -142,8 +139,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCExpression paramType = chainDots(builderType, "java", "util", "Collection");
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		JCMethodDecl method = maker.MethodDef(mods, name, returnType, typeParams, List.of(param), thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(param));
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -111,25 +111,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 
 	@Override
-	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
-		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName() + "All");
-		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getPluralName())));
-		statements.append(maker.Exec(invokeAdd));
-
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name name = data.getPluralName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
-		JCExpression paramType = getPluralMethodParamType(builderType);
-		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
-	}
-
-	private JCExpression getPluralMethodParamType(JavacNode builderType) {
+	protected JCExpression getPluralMethodParamType(JavacNode builderType) {
 		return chainDots(builderType, "java", "util", "Collection");
 	}
 
@@ -143,7 +125,8 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		return "add";
 	}
 
-	private int getTypeArgumentsCount() {
+	@Override
+	protected int getTypeArgumentsCount() {
 		return 1;
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -100,7 +100,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
 		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "add");
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, getAddMethodName());
 	}
 
 	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
@@ -132,5 +132,9 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		paramType = addTypeArgs(1, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
+	}
+
+	private String getAddMethodName() {
+		return "add";
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -97,20 +97,15 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 
 	@Override
-	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
-		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, getAddMethodName());
-	}
-
-	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
 		statements.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 		return statements;
 	}
 
-	private List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		return List.of(param);
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -101,9 +101,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, false, source));
-		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), "add");
-		JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotFieldDotAdd, List.<JCExpression>of(maker.Ident(data.getSingularName())));
-		JCStatement st = maker.Exec(invokeAdd);
+		JCStatement st = generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString());
 		statements.append(st);
 
 		if (returnStatement != null) statements.append(returnStatement);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -30,6 +30,7 @@ import lombok.javac.JavacNode;
 import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacHandlerUtil;
 import lombok.javac.handlers.JavacSingularsRecipes.ExpressionMaker;
+import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 
@@ -43,27 +44,24 @@ import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
 
 abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularizer {
-	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {
-		if (useGuavaInstead(builderType)) {
-			return guavaListSetSingularizer.listFieldsToBeGenerated(data, builderType);
+
+	@Override
+	protected JavacSingularizer getGuavaInsteadIfNeeded(JavacNode node) {
+		if (useGuavaInstead(node)) {
+			return guavaListSetSingularizer;
 		}
-		
+		return this;
+	}
+
+	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {
 		return super.listFieldsToBeGenerated(data, builderType);
 	}
 	
 	@Override public java.util.List<Name> listMethodsToBeGenerated(SingularData data, JavacNode builderType) {
-		if (useGuavaInstead(builderType)) {
-			return guavaListSetSingularizer.listMethodsToBeGenerated(data, builderType);
-		}
-		
 		return super.listMethodsToBeGenerated(data, builderType);
 	}
 	
 	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JCTree source) {
-		if (useGuavaInstead(builderType)) {
-			return guavaListSetSingularizer.generateFields(data, builderType, source);
-		}
-		
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		JCExpression type = JavacHandlerUtil.chainDots(builderType, "java", "util", "ArrayList");
 		type = addTypeArgs(1, false, builderType, type, data.getTypeArgs(), source);
@@ -73,11 +71,6 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 	
 	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker) {
-		if (useGuavaInstead(builderType)) {
-			guavaListSetSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
-			return;
-		}
-
 		doGenerateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -36,12 +36,10 @@ import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
-import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
@@ -112,11 +110,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("add", name.toString()));
 		Name paramName = data.getSingularName();
-		JCExpression paramType = cloneParamType(0, maker, data.getTypeArgs(), builderType, source);
-		List<JCAnnotation> typeUseAnns = getTypeUseAnnotations(paramType);
-		paramType = removeTypeUseAnnotations(paramType);
-		JCModifiers paramMods = typeUseAnns.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnns);
-		JCVariableDecl param = maker.VarDef(paramMods, paramName, paramType, null);
+		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, paramName, paramFlags);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSingularizer.java
@@ -47,11 +47,6 @@ public class JavacJavaUtilListSingularizer extends JavacJavaUtilListSetSingulari
 	}
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
-		if (useGuavaInstead(builderType)) {
-			guavaListSetSingularizer.appendBuildCode(data, builderType, source, statements, targetVariableName, builderVariable);
-			return;
-		}
-		
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCCase> cases = new ListBuffer<JCCase>();

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -27,7 +27,6 @@ import static lombok.javac.handlers.JavacHandlerUtil.*;
 import java.util.Arrays;
 
 import lombok.core.LombokImmutableList;
-import lombok.core.handlers.HandlerUtil;
 import lombok.javac.JavacNode;
 import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacHandlerUtil;
@@ -42,7 +41,6 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -164,16 +164,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression entrySetInvocation = maker.Apply(jceBlank, maker.Select(maker.Ident(data.getPluralName()), builderType.toName("entrySet")), jceBlank);
 		JCStatement forEach = maker.ForeachLoop(maker.VarDef(maker.Modifiers(baseFlags), entryName, forEachType, null), entrySetInvocation, forEachBody);
 		statements.append(forEach);
-		
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name name = data.getPluralName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
-		JCExpression paramType = getPluralMethodParamType(builderType);
-		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
+
+		finishAndInjectPluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent, statements);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -145,7 +145,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 
 		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName);
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(paramKey, paramValue));
+		List<JCVariableDecl> params = List.of(paramKey, paramValue);
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -131,14 +131,9 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
-		/* this.pluralname$key.add(singularnameKey); */ {
-			JCStatement st = generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key");
-			statements.append(st);
-		}
-		/* this.pluralname$value.add(singularnameValue); */ {
-			JCStatement st = generateSingularMethodAddStatement(maker, builderType, valueName, data.getPluralName() + "$value");
-			statements.append(st);
-		}
+		statements.append(generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key"));
+		statements.append(generateSingularMethodAddStatement(maker, builderType, valueName, data.getPluralName() + "$value"));
+
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -135,12 +135,14 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		/* this.pluralname$key.add(singularnameKey); */ {
 			JCExpression thisDotKeyFieldDotAdd = chainDots(builderType, "this", data.getPluralName() + "$key", "add");
 			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotKeyFieldDotAdd, List.<JCExpression>of(maker.Ident(keyName)));
-			statements.append(maker.Exec(invokeAdd));
+			JCStatement st = maker.Exec(invokeAdd);
+			statements.append(st);
 		}
 		/* this.pluralname$value.add(singularnameValue); */ {
 			JCExpression thisDotValueFieldDotAdd = chainDots(builderType, "this", data.getPluralName() + "$value", "add");
 			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotValueFieldDotAdd, List.<JCExpression>of(maker.Ident(valueName)));
-			statements.append(maker.Exec(invokeAdd));
+			JCStatement st = maker.Exec(invokeAdd);
+			statements.append(st);
 		}
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -115,7 +115,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		/* Generates: this.pluralname$key.add(singularnameKey); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key"));
 		/* Generates: this.pluralname$value.add(singularnameValue); */
@@ -136,7 +135,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		long baseFlags = JavacHandlerUtil.addFinalIfNeeded(0, builderType.getContext());
 		Name entryName = builderType.toName("$lombokEntry");
 		

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -147,7 +147,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 
 	@Override
-	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+	protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
@@ -164,8 +164,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression entrySetInvocation = maker.Apply(jceBlank, maker.Select(maker.Ident(data.getPluralName()), builderType.toName("entrySet")), jceBlank);
 		JCStatement forEach = maker.ForeachLoop(maker.VarDef(maker.Modifiers(baseFlags), entryName, forEachType, null), entrySetInvocation, forEachBody);
 		statements.append(forEach);
-
-		finishAndInjectPluralMethod(deprecate, maker, returnType, returnStatement, data, builderType, source, fluent, statements);
+		return statements;
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -108,11 +108,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 			guavaMapSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 			return;
 		}
-		
-		JavacTreeMaker maker = builderType.getTreeMaker();
-		generateSingularMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
-		generatePluralMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
-		generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
+
+		doGenerateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -182,7 +182,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		injectMethod(builderType, method);
 	}
 
-	private void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+	@Override
+	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> jceBlank = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -113,19 +113,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 
 	@Override
-	protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		List<JCVariableDecl> params = List.nil();
-
-		List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
-
-		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
-	}
-
-	@Override
 	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
 		List<JCExpression> jceBlank = List.nil();
 		

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -144,11 +144,11 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		}
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-		
+
 		Name name = data.getSingularName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
 
+		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName, paramFlags);
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName, paramFlags);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(paramKey, paramValue));

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -125,8 +125,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
@@ -141,6 +139,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
 		List<JCVariableDecl> params = List.of(paramKey, paramValue);
 
+		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params, "put");
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -197,7 +197,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		}
 	}
 
-	private String getAddMethodName() {
+	@Override
+	protected String getAddMethodName() {
 		return "put";
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -53,12 +53,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap");
 	}
 
-	@Override
-	protected JavacSingularizer getGuavaInsteadIfNeeded(JavacNode node) {
-		if (useGuavaInstead(node)) {
-			return guavaMapSingularizer;
-		}
-		return this;
+	@Override protected JavacSingularizer getGuavaInstead(JavacNode node) {
+		return guavaMapSingularizer;
 	}
 
 	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -130,12 +130,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCBlock clearCalls = maker.Block(0, List.of(clearKeyCall, clearValueCall));
 		JCStatement ifSetCallClear = maker.If(cond, clearCalls, null);
 		List<JCStatement> statements = returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
-		
-		JCBlock body = maker.Block(0, statements);
-		Name methodName = builderType.toName(HandlerUtil.buildAccessorName("clear", data.getPluralName().toString()));
-		JCMethodDecl method = maker.MethodDef(mods, methodName, returnType, typeParams, params, thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+
+		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
 	}
 	
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -141,10 +141,11 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
 		List<JCVariableDecl> params = List.of(paramKey, paramValue);
 
+		String addMethodName = "put";
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getSingularName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
+		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, name.toString()));
 
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -111,10 +111,10 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 
 	@Override
 	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
-		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 
+		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		/* Generates: this.pluralname$key.add(singularnameKey); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key"));
 		/* Generates: this.pluralname$value.add(singularnameValue); */

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -149,7 +149,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCExpression> jceBlank = List.nil();
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
@@ -174,6 +173,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -168,7 +168,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		if (returnStatement != null) statements.append(returnStatement);
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getPluralName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("putAll", name.toString()));
+		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(getAddMethodName() + "All", name.toString()));
 		JCExpression paramType = getPluralMethodParamType(builderType);
 		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -114,8 +114,9 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		generatePluralMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source, fluent);
 		generateClearMethod(deprecate, maker, returnTypeMaker.make(), returnStatementMaker.make(), data, builderType, source);
 	}
-	
-	private void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
+
+	@Override
+	protected void generateClearMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source) {
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		
 		List<JCTypeParameter> typeParams = List.nil();

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -170,7 +170,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		Name name = data.getPluralName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("putAll", name.toString()));
 		JCExpression paramType = getPluralMethodParamType(builderType);
-		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
+		paramType = addTypeArgs(getTypeArgumentsCount(), true, builderType, paramType, data.getTypeArgs(), source);
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
@@ -198,5 +198,9 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	@Override
 	protected String getAddMethodName() {
 		return "put";
+	}
+
+	private int getTypeArgumentsCount() {
+		return 2;
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -127,8 +127,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
@@ -161,12 +159,13 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCModifiers paramModsValue = typeUseAnnsValue.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsValue);
 		JCVariableDecl paramKey = maker.VarDef(paramModsKey, keyName, paramTypeKey, null);
 		JCVariableDecl paramValue = maker.VarDef(paramModsValue, valueName, paramTypeValue, null);
+		List<JCTypeParameter> typeParams = List.nil();
+		List<JCExpression> thrown = List.nil();
 		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(paramKey, paramValue));
 	}
 
 	@Override
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> jceBlank = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
@@ -193,6 +192,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
+		List<JCTypeParameter> typeParams = List.nil();
 		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, jceBlank, mods, body, name, List.of(param));
 	}
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -141,13 +141,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
 		List<JCVariableDecl> params = List.of(paramKey, paramValue);
 
-		String addMethodName = "put";
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-		Name name = data.getSingularName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName(addMethodName, name.toString()));
-
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params, "put");
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -159,9 +159,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCModifiers paramModsValue = typeUseAnnsValue.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsValue);
 		JCVariableDecl paramKey = maker.VarDef(paramModsKey, keyName, paramTypeKey, null);
 		JCVariableDecl paramValue = maker.VarDef(paramModsValue, valueName, paramTypeValue, null);
-		List<JCTypeParameter> typeParams = List.nil();
-		List<JCExpression> thrown = List.nil();
-		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(paramKey, paramValue));
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(paramKey, paramValue));
 	}
 
 	@Override
@@ -192,8 +190,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		List<JCTypeParameter> typeParams = List.nil();
-		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, jceBlank, mods, body, name, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
 	}
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -119,6 +119,14 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		List<JCVariableDecl> params = List.nil();
+
+		List<JCStatement> statements = generateClearStatements(maker, returnStatement, data, builderType);
+
+		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
+	}
+
+	@Override
+	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
 		List<JCExpression> jceBlank = List.nil();
 		
 		JCExpression thisDotKeyField = chainDots(builderType, "this", data.getPluralName() + "$key");
@@ -129,9 +137,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression cond = maker.Binary(CTC_NOT_EQUAL, thisDotKeyField, maker.Literal(CTC_BOT, null));
 		JCBlock clearCalls = maker.Block(0, List.of(clearKeyCall, clearValueCall));
 		JCStatement ifSetCallClear = maker.If(cond, clearCalls, null);
-		List<JCStatement> statements = returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
-
-		finishGenerateClearMethod(maker, returnType, data, builderType, source, mods, typeParams, thrown, params, statements);
+		return returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
 	}
 	
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -176,7 +176,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 	}
 
-	private JCExpression getPluralMethodParamType(JavacNode builderType) {
+	@Override
+	protected JCExpression getPluralMethodParamType(JavacNode builderType) {
 		return chainDots(builderType, "java", "util", "Map");
 	}
 
@@ -205,7 +206,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return "put";
 	}
 
-	private int getTypeArgumentsCount() {
+	@Override
+	protected int getTypeArgumentsCount() {
 		return 2;
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -122,15 +122,9 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCBlock clearCalls = maker.Block(0, List.of(clearKeyCall, clearValueCall));
 		return maker.If(cond, clearCalls, null);
 	}
-	
-	@Override
-	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
-		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
-		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, getAddMethodName());
-	}
 
-	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
@@ -143,7 +137,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return statements;
 	}
 
-	private List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -139,8 +139,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
 		List<JCVariableDecl> params = List.of(paramKey, paramValue);
 
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, mods, statements, params, "put");
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "put");
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -137,15 +137,15 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		/* Generates: this.pluralname$value.add(singularnameValue); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, valueName, data.getPluralName() + "$value"));
 
-		if (returnStatement != null) statements.append(returnStatement);
-		JCBlock body = maker.Block(0, statements.toList());
-
-		Name name = data.getSingularName();
-		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
-
 		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName);
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
 		List<JCVariableDecl> params = List.of(paramKey, paramValue);
+
+		if (returnStatement != null) statements.append(returnStatement);
+		JCBlock body = maker.Block(0, statements.toList());
+		Name name = data.getSingularName();
+		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
+
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, params);
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -149,15 +149,17 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		
 		Name name = data.getSingularName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
+
 		JCExpression paramTypeKey = cloneParamType(0, maker, data.getTypeArgs(), builderType, source);
-		JCExpression paramTypeValue = cloneParamType(1, maker, data.getTypeArgs(), builderType, source);
 		List<JCAnnotation> typeUseAnnsKey = getTypeUseAnnotations(paramTypeKey);
-		List<JCAnnotation> typeUseAnnsValue = getTypeUseAnnotations(paramTypeValue);
 		paramTypeKey = removeTypeUseAnnotations(paramTypeKey);
-		paramTypeValue = removeTypeUseAnnotations(paramTypeValue);
 		JCModifiers paramModsKey = typeUseAnnsKey.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsKey);
-		JCModifiers paramModsValue = typeUseAnnsValue.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsValue);
 		JCVariableDecl paramKey = maker.VarDef(paramModsKey, keyName, paramTypeKey, null);
+
+		JCExpression paramTypeValue = cloneParamType(1, maker, data.getTypeArgs(), builderType, source);
+		List<JCAnnotation> typeUseAnnsValue = getTypeUseAnnotations(paramTypeValue);
+		paramTypeValue = removeTypeUseAnnotations(paramTypeValue);
+		JCModifiers paramModsValue = typeUseAnnsValue.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsValue);
 		JCVariableDecl paramValue = maker.VarDef(paramModsValue, valueName, paramTypeValue, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(paramKey, paramValue));
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -43,7 +43,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
@@ -162,9 +161,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCModifiers paramModsValue = typeUseAnnsValue.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsValue);
 		JCVariableDecl paramKey = maker.VarDef(paramModsKey, keyName, paramTypeKey, null);
 		JCVariableDecl paramValue = maker.VarDef(paramModsValue, valueName, paramTypeValue, null);
-		JCMethodDecl method = maker.MethodDef(mods, name, returnType, typeParams, List.of(paramKey, paramValue), thrown, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, thrown, mods, body, name, List.of(paramKey, paramValue));
 	}
 
 	@Override
@@ -196,9 +193,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		JCMethodDecl method = maker.MethodDef(mods, name, returnType, typeParams, List.of(param), jceBlank, body, null);
-		recursiveSetGeneratedBy(method, source, builderType.getContext());
-		injectMethod(builderType, method);
+		finishAndInjectMethod(maker, returnType, builderType, source, typeParams, jceBlank, mods, body, name, List.of(param));
 	}
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -49,14 +49,13 @@ import com.sun.tools.javac.util.Name;
 
 @ProviderFor(JavacSingularizer.class)
 public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
-	private final JavacSingularizer guavaMapSingularizer = new JavacGuavaMapSingularizer();
 
 	@Override public LombokImmutableList<String> getSupportedTypes() {
 		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap");
 	}
 
 	@Override protected JavacSingularizer getGuavaInstead(JavacNode node) {
-		return guavaMapSingularizer;
+		return new JavacGuavaMapSingularizer();
 	}
 
 	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -131,7 +131,10 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
+
+		/* Generates: this.pluralname$key.add(singularnameKey); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key"));
+		/* Generates: this.pluralname$value.add(singularnameValue); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, valueName, data.getPluralName() + "$value"));
 
 		if (returnStatement != null) statements.append(returnStatement);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -151,7 +151,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		long baseFlags = JavacHandlerUtil.addFinalIfNeeded(0, builderType.getContext());
 		Name entryName = builderType.toName("$lombokEntry");
 		
@@ -172,6 +171,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("putAll", name.toString()));
 		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
+		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -45,7 +45,6 @@ import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
-import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
@@ -150,17 +149,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		Name name = data.getSingularName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
 
-		JCExpression paramTypeKey = cloneParamType(0, maker, data.getTypeArgs(), builderType, source);
-		List<JCAnnotation> typeUseAnnsKey = getTypeUseAnnotations(paramTypeKey);
-		paramTypeKey = removeTypeUseAnnotations(paramTypeKey);
-		JCModifiers paramModsKey = typeUseAnnsKey.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsKey);
-		JCVariableDecl paramKey = maker.VarDef(paramModsKey, keyName, paramTypeKey, null);
-
-		JCExpression paramTypeValue = cloneParamType(1, maker, data.getTypeArgs(), builderType, source);
-		List<JCAnnotation> typeUseAnnsValue = getTypeUseAnnotations(paramTypeValue);
-		paramTypeValue = removeTypeUseAnnotations(paramTypeValue);
-		JCModifiers paramModsValue = typeUseAnnsValue.isEmpty() ? maker.Modifiers(paramFlags) : maker.Modifiers(paramFlags, typeUseAnnsValue);
-		JCVariableDecl paramValue = maker.VarDef(paramModsValue, valueName, paramTypeValue, null);
+		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName, paramFlags);
+		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName, paramFlags);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(paramKey, paramValue));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -49,6 +49,8 @@ import com.sun.tools.javac.util.Name;
 
 @ProviderFor(JavacSingularizer.class)
 public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
+	private final JavacSingularizer guavaMapSingularizer = new JavacGuavaMapSingularizer();
+
 	@Override public LombokImmutableList<String> getSupportedTypes() {
 		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap");
 	}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -125,21 +125,30 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	
 	@Override
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
+		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "put");
+	}
+
+	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 
+		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
 		/* Generates: this.pluralname$key.add(singularnameKey); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key"));
 		/* Generates: this.pluralname$value.add(singularnameValue); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, valueName, data.getPluralName() + "$value"));
+		return statements;
+	}
 
+	private List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
+		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName);
 		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
-		List<JCVariableDecl> params = List.of(paramKey, paramValue);
-
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "put");
+		return List.of(paramKey, paramValue);
 	}
 
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -140,7 +140,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		injectMethod(builderType, method);
 	}
 	
-	private void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
+	@Override
+	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCTypeParameter> typeParams = List.nil();
 		List<JCExpression> thrown = List.nil();
 		JCModifiers mods = makeMods(maker, builderType, deprecate);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -52,29 +52,25 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
 		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap");
 	}
-	
-	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {
-		if (useGuavaInstead(builderType)) {
-			return guavaMapSingularizer.listFieldsToBeGenerated(data, builderType);
+
+	@Override
+	protected JavacSingularizer getGuavaInsteadIfNeeded(JavacNode node) {
+		if (useGuavaInstead(node)) {
+			return guavaMapSingularizer;
 		}
-		
+		return this;
+	}
+
+	@Override public java.util.List<Name> listFieldsToBeGenerated(SingularData data, JavacNode builderType) {
 		String p = data.getPluralName().toString();
 		return Arrays.asList(builderType.toName(p + "$key"), builderType.toName(p + "$value"));
 	}
 	
 	@Override public java.util.List<Name> listMethodsToBeGenerated(SingularData data, JavacNode builderType) {
-		if (useGuavaInstead(builderType)) {
-			return guavaMapSingularizer.listMethodsToBeGenerated(data, builderType);
-		}
-		
 		return super.listMethodsToBeGenerated(data, builderType);
 	}
 	
 	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JCTree source) {
-		if (useGuavaInstead(builderType)) {
-			return guavaMapSingularizer.generateFields(data, builderType, source);
-		}
-		
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		
 		JCVariableDecl buildKeyField; {
@@ -99,11 +95,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 	
 	@Override public void generateMethods(SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker) {
-		if (useGuavaInstead(builderType)) {
-			guavaMapSingularizer.generateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
-			return;
-		}
-
 		doGenerateMethods(data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker);
 	}
 
@@ -176,11 +167,6 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
-		if (useGuavaInstead(builderType)) {
-			guavaMapSingularizer.appendBuildCode(data, builderType, source, statements, targetVariableName, builderVariable);
-			return;
-		}
-		
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		
 		if (data.getTargetFqn().equals("java.util.Map")) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -127,7 +127,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	protected void generateSingularMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		ListBuffer<JCStatement> statements = generateSingularMethodStatements(maker, data, builderType, source);
 		List<JCVariableDecl> params = generateSingularMethodParameters(maker, data, builderType, source);
-		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, "put");
+		finishAndInjectSingularMethod(maker, returnType, returnStatement, data, builderType, source, fluent, deprecate, statements, params, getAddMethodName());
 	}
 
 	private ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
@@ -195,5 +195,9 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		} else {
 			statements.appendList(createJavaUtilSimpleCreationAndFillStatements(maker, data, builderType, true, true, false, true, "TreeMap", source, builderVariable));
 		}
+	}
+
+	private String getAddMethodName() {
+		return "put";
 	}
 }

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -129,7 +129,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
+		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		/* Generates: this.pluralname$key.add(singularnameKey); */
 		statements.append(generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key"));
 		/* Generates: this.pluralname$value.add(singularnameValue); */
@@ -150,7 +150,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	protected void generatePluralMethod(boolean deprecate, JavacTreeMaker maker, JCExpression returnType, JCStatement returnStatement, SingularData data, JavacNode builderType, JCTree source, boolean fluent) {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
-		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, true, source));
+		statements.append(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
 		long baseFlags = JavacHandlerUtil.addFinalIfNeeded(0, builderType.getContext());
 		Name entryName = builderType.toName("$lombokEntry");
 		
@@ -178,6 +178,10 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 
 	private JCExpression getPluralMethodParamType(JavacNode builderType) {
 		return chainDots(builderType, "java", "util", "Map");
+	}
+
+	private JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+		return createConstructBuilderVarIfNeeded(maker, data, builderType, true, source);
 	}
 
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -113,7 +113,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 
 	@Override
-	protected List<JCStatement> generateClearStatements(JavacTreeMaker maker, JCStatement returnStatement, SingularData data, JavacNode builderType) {
+	protected JCStatement generateClearStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType) {
 		List<JCExpression> jceBlank = List.nil();
 		
 		JCExpression thisDotKeyField = chainDots(builderType, "this", data.getPluralName() + "$key");
@@ -123,8 +123,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCStatement clearValueCall = maker.Exec(maker.Apply(jceBlank, thisDotValueFieldDotClear, jceBlank));
 		JCExpression cond = maker.Binary(CTC_NOT_EQUAL, thisDotKeyField, maker.Literal(CTC_BOT, null));
 		JCBlock clearCalls = maker.Block(0, List.of(clearKeyCall, clearValueCall));
-		JCStatement ifSetCallClear = maker.If(cond, clearCalls, null);
-		return returnStatement != null ? List.of(ifSetCallClear, returnStatement) : List.of(ifSetCallClear);
+		return maker.If(cond, clearCalls, null);
 	}
 	
 	@Override

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -173,8 +173,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
-		JCModifiers mods = makeMods(maker, builderType, deprecate);
-		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(param));
+		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 	}
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -148,9 +148,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		Name name = data.getSingularName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("put", name.toString()));
 
-		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
-		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName, paramFlags);
-		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName, paramFlags);
+		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName);
+		JCVariableDecl paramValue = generateSingularMethodParameter(1, maker, data, builderType, source, valueName);
 		finishAndInjectMethod(maker, returnType, builderType, source, mods, body, name, List.of(paramKey, paramValue));
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -180,7 +180,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return chainDots(builderType, "java", "util", "Map");
 	}
 
-	private JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	@Override
+	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
 		return createConstructBuilderVarIfNeeded(maker, data, builderType, true, source);
 	}
 

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -40,7 +40,6 @@ import org.mangosdk.spi.ProviderFor;
 
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
@@ -133,15 +132,11 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 		/* this.pluralname$key.add(singularnameKey); */ {
-			JCExpression thisDotKeyFieldDotAdd = chainDots(builderType, "this", data.getPluralName() + "$key", "add");
-			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotKeyFieldDotAdd, List.<JCExpression>of(maker.Ident(keyName)));
-			JCStatement st = maker.Exec(invokeAdd);
+			JCStatement st = generateSingularMethodAddStatement(maker, builderType, keyName, data.getPluralName() + "$key");
 			statements.append(st);
 		}
 		/* this.pluralname$value.add(singularnameValue); */ {
-			JCExpression thisDotValueFieldDotAdd = chainDots(builderType, "this", data.getPluralName() + "$value", "add");
-			JCExpression invokeAdd = maker.Apply(List.<JCExpression>nil(), thisDotValueFieldDotAdd, List.<JCExpression>of(maker.Ident(valueName)));
-			JCStatement st = maker.Exec(invokeAdd);
+			JCStatement st = generateSingularMethodAddStatement(maker, builderType, valueName, data.getPluralName() + "$value");
 			statements.append(st);
 		}
 		if (returnStatement != null) statements.append(returnStatement);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -169,13 +169,17 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		JCBlock body = maker.Block(0, statements.toList());
 		Name name = data.getPluralName();
 		if (!fluent) name = builderType.toName(HandlerUtil.buildAccessorName("putAll", name.toString()));
-		JCExpression paramType = chainDots(builderType, "java", "util", "Map");
+		JCExpression paramType = getPluralMethodParamType(builderType);
 		paramType = addTypeArgs(2, true, builderType, paramType, data.getTypeArgs(), source);
 		long paramFlags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, builderType.getContext());
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(paramFlags), data.getPluralName(), paramType, null);
 		finishAndInjectMethod(maker, returnType, builderType, source, deprecate, body, name, List.of(param));
 	}
-	
+
+	private JCExpression getPluralMethodParamType(JavacNode builderType) {
+		return chainDots(builderType, "java", "util", "Map");
+	}
+
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
 		if (useGuavaInstead(builderType)) {
 			guavaMapSingularizer.appendBuildCode(data, builderType, source, statements, targetVariableName, builderVariable);

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSetSingularizer.java
@@ -41,11 +41,6 @@ public class JavacJavaUtilSetSingularizer extends JavacJavaUtilListSetSingulariz
 	}
 	
 	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
-		if (useGuavaInstead(builderType)) {
-			guavaListSetSingularizer.appendBuildCode(data, builderType, source, statements, targetVariableName, builderVariable);
-			return;
-		}
-		
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		
 		if (data.getTargetFqn().equals("java.util.Set")) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSingularizer.java
@@ -39,8 +39,6 @@ import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 
 abstract class JavacJavaUtilSingularizer extends JavacSingularizer {
-	protected final JavacSingularizer guavaListSetSingularizer = new JavacGuavaSetListSingularizer();
-	protected final JavacSingularizer guavaMapSingularizer = new JavacGuavaMapSingularizer();
 	
 	protected List<JCStatement> createJavaUtilSetMapInitialCapacitySwitchStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, String emptyCollectionMethod, String singletonCollectionMethod, String targetType, JCTree source, String builderVariable) {
 		List<JCExpression> jceBlank = List.nil();

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSingularizer.java
@@ -42,10 +42,6 @@ abstract class JavacJavaUtilSingularizer extends JavacSingularizer {
 	protected final JavacSingularizer guavaListSetSingularizer = new JavacGuavaSetListSingularizer();
 	protected final JavacSingularizer guavaMapSingularizer = new JavacGuavaMapSingularizer();
 	
-	protected boolean useGuavaInstead(JavacNode node) {
-		return Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.SINGULAR_USE_GUAVA));
-	}
-	
 	protected List<JCStatement> createJavaUtilSetMapInitialCapacitySwitchStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, String emptyCollectionMethod, String singletonCollectionMethod, String targetType, JCTree source, String builderVariable) {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCCase> cases = new ListBuffer<JCCase>();


### PR DESCRIPTION
As I was working on #2004, I noticed this part of the code looked like it could need some love. The main changes are

- Split the `generateMethods` methods up into parts so that identical parts can be reused between them.
- Condense the "use Guava instead" logic into a single check which replaces the whole singularizer instance once instead of sprinking `if (useGuavaInstead())` checks all over the place.

When I started, I expected the end result would be more substantial than a net -42 LOC change (-69 if ignoring whitespace), so I was a bit underwhelmed by the reduction volume and I'm not sure it's worth the rather extensive code changes. That said, the changes are organised into small commits such that it's easy to manually verify the correctness of each step, and I do believe that splitting the code into smaller functions makes it easier to work with.

Anyway, here it is. This was my attempt to make this code region easier to read and understand. You're welcome to close this or chery-pick individual changes as you like, and I welcome any critique on how this could be done better.

These changes are pure refactorizations, with the exception of commits a633e39 through 92fc11f which do change internal behaviour but should not change externally observable behaviour.