### PR TITLE
Update gradle documentation

### DIFF
--- a/website/templates/setup/gradle.html
+++ b/website/templates/setup/gradle.html
@@ -11,7 +11,7 @@
 
 	<@s.section title="The Lombok Gradle Plugin">
 		<p>
-			There is a plugin for gradle that we recommend you use; it makes deployment a breeze, works around shortcomings of gradle prior to v2.12, and makes it easy to do additional tasks, such as running the lombok eclipse installer or delomboking. The plugin is open source. Read more <a href="https://plugins.gradle.org/plugin/io.freefair.lombok">about the gradle-lombok plugin</a>.
+			There is a plugin for gradle that we recommend you use; it makes deployment a breeze, and makes it easy to do additional tasks, such as delomboking. The plugin is open source. Read more <a href="https://plugins.gradle.org/plugin/io.freefair.lombok">about the gradle-lombok plugin</a>.
 		</p>
 	</@s.section>
 	


### PR DESCRIPTION
The linked gradle plugin doesn't work with Gradle 2.12 (which is way too old anyway) and doesn't support running the eclipse installer.