### PR TITLE
Avoid Eclipse warnings about lombok.NonNull when NonNullByDefault is used

### DIFF
--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -315,7 +315,17 @@ final class PatchFixesHider {
 			}
 			return result;
 		}
-		
+
+		public static boolean isGenerated(org.eclipse.jdt.internal.compiler.ast.ASTNode node) {
+			boolean result = false;
+			try {
+				result = node.getClass().getField("$generatedBy").get(node) != null;
+			} catch (Exception e) {
+				// better to assume it isn't generated
+			}
+			return result;
+		}
+
 		public static boolean isListRewriteOnGeneratedNode(org.eclipse.jdt.core.dom.rewrite.ListRewrite rewrite) {
 			return isGenerated(rewrite.getParent());
 		}


### PR DESCRIPTION
When annotations based null analysis is enabled in Eclipse and NonNullByDefault is in effect, @lombok.NonNull causes warning, e.g. in the following example:
```
import org.eclipse.jdt.annotation.NonNullByDefault;
import lombok.NonNull;

@NonNullByDefault
public class App {
	String f(@NonNull String s) {
		return s;
	}
}
```
two warnings are reported  at the `@NonNull` annotation:
- `Dead code`
- `Redundant null check: comparing '@NonNull String' against null`

(obviously, both warnings are only reported when enabled in the Compiler preferences)


