### PR TITLE
Documentation improvements for SuperBuilder

### DIFF
--- a/website/templates/features/experimental/SuperBuilder.html
+++ b/website/templates/features/experimental/SuperBuilder.html
@@ -26,7 +26,7 @@
 			<code>@SuperBuilder</code> is not compatible with <code>@Builder</code>.
 		</p><p>
 			You can use <code>@SuperBuilder(toBuilder = true)</code> to also generate an instance method in your class called <code>toBuilder()</code>; it creates a new builder that starts out with all the values of this instance.
-			Using <code>toBuilder</code> requires that all superclasses must also have <code>toBuilder = true</code>.
+			Using <code>toBuilder</code> requires that all superclasses also have <code>toBuilder = true</code>.
 			You can put the <code>@Builder.ObtainVia</code> annotation on the fields to indicate alternative means by which the value for that field/parameter is obtained from this instance.
 			For example, you can specify a method to be invoked: <code>@Builder.ObtainVia(method = "calculateFoo")</code>.
 		</p><p>

--- a/website/templates/features/experimental/SuperBuilder.html
+++ b/website/templates/features/experimental/SuperBuilder.html
@@ -25,7 +25,10 @@
 		</p><p>
 			<code>@SuperBuilder</code> is not compatible with <code>@Builder</code>.
 		</p><p>
-			You can use <code>@SuperBuilder(toBuilder = true)</code> to also generate an instance method in your class called <code>toBuilder()</code>; it creates a new builder that starts out with all the values of this instance. You can put the <code>@Builder.ObtainVia</code> annotation on the fields to indicate alternative means by which the value for that field/parameter is obtained from this instance. For example, you can specify a method to be invoked: <code>@Builder.ObtainVia(method = "calculateFoo")</code>.
+			You can use <code>@SuperBuilder(toBuilder = true)</code> to also generate an instance method in your class called <code>toBuilder()</code>; it creates a new builder that starts out with all the values of this instance.
+			Using <code>toBuilder</code> requires that all superclasses must also have <code>toBuilder = true</code>.
+			You can put the <code>@Builder.ObtainVia</code> annotation on the fields to indicate alternative means by which the value for that field/parameter is obtained from this instance.
+			For example, you can specify a method to be invoked: <code>@Builder.ObtainVia(method = "calculateFoo")</code>.
 		</p><p>
 			To ensure type-safety, <code>@SuperBuilder</code> generates two inner builder classes for each annotated class, one abstract and one concrete class named <code><em>Foobar</em>Builder</code> and <code><em>Foobar</em>BuilderImpl</code> (where <em>Foobar</em> is the name of the annotated class).
 		</p><p>
@@ -65,15 +68,11 @@
 
 	<@f.smallPrint>
 		<p>
-			@Singular support for <code>java.util.NavigableMap/Set</code> only works if you are compiling with JDK1.8 or higher.
-		</p><p>
-			The sorted collections (java.util: <code>SortedSet</code>, <code>NavigableSet</code>, <code>SortedMap</code>, <code>NavigableMap</code> and guava: <code>ImmutableSortedSet</code>, <code>ImmutableSortedMap</code>) require that the type argument of the collection has natural order (implements <code>java.util.Comparable</code>). There is no way to pass an explicit <code>Comparator</code> to use in the builder.
-		</p><p>
-			An <code>ArrayList</code> is used to store added elements as call methods of a <code>@Singular</code> marked field, if the target collection is from the <code>java.util</code> package, <em>even if the collection is a set or map</em>. Because lombok ensures that generated collections are compacted, a new backing instance of a set or map must be constructed anyway, and storing the data as an <code>ArrayList</code> during the build process is more efficient that storing it as a map or set. This behaviour is not externally visible, an implementation detail of the current implementation of the <code>java.util</code> recipes for <code>@Singular</code>.
-		</p><p>
 			The generated builder code heavily relies on generics to avoid class casting when using the builder.
 		</p><p>
-			Various well known annotations about nullity cause null checks to be inserted and will be copied to parameter of the builder's 'setter' method. See <a href="/features/GetterSetter">Getter/Setter</a> documentation's small print for more information.
+			For remarks on <code>@Singular</code>, see <a href="/features/Builder#small-print">the <code>@Builder</code> documentation's</a> small print.
+		</p><p>
+			Various well known annotations about nullity cause null checks to be inserted and will be copied to parameter of the builder's 'setter' method. See <a href="/features/GetterSetter#small-print">Getter/Setter documentation's small print</a> for more information.
 		</p>
 	</@f.smallPrint>
 </@f.scaffold>


### PR DESCRIPTION
Documentation for `@SuperBuilder(toBuilder = true)` now mentions that it requires `toBuilder` on all superclasses.