### PR TITLE
Also copy @JacksonXmlProperty to setter

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -314,6 +314,7 @@ public class HandlerUtil {
 		COPY_TO_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonProperty",
 			"com.fasterxml.jackson.annotation.JsonSetter",
+			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
 		}));
 		JACKSON_COPY_TO_BUILDER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonFormat",

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -76,7 +76,7 @@ public class HandlerUtil {
 		return 43;
 	}
 	
-	public static final List<String> NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
+	public static final List<String> NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
 	static {
 		NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"androidx.annotation.NonNull",
@@ -314,7 +314,13 @@ public class HandlerUtil {
 		COPY_TO_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonProperty",
 			"com.fasterxml.jackson.annotation.JsonSetter",
+			"com.fasterxml.jackson.annotation.JsonDeserialize",
+			"com.fasterxml.jackson.annotation.JsonIgnore",
+			"com.fasterxml.jackson.annotation.JacksonInject",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
+		}));
+		COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
+			"com.fasterxml.jackson.annotation.JsonAnySetter",
 		}));
 		JACKSON_COPY_TO_BUILDER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonFormat",

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -149,7 +149,6 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		// @SuperBuilder? Make it package-private!
 		if (superBuilderAnnotationNode != null)
 			builderClass.mods.flags = builderClass.mods.flags & ~Flags.PRIVATE;
-		
  	}
 
 	private String getBuilderClassName(JCAnnotation ast, JavacNode annotationNode, JavacNode annotatedNode, JCClassDecl td, AnnotationValues<Builder> builderAnnotation, JavacTreeMaker maker) {

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1520,6 +1520,20 @@ public class JavacHandlerUtil {
 	 * Searches the given field node for annotations that are specifically intentioned to be copied to the setter.
 	 */
 	public static List<JCAnnotation> findCopyableToSetterAnnotations(JavacNode node) {
+		return findAnnotationsInList(node, COPY_TO_SETTER_ANNOTATIONS);
+	}
+
+	/**
+	 * Searches the given field node for annotations that are specifically intentioned to be copied to the builder's singular method.
+	 */
+	public static List<JCAnnotation> findCopyableToBuilderSingularSetterAnnotations(JavacNode node) {
+		return findAnnotationsInList(node, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS);
+	}
+	
+	/**
+	 * Searches the given field node for annotations that are in the given list, and returns those.
+	 */
+	private static List<JCAnnotation> findAnnotationsInList(JavacNode node, java.util.List<String> annotationsToFind) {
 		JCAnnotation anno = null;
 		String annoName = null;
 		for (JavacNode child : node.down()) {
@@ -1537,7 +1551,7 @@ public class JavacHandlerUtil {
 		if (annoName == null) return List.nil();
 		
 		if (!annoName.isEmpty()) {
-			for (String bn : COPY_TO_SETTER_ANNOTATIONS) if (typeMatches(bn, node, anno.annotationType)) return List.of(anno);
+			for (String bn : annotationsToFind) if (typeMatches(bn, node, anno.annotationType)) return List.of(anno);
 		}
 		
 		ListBuffer<JCAnnotation> result = new ListBuffer<JCAnnotation>();
@@ -1545,7 +1559,7 @@ public class JavacHandlerUtil {
 			if (child.getKind() == Kind.ANNOTATION) {
 				JCAnnotation annotation = (JCAnnotation) child.get();
 				boolean match = false;
-				if (!match) for (String bn : COPY_TO_SETTER_ANNOTATIONS) if (typeMatches(bn, node, annotation.annotationType)) {
+				if (!match) for (String bn : annotationsToFind) if (typeMatches(bn, node, annotation.annotationType)) {
 					result.append(annotation);
 					break;
 				}

--- a/test/stubs/com/fasterxml/jackson/annotation/JsonAnySetter.java
+++ b/test/stubs/com/fasterxml/jackson/annotation/JsonAnySetter.java
@@ -1,0 +1,12 @@
+package com.fasterxml.jackson.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonAnySetter {
+	boolean enabled() default true;
+}

--- a/test/transform/resource/after-delombok/JacksonBuilderSingular.java
+++ b/test/transform/resource/after-delombok/JacksonBuilderSingular.java
@@ -1,0 +1,137 @@
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonBuilderSingular.JacksonBuilderSingularBuilder.class)
+public class JacksonBuilderSingular {
+	@JsonAnySetter
+	public Map<String, Object> any;
+	@JsonProperty("v_a_l_u_e_s")
+	public Map<String, Object> values;
+	@java.lang.SuppressWarnings("all")
+	JacksonBuilderSingular(final Map<String, Object> any, final Map<String, Object> values) {
+		this.any = any;
+		this.values = values;
+	}
+	@java.lang.SuppressWarnings("all")
+	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+	public static class JacksonBuilderSingularBuilder {
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<String> any$key;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<Object> any$value;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<String> values$key;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<Object> values$value;
+		@java.lang.SuppressWarnings("all")
+		JacksonBuilderSingularBuilder() {
+		}
+		@JsonAnySetter
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder any(final String anyKey, final Object anyValue) {
+			if (this.any$key == null) {
+				this.any$key = new java.util.ArrayList<String>();
+				this.any$value = new java.util.ArrayList<Object>();
+			}
+			this.any$key.add(anyKey);
+			this.any$value.add(anyValue);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder any(final java.util.Map<? extends String, ? extends Object> any) {
+			if (any == null) {
+				throw new java.lang.NullPointerException("any cannot be null");
+			}
+			if (this.any$key == null) {
+				this.any$key = new java.util.ArrayList<String>();
+				this.any$value = new java.util.ArrayList<Object>();
+			}
+			for (final java.util.Map.Entry<? extends String, ? extends Object> $lombokEntry : any.entrySet()) {
+				this.any$key.add($lombokEntry.getKey());
+				this.any$value.add($lombokEntry.getValue());
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder clearAny() {
+			if (this.any$key != null) {
+				this.any$key.clear();
+				this.any$value.clear();
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder value(final String valueKey, final Object valueValue) {
+			if (this.values$key == null) {
+				this.values$key = new java.util.ArrayList<String>();
+				this.values$value = new java.util.ArrayList<Object>();
+			}
+			this.values$key.add(valueKey);
+			this.values$value.add(valueValue);
+			return this;
+		}
+		@JsonProperty("v_a_l_u_e_s")
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder values(final java.util.Map<? extends String, ? extends Object> values) {
+			if (values == null) {
+				throw new java.lang.NullPointerException("values cannot be null");
+			}
+			if (this.values$key == null) {
+				this.values$key = new java.util.ArrayList<String>();
+				this.values$value = new java.util.ArrayList<Object>();
+			}
+			for (final java.util.Map.Entry<? extends String, ? extends Object> $lombokEntry : values.entrySet()) {
+				this.values$key.add($lombokEntry.getKey());
+				this.values$value.add($lombokEntry.getValue());
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder clearValues() {
+			if (this.values$key != null) {
+				this.values$key.clear();
+				this.values$value.clear();
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular build() {
+			java.util.Map<String, Object> any;
+			switch (this.any$key == null ? 0 : this.any$key.size()) {
+			case 0: 
+				any = java.util.Collections.emptyMap();
+				break;
+			case 1: 
+				any = java.util.Collections.singletonMap(this.any$key.get(0), this.any$value.get(0));
+				break;
+			default: 
+				any = new java.util.LinkedHashMap<String, Object>(this.any$key.size() < 1073741824 ? 1 + this.any$key.size() + (this.any$key.size() - 3) / 3 : java.lang.Integer.MAX_VALUE);
+				for (int $i = 0; $i < this.any$key.size(); $i++) any.put(this.any$key.get($i), (Object) this.any$value.get($i));
+				any = java.util.Collections.unmodifiableMap(any);
+			}
+			java.util.Map<String, Object> values;
+			switch (this.values$key == null ? 0 : this.values$key.size()) {
+			case 0: 
+				values = java.util.Collections.emptyMap();
+				break;
+			case 1: 
+				values = java.util.Collections.singletonMap(this.values$key.get(0), this.values$value.get(0));
+				break;
+			default: 
+				values = new java.util.LinkedHashMap<String, Object>(this.values$key.size() < 1073741824 ? 1 + this.values$key.size() + (this.values$key.size() - 3) / 3 : java.lang.Integer.MAX_VALUE);
+				for (int $i = 0; $i < this.values$key.size(); $i++) values.put(this.values$key.get($i), (Object) this.values$value.get($i));
+				values = java.util.Collections.unmodifiableMap(values);
+			}
+			return new JacksonBuilderSingular(any, values);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "JacksonBuilderSingular.JacksonBuilderSingularBuilder(any$key=" + this.any$key + ", any$value=" + this.any$value + ", values$key=" + this.values$key + ", values$value=" + this.values$value + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	public static JacksonBuilderSingular.JacksonBuilderSingularBuilder builder() {
+		return new JacksonBuilderSingular.JacksonBuilderSingularBuilder();
+	}
+}

--- a/test/transform/resource/before/JacksonBuilderSingular.java
+++ b/test/transform/resource/before/JacksonBuilderSingular.java
@@ -1,0 +1,20 @@
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Singular;
+import lombok.extern.jackson.Jacksonized;
+
+@Jacksonized
+@Builder
+public class JacksonBuilderSingular {
+	@JsonAnySetter
+	@Singular("any")
+	public Map<String, Object> any;
+
+	@JsonProperty("v_a_l_u_e_s")
+	@Singular
+	public Map<String, Object> values;
+}


### PR DESCRIPTION
`@JacksonXmlProperty` is the XML counterpart to `@JsonProperty`. It allows XML-specific settings, e.g., setting the namespace.

This will allow using a builder to deserialize XML when there are `@JacksonXmlProperty`s present.
See also FasterXML/jackson-dataformat-xml#384.

PS: There are probably a few more of those annotation in the JAXB annotation package, but I never worked with those, so I'm not sure for which of these annotations copying would be always correct.