### PR TITLE
Set missing argumentTypes for eclipse extension methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Peter Grant <petercgrant@users.noreply.github.com>
 Philipp Eichhorn <peichhor@web.de>
 Philippe Charles <philippe.charles@nbb.be>
 Rabea Gransberger <rgra@users.noreply.github.com>
+Raul Wißfeld <Rawi01@users.noreply.github.com>
 Reinier Zwitserloot <reinier@zwitserloot.com>
 Robbert Jan Grootjans <grootjans@gmail.com>
 Robert Wertman <robert.wertman@gmail.com>


### PR DESCRIPTION
This PR fixes #1441, #1695, and #2236. 

As discussed [here](https://groups.google.com/forum/#!topic/project-lombok/qNu0SUGxNjQ) it uses reflection to support older eclipse versions.