### PR TITLE
Add null check in copyTypeAnns

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -660,9 +660,11 @@ public class EclipseHandlerUtil {
 		
 		Annotation[][] b = new Annotation[a.length][];
 		for (int i = 0; i < a.length; i++) {
-			b[i] = new Annotation[a[i].length];
-			for (int j = 0 ; j < a[i].length; j++) {
-				b[i][j] = copyAnnotation(a[i][j], a[i][j]);
+			if (a[i] != null) {
+				b[i] = new Annotation[a[i].length];
+				for (int j = 0 ; j < a[i].length; j++) {
+					b[i][j] = copyAnnotation(a[i][j], a[i][j]);
+				}
 			}
 		}
 		

--- a/test/transform/resource/after-delombok/TypeUseAnnotations.java
+++ b/test/transform/resource/after-delombok/TypeUseAnnotations.java
@@ -7,8 +7,18 @@ import java.util.List;
 }
 class TypeUseAnnotations {
 	List<@TA(x = 5) String> foo;
+	List<TypeUseAnnotations.@TA(x = 5) Inner> bar;
+
+	class Inner {
+	}
+
 	@java.lang.SuppressWarnings("all")
 	public List<@TA(x = 5) String> getFoo() {
 		return this.foo;
+	}
+	
+	@java.lang.SuppressWarnings("all")
+	public List<TypeUseAnnotations.@TA(x = 5) Inner> getBar() {
+		return this.bar;
 	}
 }

--- a/test/transform/resource/after-ecj/TypeUseAnnotations.java
+++ b/test/transform/resource/after-ecj/TypeUseAnnotations.java
@@ -5,11 +5,20 @@ import java.util.List;
   int x();
 }
 class TypeUseAnnotations {
+  class Inner {
+    Inner() {
+      super();
+    }
+  }
   @lombok.Getter List<@TA(x = 5) String> foo;
+  @lombok.Getter List<TypeUseAnnotations.@TA(x = 5) Inner> bar;
   TypeUseAnnotations() {
     super();
   }
   public @java.lang.SuppressWarnings("all") List<@TA(x = 5) String> getFoo() {
     return this.foo;
+  }
+  public @java.lang.SuppressWarnings("all") List<TypeUseAnnotations.@TA(x = 5) Inner> getBar() {
+    return this.bar;
   }
 }

--- a/test/transform/resource/before/TypeUseAnnotations.java
+++ b/test/transform/resource/before/TypeUseAnnotations.java
@@ -8,4 +8,6 @@ import java.util.List;
 }
 class TypeUseAnnotations {
 	@lombok.Getter List<@TA(x=5) String> foo;
+	@lombok.Getter List<TypeUseAnnotations.@TA(x=5) Inner> bar;
+	class Inner { }
 }


### PR DESCRIPTION
This PR fixes #2246.

An annotated generic type (`List<TypeUseAnnotations.@TA(x = 5) Inner>` returns an annotatons array with null values(`[null, [TA]]`). The copy method can now handle these cases.

I also added a simple test.