### PR TITLE
Updated the text explanation link.

### DIFF
--- a/website/templates/main.html
+++ b/website/templates/main.html
@@ -25,7 +25,7 @@
 			</video>
 			<div class="row">
 				<div class="text-center">
-					<a href="http://jnb.ociweb.com/jnb/jnbJan2010.html">Show me a text and images based explanation and tutorial instead!</a>
+					<a href="https://objectcomputing.com/resources/publications/sett/january-2010-reducing-boilerplate-code-with-project-lombok">Show me a text and images based explanation and tutorial instead!</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
OCI moved their Java News Briefs (JNB) to a more general format called Software Engineering Tech Trends (SETT).  This changed the link for the article featuring Project Lombok.

This minor modification corrects the JNB link to the current location of the article.