### PR TITLE
[fixes #2286] Set source range for vararg arrays

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -103,6 +103,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 			patchIdentifierEndReparse(sm);
 			patchRetrieveEllipsisStartPosition(sm);
 			patchRetrieveRightBraceOrSemiColonPosition(sm);
+			patchRetrieveProperRightBracketPosition(sm);
 			patchSetGeneratedFlag(sm);
 			patchDomAstReparseIssues(sm);
 			patchHideGeneratedNodes(sm);
@@ -443,6 +444,16 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 //				.target(new MethodTarget("org.eclipse.jdt.core.dom.ASTConverter", "retrieveRightBrace"))
 //				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "fixRetrieveRightBraceOrSemiColonPosition", "int", "int", "int"))
 //				.transplant().request(StackRequest.RETURN_VALUE, StackRequest.PARAM2).build());
+	}
+
+	private static void patchRetrieveProperRightBracketPosition(ScriptManager sm) {
+		sm.addScript(ScriptBuilder.wrapMethodCall()
+			.target(new MethodTarget("org.eclipse.jdt.core.dom.ASTConverter", "extractSubArrayType", "org.eclipse.jdt.core.dom.ArrayType", "org.eclipse.jdt.core.dom.ArrayType", "int", "int"))
+			.methodToWrap(new Hook("org.eclipse.jdt.core.dom.ASTConverter", "retrieveProperRightBracketPosition", "int", "int", "int"))
+			.wrapMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "fixRetrieveProperRightBracketPosition", "int", "int", "org.eclipse.jdt.core.dom.ArrayType"))
+			.requestExtra(StackRequest.PARAM1)
+			.transplant()
+			.build());
 	}
 
 	private static void patchSetGeneratedFlag(ScriptManager sm) {

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.search.SearchMatch;
@@ -514,6 +515,12 @@ final class PatchFixesHider {
 			if (retVal != -1 || fd == null) return retVal;
 			boolean isGenerated = EclipseAugments.ASTNode_generatedBy.get(fd) != null;
 			if (isGenerated) return fd.declarationSourceEnd;
+			return -1;
+		}
+		
+		public static int fixRetrieveProperRightBracketPosition(int retVal, ArrayType arrayType) {
+			if (retVal != -1 || arrayType == null) return retVal;
+			if (isGenerated(arrayType)) return arrayType.getStartPosition() + arrayType.getLength() - 1;
 			return -1;
 		}
 		


### PR DESCRIPTION
This on fixes #2286.

You can use this class to reproduce the original issue (delegating a method with vararg array e.g. `String[]...` parameter)

```java
import lombok.experimental.Delegate;

public class A {
	
	@Delegate
	private A.B delegate;
	
	public class B {
		public void varargs(Object[]... keys) {
		}
	}

}
```