### PR TITLE
Encode partial URL. Fixes #1536

### DIFF
--- a/src/launch/lombok/launch/ShadowClassLoader.java
+++ b/src/launch/lombok/launch/ShadowClassLoader.java
@@ -321,8 +321,9 @@ class ShadowClassLoader extends ClassLoader {
 	}
 	
 	private static String urlDecode(String in) {
+		final String plusFixed = in.replaceAll("\\+", "%2B");
 		try {
-			return URLDecoder.decode(in, "UTF-8");
+			return URLDecoder.decode(plusFixed, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			throw new InternalError("UTF-8 not supported");
 		}


### PR DESCRIPTION
url.toString is not encoded properly, so to not lose the "+" in the url one has to properly encode it before decoding other chars like " " are correctly encoded
According to https://docs.oracle.com/javase/7/docs/api/java/net/URLDecoder.html this behaviour is correct "+" is Encoded as " " which is not the file someone whants
This Fixes #1536 