### PR TITLE
remove createFormat() method (#1040 fix)

### DIFF
--- a/src/delombok/lombok/delombok/ant/DelombokTask.java
+++ b/src/delombok/lombok/delombok/ant/DelombokTask.java
@@ -154,10 +154,6 @@ class Tasks {
 			path.add(set);
 		}
 		
-		public Format createFormat() {
-			return new Format();
-		}
-		
 		public void addFormat(Format format) {
 			formatOptions.add(format);
 		}


### PR DESCRIPTION
Method createFormat() causes ambiguous behavior and shouldn't be used with addFormat(), especially because the created format instance doesn't being added to the formatOptions.

This fixes #1040