### PR TITLE
Avoid more name clashes for SuperBuilder

### DIFF
--- a/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
@@ -1,0 +1,126 @@
+public class SuperBuilderNameClashes {
+	public static class GenericsClash<B, C, C2> {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class GenericsClashBuilder<B, C, C2, C3 extends GenericsClash<B, C, C2>, B2 extends GenericsClashBuilder<B, C, C2, C3, B2>> {
+			@java.lang.SuppressWarnings("all")
+			protected abstract B2 self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C3 build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderNameClashes.GenericsClash.GenericsClashBuilder()";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class GenericsClashBuilderImpl<B, C, C2> extends GenericsClashBuilder<B, C, C2, GenericsClash<B, C, C2>, GenericsClashBuilderImpl<B, C, C2>> {
+			@java.lang.SuppressWarnings("all")
+			private GenericsClashBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected GenericsClashBuilderImpl<B, C, C2> self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public GenericsClash<B, C, C2> build() {
+				return new GenericsClash<B, C, C2>(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected GenericsClash(final GenericsClashBuilder<B, C, C2, ?, ?> b) {
+		}
+		@java.lang.SuppressWarnings("all")
+		public static <B, C, C2> GenericsClashBuilder<B, C, C2, ?, ?> builder() {
+			return new GenericsClashBuilderImpl<B, C, C2>();
+		}
+	}
+	public static class B {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class BBuilder<C extends B, B2 extends BBuilder<C, B2>> {
+			@java.lang.SuppressWarnings("all")
+			protected abstract B2 self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderNameClashes.B.BBuilder()";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class BBuilderImpl extends BBuilder<B, BBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private BBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected BBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public B build() {
+				return new B(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected B(final BBuilder<?, ?> b) {
+		}
+		@java.lang.SuppressWarnings("all")
+		public static BBuilder<?, ?> builder() {
+			return new BBuilderImpl();
+		}
+	}
+	public static class C2 {
+	}
+	public static class C {
+		C2 c2;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class CBuilder<C3 extends C, B extends CBuilder<C3, B>> {
+			@java.lang.SuppressWarnings("all")
+			private C2 c2;
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C3 build();
+			@java.lang.SuppressWarnings("all")
+			public B c2(final C2 c2) {
+				this.c2 = c2;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderNameClashes.C.CBuilder(c2=" + this.c2 + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class CBuilderImpl extends CBuilder<C, CBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private CBuilderImpl() {
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected CBuilderImpl self() {
+				return this;
+			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public C build() {
+				return new C(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected C(final CBuilder<?, ?> b) {
+			this.c2 = b.c2;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static CBuilder<?, ?> builder() {
+			return new CBuilderImpl();
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
@@ -1,0 +1,104 @@
+public class SuperBuilderNameClashes {
+  public static @lombok.experimental.SuperBuilder class GenericsClash<B, C, C2> {
+    public static abstract @java.lang.SuppressWarnings("all") class GenericsClashBuilder<B, C, C2, C3 extends GenericsClash<B, C, C2>, B2 extends GenericsClashBuilder<B, C, C2, C3, B2>> {
+      public GenericsClashBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B2 self();
+      public abstract @java.lang.SuppressWarnings("all") C3 build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return "SuperBuilderNameClashes.GenericsClash.GenericsClashBuilder()";
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class GenericsClashBuilderImpl<B, C, C2> extends GenericsClashBuilder<B, C, C2, GenericsClash<B, C, C2>, GenericsClashBuilderImpl<B, C, C2>> {
+      private GenericsClashBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") GenericsClashBuilderImpl<B, C, C2> self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") GenericsClash<B, C, C2> build() {
+        return new GenericsClash<B, C, C2>(this);
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") GenericsClash(final GenericsClashBuilder<B, C, C2, ?, ?> b) {
+      super();
+    }
+    public static @java.lang.SuppressWarnings("all") <B, C, C2>GenericsClashBuilder<B, C, C2, ?, ?> builder() {
+      return new GenericsClashBuilderImpl<B, C, C2>();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class B {
+    public static abstract @java.lang.SuppressWarnings("all") class BBuilder<C extends B, B2 extends BBuilder<C, B2>> {
+      public BBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B2 self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return "SuperBuilderNameClashes.B.BBuilder()";
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class BBuilderImpl extends BBuilder<B, BBuilderImpl> {
+      private BBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") BBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") B build() {
+        return new B(this);
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") B(final BBuilder<?, ?> b) {
+      super();
+    }
+    public static @java.lang.SuppressWarnings("all") BBuilder<?, ?> builder() {
+      return new BBuilderImpl();
+    }
+  }
+  public static class C2 {
+    public C2() {
+      super();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class C {
+    public static abstract @java.lang.SuppressWarnings("all") class CBuilder<C3 extends C, B extends CBuilder<C3, B>> {
+      private @java.lang.SuppressWarnings("all") C2 c2;
+      public CBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C3 build();
+      public @java.lang.SuppressWarnings("all") B c2(final C2 c2) {
+        this.c2 = c2;
+        return self();
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderNameClashes.C.CBuilder(c2=" + this.c2) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class CBuilderImpl extends CBuilder<C, CBuilderImpl> {
+      private CBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") CBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") C build() {
+        return new C(this);
+      }
+    }
+    C2 c2;
+    protected @java.lang.SuppressWarnings("all") C(final CBuilder<?, ?> b) {
+      super();
+      this.c2 = b.c2;
+    }
+    public static @java.lang.SuppressWarnings("all") CBuilder<?, ?> builder() {
+      return new CBuilderImpl();
+    }
+  }
+  public SuperBuilderNameClashes() {
+    super();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderNameClashes.java
+++ b/test/transform/resource/before/SuperBuilderNameClashes.java
@@ -1,0 +1,17 @@
+public class SuperBuilderNameClashes {
+	@lombok.experimental.SuperBuilder
+	public static class GenericsClash<B, C, C2> {
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class B {
+	}
+	
+	public static class C2 {
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class C {
+		C2 c2;
+	}
+}

--- a/test/transform/resource/messages-ecj/SuperBuilderNameClashes.java.messages
+++ b/test/transform/resource/messages-ecj/SuperBuilderNameClashes.java.messages
@@ -1,0 +1,3 @@
+3 WARNING The type parameter B is hiding the type SuperBuilderNameClashes.B
+3 WARNING The type parameter C is hiding the type SuperBuilderNameClashes.C
+3 WARNING The type parameter C2 is hiding the type SuperBuilderNameClashes.C2


### PR DESCRIPTION
Previously, the names of the type parameters of `@SuperBuilder` are chosen that they do not collide with the type parameters of the annotated class.

With this PR, the classname of the annotated class and the type names of fields in that class are also considered in this collision check.

This fixes #2297.