### PR TITLE
SuperBuilder javac fix for nested generic types

### DIFF
--- a/test/transform/resource/after-delombok/SuperBuilderNestedGenericTypes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderNestedGenericTypes.java
@@ -1,0 +1,41 @@
+public class SuperBuilderNestedGenericTypes {
+	public static abstract class Generic<T extends Generic<?>> {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class GenericBuilder<T extends Generic<?>, C extends SuperBuilderNestedGenericTypes.Generic<T>, B extends SuperBuilderNestedGenericTypes.Generic.GenericBuilder<T, C, B>> {
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderNestedGenericTypes.Generic.GenericBuilder()";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Generic(final SuperBuilderNestedGenericTypes.Generic.GenericBuilder<T, ?, ?> b) {
+		}
+	}
+	public static abstract class NestedGeneric<T extends OtherGeneric<?>> extends Generic<NestedGeneric<? extends OtherGeneric<?>>> {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class NestedGenericBuilder<T extends OtherGeneric<?>, C extends SuperBuilderNestedGenericTypes.NestedGeneric<T>, B extends SuperBuilderNestedGenericTypes.NestedGeneric.NestedGenericBuilder<T, C, B>> extends Generic.GenericBuilder<NestedGeneric<? extends OtherGeneric<?>>, C, B> {
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderNestedGenericTypes.NestedGeneric.NestedGenericBuilder(super=" + super.toString() + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected NestedGeneric(final SuperBuilderNestedGenericTypes.NestedGeneric.NestedGenericBuilder<T, ?, ?> b) {
+			super(b);
+		}
+	}
+	public interface OtherGeneric<T> {
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderNestedGenericTypes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderNestedGenericTypes.java
@@ -1,0 +1,37 @@
+public class SuperBuilderNestedGenericTypes {
+  public static abstract @lombok.experimental.SuperBuilder class Generic<T extends Generic<?>> {
+    public static abstract @java.lang.SuppressWarnings("all") class GenericBuilder<T extends Generic<?>, C extends SuperBuilderNestedGenericTypes.Generic<T>, B extends SuperBuilderNestedGenericTypes.Generic.GenericBuilder<T, C, B>> {
+      public GenericBuilder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return "SuperBuilderNestedGenericTypes.Generic.GenericBuilder()";
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") Generic(final SuperBuilderNestedGenericTypes.Generic.GenericBuilder<T, ?, ?> b) {
+      super();
+    }
+  }
+  public static abstract @lombok.experimental.SuperBuilder class NestedGeneric<T extends OtherGeneric<?>> extends Generic<NestedGeneric<? extends OtherGeneric<?>>> {
+    public static abstract @java.lang.SuppressWarnings("all") class NestedGenericBuilder<T extends OtherGeneric<?>, C extends SuperBuilderNestedGenericTypes.NestedGeneric<T>, B extends SuperBuilderNestedGenericTypes.NestedGeneric.NestedGenericBuilder<T, C, B>> extends Generic.GenericBuilder<NestedGeneric<? extends OtherGeneric<?>>, C, B> {
+      public NestedGenericBuilder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderNestedGenericTypes.NestedGeneric.NestedGenericBuilder(super=" + super.toString()) + ")");
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") NestedGeneric(final SuperBuilderNestedGenericTypes.NestedGeneric.NestedGenericBuilder<T, ?, ?> b) {
+      super(b);
+    }
+  }
+  public interface OtherGeneric<T> {
+  }
+  public SuperBuilderNestedGenericTypes() {
+    super();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderNestedGenericTypes.java
+++ b/test/transform/resource/before/SuperBuilderNestedGenericTypes.java
@@ -1,0 +1,12 @@
+public class SuperBuilderNestedGenericTypes {
+	@lombok.experimental.SuperBuilder
+	public static abstract class Generic<T extends Generic<?>> {
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static abstract class NestedGeneric<T extends OtherGeneric<?>> extends Generic<NestedGeneric<? extends OtherGeneric<?>>> {
+	}
+	
+	public interface OtherGeneric<T> {
+	}
+}


### PR DESCRIPTION
The javac `@SuperBuilder` implementation now works correctly with nested generic type parameters in the extends clause of the annotated class.

This fixes #2359.