### PR TITLE
val. override error handling policy for problemReporter to guarantee AbortCompilation is throwing.

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchVal.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchVal.java
@@ -26,17 +26,22 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ConditionalExpression;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
+import org.eclipse.jdt.internal.compiler.ast.FunctionalExpression;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
+import org.eclipse.jdt.internal.compiler.ast.LambdaExpression;
 import org.eclipse.jdt.internal.compiler.ast.LocalDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 import org.eclipse.jdt.internal.compiler.lookup.ArrayBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
@@ -53,6 +58,7 @@ import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 
 import java.lang.reflect.Field;
 
+import static lombok.Lombok.sneakyThrow;
 import static lombok.eclipse.Eclipse.poss;
 import static lombok.eclipse.handlers.EclipseHandlerUtil.makeType;
 import static org.eclipse.jdt.core.compiler.CategorizedProblem.CAT_TYPE;
@@ -390,6 +396,18 @@ public class PatchVal {
 						}
 					}
 					compilationResult.removeProblem(problem);
+					if (!compilationResult.hasErrors()) {
+						clearIgnoreFurtherInvestigationField(scope.referenceContext());
+						setValue(getField(CompilationResult.class, "hasMandatoryErrors"), compilationResult, false);
+					}
+					
+					if (ifFalse instanceof FunctionalExpression) {
+						FunctionalExpression functionalExpression = (FunctionalExpression) ifFalse;
+						functionalExpression.setExpectedType(ifTrueResolvedType);
+					}
+					if (ifFalse.resolvedType == null) {
+						ifFalse.resolve(scope);
+					}
 					
 					return ifTrueResolvedType;
 				}
@@ -397,6 +415,57 @@ public class PatchVal {
 			throw e;
 		} finally {
 			referenceContext.problemReporter = oldProblemReporter;
+		}
+	}
+	
+	private static void clearIgnoreFurtherInvestigationField(ReferenceContext currentContext) {
+		if (currentContext instanceof AbstractMethodDeclaration) {
+			AbstractMethodDeclaration methodDeclaration = (AbstractMethodDeclaration) currentContext;
+			methodDeclaration.ignoreFurtherInvestigation = false;
+		} else if (currentContext instanceof LambdaExpression) {
+			LambdaExpression lambdaExpression = (LambdaExpression) currentContext;
+			setValue(getField(LambdaExpression.class, "ignoreFurtherInvestigation"), lambdaExpression, false);
+			
+			Scope parent = lambdaExpression.enclosingScope.parent;
+			while (parent != null) {
+				switch(parent.kind) {
+					case Scope.CLASS_SCOPE:
+					case Scope.METHOD_SCOPE:
+						ReferenceContext parentAST = parent.referenceContext();
+						if (parentAST != lambdaExpression) {
+							clearIgnoreFurtherInvestigationField(parentAST);
+							return;
+						}
+					default:
+						parent = parent.parent;
+						break;
+				}
+			}
+			
+		} else if (currentContext instanceof TypeDeclaration) {
+			TypeDeclaration typeDeclaration = (TypeDeclaration) currentContext;
+			typeDeclaration.ignoreFurtherInvestigation = false;
+		} else if (currentContext instanceof CompilationUnitDeclaration) {
+			CompilationUnitDeclaration typeDeclaration = (CompilationUnitDeclaration) currentContext;
+			typeDeclaration.ignoreFurtherInvestigation = false;
+		} else {
+			throw new UnsupportedOperationException("clearIgnoreFurtherInvestigationField for " + currentContext.getClass());
+		}
+	}
+	
+	private static void setValue(Field field, Object object, Object value) {
+		try {
+			field.set(object, value);
+		} catch (IllegalAccessException e) {
+			throw sneakyThrow(e);
+		}
+	}
+	
+	private static Field getField(Class clazz, String name) {
+		try {
+			return Permit.getField(clazz, name);
+		} catch (NoSuchFieldException e) {
+			throw sneakyThrow(e);
 		}
 	}
 }

--- a/test/transform/resource/after-delombok/ValInLambda.java
+++ b/test/transform/resource/after-delombok/ValInLambda.java
@@ -2,17 +2,26 @@
 class ValInLambda {
     Runnable foo = (Runnable) () -> {
         final int i = 1;
+        final java.lang.Runnable foo = (System.currentTimeMillis() > 0) ? (Runnable) () -> {
+        } : System.out::println;
     };
-
+    
     public void easyLambda() {
         Runnable foo = (Runnable) () -> {
             final int i = 1;
         };
     }
-
+    
     public void easyIntersectionLambda() {
         Runnable foo = (Runnable) () -> {
             final int i = 1;
+        };
+    }
+    
+    public void easyLubLambda() {
+        Runnable foo = (Runnable) () -> {
+            final java.lang.Runnable fooInner = (System.currentTimeMillis() > 0) ? (Runnable) () -> {
+            } : System.out::println;
         };
     }
 }

--- a/test/transform/resource/after-delombok/ValLambda.java
+++ b/test/transform/resource/after-delombok/ValLambda.java
@@ -1,15 +1,27 @@
 // version 8:
 class ValLambda {
+	static {
+		final java.lang.Runnable foo = (System.currentTimeMillis() > 0) ? (Runnable) () -> {
+		} : System.out::println;
+	}
+	
+	{
+		final java.lang.Runnable foo = (System.currentTimeMillis() > 0) ? (Runnable) () -> {
+		} : System.out::println;
+	}
+	
 	public void easyLambda() {
 		final java.lang.Runnable foo = (Runnable) () -> {
 		};
 	}
+	
 	public void easyIntersectionLambda() {
 		final java.lang.Runnable foo = (Runnable & java.io.Serializable) () -> {
 		};
 		final java.io.Serializable bar = (java.io.Serializable & Runnable) () -> {
 		};
 	}
+	
 	public void easyLubLambda() {
 		final java.lang.Runnable foo = (System.currentTimeMillis() > 0) ? (Runnable) () -> {
 		} : System.out::println;

--- a/test/transform/resource/after-ecj/ValInLambda.java
+++ b/test/transform/resource/after-ecj/ValInLambda.java
@@ -1,9 +1,9 @@
-// version 8:
-
 import lombok.val;
 class ValInLambda {
   Runnable foo = (Runnable) () -> {
   final @val int i = 1;
+  final @lombok.val java.lang.Runnable foo = ((System.currentTimeMillis() > 0) ? (Runnable) () -> {
+} : System.out::println);
 };
   ValInLambda() {
     super();
@@ -16,6 +16,12 @@ class ValInLambda {
   public void easyIntersectionLambda() {
     Runnable foo = (Runnable) () -> {
   final @val int i = 1;
+};
+  }
+  public void easyLubLambda() {
+    Runnable foo = (Runnable) () -> {
+  final @lombok.val java.lang.Runnable fooInner = ((System.currentTimeMillis() > 0) ? (Runnable) () -> {
+} : System.out::println);
 };
   }
 }

--- a/test/transform/resource/after-ecj/ValLambda.java
+++ b/test/transform/resource/after-ecj/ValLambda.java
@@ -1,4 +1,14 @@
 class ValLambda {
+  static {
+    final @lombok.val java.lang.Runnable foo = ((System.currentTimeMillis() > 0) ? (Runnable) () -> {
+} : System.out::println);
+  }
+  {
+    final @lombok.val java.lang.Runnable foo = ((System.currentTimeMillis() > 0) ? (Runnable) () -> {
+} : System.out::println);
+  }
+  <clinit>() {
+  }
   ValLambda() {
     super();
   }

--- a/test/transform/resource/before/ValInLambda.java
+++ b/test/transform/resource/before/ValInLambda.java
@@ -5,6 +5,7 @@ import lombok.val;
 class ValInLambda {
     Runnable foo = (Runnable) () -> {
         val i = 1;
+        lombok.val foo = (System.currentTimeMillis() > 0) ? (Runnable)()-> {} : System.out::println;
     };
 
     public void easyLambda() {
@@ -16,6 +17,12 @@ class ValInLambda {
     public void easyIntersectionLambda() {
         Runnable foo = (Runnable) () -> {
             val i = 1;
+        };
+    }
+    
+    public void easyLubLambda() {
+        Runnable foo = (Runnable) () -> {
+            lombok.val fooInner = (System.currentTimeMillis() > 0) ? (Runnable)()-> {} : System.out::println;
         };
     }
 }

--- a/test/transform/resource/before/ValLambda.java
+++ b/test/transform/resource/before/ValLambda.java
@@ -1,5 +1,13 @@
 // version 8:
 class ValLambda {
+	
+	static {
+		lombok.val foo = (System.currentTimeMillis() > 0) ? (Runnable)()-> {} : System.out::println;
+	}
+	{
+		lombok.val foo = (System.currentTimeMillis() > 0) ? (Runnable)()-> {} : System.out::println;
+	}
+	
 	public void easyLambda() {
 		lombok.val foo = (Runnable)()-> {};
 	}

--- a/test/transform/resource/messages-ecj/ValLambda.java.messages
+++ b/test/transform/resource/messages-ecj/ValLambda.java.messages
@@ -1,2 +1,2 @@
-14 Function is a raw type. References to generic type Function<T,R> should be parameterized
-15 Function is a raw type. References to generic type Function<T,R> should be parameterized
+23 Function is a raw type. References to generic type Function<T,R> should be parameterized
+24 Function is a raw type. References to generic type Function<T,R> should be parameterized


### PR DESCRIPTION
Sorry for being late. 
I forget to add some code that replaces an error handling policy in EJC in the type resolve method. It is necessary to guarantee that AbortCompilation will be thrown when a type evaluation of then false part being failed in a conditional expression. Implementing the stopOnFirstError method in IErrorHandlingPolicy may return false, which will result in an error message, 
but the compilation will not be interrupted by AbortCompilation throwing.

Example:
```console
LOMBOK=./dist/lombok-1.18.9.jar
ECJ=./lib/ecj8/org.eclipse.jdt.core.compiler-ecj.jar
RT=./lib/oracleJDK8Environment/rt.jar
CLASS_SRC=./test/transform/resource/before/ValLambda.java
java -javaagent:$LOMBOK -jar $ECJ -classpath $RT:$LOMBOK -1.8 $CLASS_SRC
```

there will be errors:
```console
----------
1. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 4)
        lombok.val foo = (Runnable)()-> {};
                   ^^^
The value of the local variable foo is not used
----------
2. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 8)
        lombok.val foo = (Runnable & java.io.Serializable)()-> {};
                   ^^^
The value of the local variable foo is not used
----------
3. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 9)
        lombok.val bar = (java.io.Serializable & Runnable)()-> {};
                   ^^^
The value of the local variable bar is not used
----------
4. ERROR in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 13)
        lombok.val foo = (System.currentTimeMillis() > 0) ? (Runnable)()-> {} : System.out::println;
                                                                                ^^^^^^^^^^^^^^^^^^^
The target type of this expression must be a functional interface
----------
5. ERROR in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 14)
        lombok.val foo1 = (System.currentTimeMillis() > 0) ? (Runnable)System.out::println : System.out::println;
                                                                                             ^^^^^^^^^^^^^^^^^^^
The target type of this expression must be a functional interface
----------
6. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 15)
        lombok.val foo2 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
7. ERROR in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 15)
        lombok.val foo2 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
                                                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
The target type of this expression must be a functional interface
----------
8. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 16)
        java.util.function.Function foo3 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
9. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 16)
        java.util.function.Function foo3 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
10. ERROR in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 17)
        lombok.val foo4 = (System.currentTimeMillis() < 0) ? (java.util.function.Function<String, String>) r -> "" : r -> String.valueOf(System.currentTimeMillis());
                                                                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
The target type of this expression must be a functional interface
----------
10 problems (4 errors, 6 warnings)
```

but with this patch, there will be only warnings:
```console
1. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 4)
        lombok.val foo = (Runnable)()-> {};
                   ^^^
The value of the local variable foo is not used
----------
2. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 8)
        lombok.val foo = (Runnable & java.io.Serializable)()-> {};
                   ^^^
The value of the local variable foo is not used
----------
3. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 9)
        lombok.val bar = (java.io.Serializable & Runnable)()-> {};
                   ^^^
The value of the local variable bar is not used
----------
4. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 15)
        lombok.val foo2 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
        ^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
5. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 15)
        lombok.val foo2 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
6. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 16)
        java.util.function.Function foo3 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
7. WARNING in /Users/alexander/Documents/github/lombok/test/transform/resource/before/ValLambda.java (at line 16)
        java.util.function.Function foo3 = (System.currentTimeMillis() < 0) ? (java.util.function.Function) r -> "" : r -> System.currentTimeMillis();
                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Function is a raw type. References to generic type Function<T,R> should be parameterized
----------
7 problems (7 warnings)
```
