### PR TITLE
populates 'pos' fields to disable usage 'var' instead of an explicit …

### DIFF
--- a/src/core/lombok/javac/handlers/HandleHelper.java
+++ b/src/core/lombok/javac/handlers/HandleHelper.java
@@ -143,6 +143,7 @@ public class HandleHelper extends JavacAnnotationHandler<Helper> {
 			mark = true;
 			JCExpression init = maker.NewClass(null, List.<JCExpression>nil(), maker.Ident(annotatedType_.name), List.<JCExpression>nil(), null);
 			JCExpression varType = maker.Ident(annotatedType_.name);
+			varType.pos = annotatedType_.pos;
 			JCVariableDecl decl = maker.VarDef(maker.Modifiers(Flags.FINAL), helperName, varType, init);
 			newStatements.append(decl);
 		}

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -26,6 +26,7 @@ import static lombok.javac.handlers.JavacHandlerUtil.*;
 
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.tree.JCTree.JCTypeApply;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -350,8 +351,9 @@ public class JavacSingularsRecipes {
 		protected JCExpression addTypeArgs(int count, boolean addExtends, JavacNode node, JCExpression type, List<JCExpression> typeArgs, JCTree source) {
 			JavacTreeMaker maker = node.getTreeMaker();
 			List<JCExpression> clonedAndFixedTypeArgs = createTypeArgs(count, addExtends, node, typeArgs, source);
-			
-			return maker.TypeApply(type, clonedAndFixedTypeArgs);
+			JCTypeApply result = maker.TypeApply(type, clonedAndFixedTypeArgs);
+			result.pos = source.pos;
+			return result;
 		}
 		
 		protected List<JCExpression> createTypeArgs(int count, boolean addExtends, JavacNode node, List<JCExpression> typeArgs, JCTree source) {


### PR DESCRIPTION
…variable type in generated @Builder's and @Helper's fields (fix related tests).