### PR TITLE
Fixes for CustomLog, AUTHORS entry, extended changlog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Lombok contributors in alphabetical order:
 
+Adam Juraszek <juriad@gmail.com>
 Bulgakov Alexander <buls@yandex.ru>
 Christian Nüssgens <christian@nuessgens.com>
 Christian Sterzl <christian.sterzl@gmail.com>

--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,6 +3,7 @@ Lombok Changelog
 
 ### v1.18.9 "Edgy Guinea Pig"
 * FEATURE: You can now configure a custom logger framework using the new `@CustomLog` annotation in combination with the `lombok.log.custom.declaration` configuration key. See the [log documentation](https://projectlombok.org/features/Log) for more information. [Pullrequest #2086](https://github.com/rzwitserloot/lombok/pull/2086) with thanks to Adam Juraszek.
+* IMPROBABLE BREAKING CHANGE: Stricter validation of configuration keys dealing with identifiers and types (`lombok.log.fieldName`, `lombok.fieldNameConstants.innerTypeName`, `lombok.copyableAnnotations`).
 
 ### v1.18.8 (May 7th, 2019)
 * FEATURE: You can now configure `@FieldNameConstants` to `CONSTANT_CASE` the generated constants, using a `lombok.config` option. See the [FieldNameConstants documentation](https://projectlombok.org/features/experimental/FieldNameConstants). [Issue #2092](https://github.com/rzwitserloot/lombok/issues/2092).

--- a/src/core/lombok/core/configuration/TypeName.java
+++ b/src/core/lombok/core/configuration/TypeName.java
@@ -34,7 +34,7 @@ public final class TypeName implements ConfigurationValueType {
 		if (name == null || name.trim().isEmpty()) return null;
 		
 		String trimmedName = name.trim();
-		for (String identifier : trimmedName.split(".")) {
+		for (String identifier : trimmedName.split("\\.")) {
 			if (!JavaIdentifiers.isValidJavaIdentifier(identifier)) throw new IllegalArgumentException("Invalid type name " + trimmedName + " (part " + identifier + ")");
 		}
 		return new TypeName(trimmedName);

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -760,7 +760,7 @@ public class EclipseHandlerUtil {
 			TypeReference typeRef = annotation.type;
 			boolean match = false;
 			if (typeRef != null && typeRef.getTypeName() != null) {
-				for (TypeName cn : configuredCopyable) if (typeMatches(cn.toString(), node, typeRef)) {
+				for (TypeName cn : configuredCopyable) if (cn != null && typeMatches(cn.toString(), node, typeRef)) {
 					result.add(annotation);
 					match = true;
 					break;

--- a/src/core/lombok/eclipse/handlers/HandleFieldNameConstants.java
+++ b/src/core/lombok/eclipse/handlers/HandleFieldNameConstants.java
@@ -135,7 +135,7 @@ public class HandleFieldNameConstants extends EclipseAnnotationHandler<FieldName
 		TypeDeclaration parent = (TypeDeclaration) typeNode.get();
 		EclipseNode fieldsType = findInnerClass(typeNode, innerTypeName.getName());
 		boolean genConstr = false, genClinit = false;
-		char[] name = innerTypeName.getName().toCharArray();
+		char[] name = innerTypeName.getCharArray();
 		TypeDeclaration generatedInnerType = null;
 		if (fieldsType == null) {
 			generatedInnerType = new TypeDeclaration(parent.compilationResult);

--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -88,6 +88,11 @@ public class HandleLog {
 			if (loggerTopic != null && loggerTopic.trim().isEmpty()) loggerTopic = null;
 			if (framework.getDeclaration().getParametersWithTopic() == null && loggerTopic != null) {
 				annotationNode.addError(framework.getAnnotationAsString() + " does not allow a topic.");
+				loggerTopic = null;
+			}
+			if (framework.getDeclaration().getParametersWithoutTopic() == null && loggerTopic == null) {
+				annotationNode.addError(framework.getAnnotationAsString() + " requires a topic.");
+				loggerTopic = "";
 			}
 			
 			ClassLiteralAccess loggingType = selfType(owner, source);

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -79,6 +79,11 @@ public class HandleLog {
 			if (loggerTopic != null && loggerTopic.trim().isEmpty()) loggerTopic = null;
 			if (framework.getDeclaration().getParametersWithTopic() == null && loggerTopic != null) {
 				annotationNode.addError(framework.getAnnotationAsString() + " does not allow a topic.");
+				loggerTopic = null;
+			}
+			if (framework.getDeclaration().getParametersWithoutTopic() == null && loggerTopic == null) {
+				annotationNode.addError(framework.getAnnotationAsString() + " requires a topic.");
+				loggerTopic = "";
 			}
 			
 			JCFieldAccess loggingType = selfType(typeNode);

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1450,7 +1450,7 @@ public class JavacHandlerUtil {
 		java.util.List<TypeName> configuredCopyable = node.getAst().readConfiguration(ConfigurationKeys.COPYABLE_ANNOTATIONS);
 		
 		if (!annoName.isEmpty()) {
-			for (TypeName cn : configuredCopyable) if (typeMatches(cn.toString(), node, anno.annotationType)) return List.of(anno);
+			for (TypeName cn : configuredCopyable) if (cn != null && typeMatches(cn.toString(), node, anno.annotationType)) return List.of(anno);
 			for (String bn : BASE_COPYABLE_ANNOTATIONS) if (typeMatches(bn, node, anno.annotationType)) return List.of(anno);
 		}
 		
@@ -1459,7 +1459,7 @@ public class JavacHandlerUtil {
 			if (child.getKind() == Kind.ANNOTATION) {
 				JCAnnotation annotation = (JCAnnotation) child.get();
 				boolean match = false;
-				for (TypeName cn : configuredCopyable) if (typeMatches(cn.toString(), node, annotation.annotationType)) {
+				for (TypeName cn : configuredCopyable) if (cn != null && typeMatches(cn.toString(), node, annotation.annotationType)) {
 					result.append(annotation);
 					match = true;
 					break;

--- a/website/templates/features/log.html
+++ b/website/templates/features/log.html
@@ -15,7 +15,7 @@
 
 	<@f.overview>
 		<p>
-			You put the variant of <code>@Log</code> on your class (whichever one applies to the logging system you use); you then have a static final <code>log</code> field, initialized as is the commonly proscribed way for the logging framework you use, which you can then use to write log statements.
+			You put the variant of <code>@Log</code> on your class (whichever one applies to the logging system you use); you then have a static final <code>log</code> field, initialized as is the commonly prescribed way for the logging framework you use, which you can then use to write log statements.
 		</p><p>
 			There are several choices available:<br />
 			<dl>


### PR DESCRIPTION
I noticed the style and tried to keep it mostly; I missed some places though. Thanks for fixing them.

I have no complaints to the changes.
There is one improbable breaking change: setting `lombok.log.fieldName=private` used to be valid (and it compiled!); similarly `lombok.fieldNameConstants.innerTypeName=42`, `lombok.copyableAnnotations+=int.float.package.class`, and `lombok.copyableAnnotations+=a-b-c`.
I also found two bugs regarding `TypeName`.