### PR TITLE
Copy more Jackson annotation to the builder, also to @Singular methods

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -76,7 +76,7 @@ public class HandlerUtil {
 		return 43;
 	}
 	
-	public static final List<String> NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
+	public static final List<String> NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
 	static {
 		NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"androidx.annotation.NonNull",
@@ -314,6 +314,13 @@ public class HandlerUtil {
 		COPY_TO_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonProperty",
 			"com.fasterxml.jackson.annotation.JsonSetter",
+			"com.fasterxml.jackson.annotation.JsonDeserialize",
+			"com.fasterxml.jackson.annotation.JsonIgnore",
+			"com.fasterxml.jackson.annotation.JacksonInject",
+			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
+		}));
+		COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
+			"com.fasterxml.jackson.annotation.JsonAnySetter",
 		}));
 		JACKSON_COPY_TO_BUILDER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonFormat",

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseGuavaSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseGuavaSingularizer.java
@@ -175,8 +175,10 @@ abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 		md.returnType = returnType;
 		char[] prefixedSingularName = data.getSetterPrefix().length == 0 ? data.getSingularName() : HandlerUtil.buildAccessorName(new String(data.getSetterPrefix()), new String(data.getSingularName())).toCharArray();
 		md.selector = fluent ? prefixedSingularName : HandlerUtil.buildAccessorName("add", new String(data.getSingularName())).toCharArray();
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
-		
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToBuilderSingularSetterAnnotations(data.getAnnotation().up()));
+		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
+
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);
 		HandleNonNull.INSTANCE.fix(injectMethod(builderType, md));
@@ -213,8 +215,10 @@ abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 		md.returnType = returnType;
 		char[] prefixedSelector = data.getSetterPrefix().length == 0 ? data.getPluralName() : HandlerUtil.buildAccessorName(new String(data.getSetterPrefix()), new String(data.getPluralName())).toCharArray();
 		md.selector = fluent ? prefixedSelector : HandlerUtil.buildAccessorName("addAll", new String(data.getPluralName())).toCharArray();
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
-		
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToSetterAnnotations(data.getAnnotation().up()));
+		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
+
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);
 		injectMethod(builderType, md);

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSetSingularizer.java
@@ -153,8 +153,10 @@ abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingula
 		md.returnType = returnType;
 		char[] prefixedSingularName = data.getSetterPrefix().length == 0 ? data.getSingularName() : HandlerUtil.buildAccessorName(new String(data.getSetterPrefix()), new String(data.getSingularName())).toCharArray();
 		md.selector = fluent ? prefixedSingularName : HandlerUtil.buildAccessorName("add", new String(data.getSingularName())).toCharArray();
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
-		
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToBuilderSingularSetterAnnotations(data.getAnnotation().up()));
+		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
+
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);
 		HandleNonNull.INSTANCE.fix(injectMethod(builderType, md));
@@ -189,8 +191,10 @@ abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingula
 		md.returnType = returnType;
 		char[] prefixedSelector = data.getSetterPrefix().length == 0 ? data.getPluralName() : HandlerUtil.buildAccessorName(new String(data.getSetterPrefix()), new String(data.getPluralName())).toCharArray();
 		md.selector = fluent ? prefixedSelector : HandlerUtil.buildAccessorName("addAll", new String(data.getPluralName())).toCharArray();
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
-		
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToSetterAnnotations(data.getAnnotation().up()));
+		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
+
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);
 		injectMethod(builderType, md);

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
@@ -252,7 +252,9 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		String setterName = HandlerUtil.buildAccessorName(setterPrefix, name);
 		
 		md.selector = setterName.toCharArray();
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToBuilderSingularSetterAnnotations(data.getAnnotation().up()));
+		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 		
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);
@@ -326,7 +328,9 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		String setterName = HandlerUtil.buildAccessorName(setterPrefix, name);
 		
 		md.selector = setterName.toCharArray();
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToSetterAnnotations(data.getAnnotation().up()));
+		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 		
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -149,7 +149,6 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		// @SuperBuilder? Make it package-private!
 		if (superBuilderAnnotationNode != null)
 			builderClass.mods.flags = builderClass.mods.flags & ~Flags.PRIVATE;
-		
  	}
 
 	private String getBuilderClassName(JCAnnotation ast, JavacNode annotationNode, JavacNode annotatedNode, JCClassDecl td, AnnotationValues<Builder> builderAnnotation, JavacTreeMaker maker) {

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1520,6 +1520,20 @@ public class JavacHandlerUtil {
 	 * Searches the given field node for annotations that are specifically intentioned to be copied to the setter.
 	 */
 	public static List<JCAnnotation> findCopyableToSetterAnnotations(JavacNode node) {
+		return findAnnotationsInList(node, COPY_TO_SETTER_ANNOTATIONS);
+	}
+
+	/**
+	 * Searches the given field node for annotations that are specifically intentioned to be copied to the builder's singular method.
+	 */
+	public static List<JCAnnotation> findCopyableToBuilderSingularSetterAnnotations(JavacNode node) {
+		return findAnnotationsInList(node, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS);
+	}
+	
+	/**
+	 * Searches the given field node for annotations that are in the given list, and returns those.
+	 */
+	private static List<JCAnnotation> findAnnotationsInList(JavacNode node, java.util.List<String> annotationsToFind) {
 		JCAnnotation anno = null;
 		String annoName = null;
 		for (JavacNode child : node.down()) {
@@ -1537,7 +1551,7 @@ public class JavacHandlerUtil {
 		if (annoName == null) return List.nil();
 		
 		if (!annoName.isEmpty()) {
-			for (String bn : COPY_TO_SETTER_ANNOTATIONS) if (typeMatches(bn, node, anno.annotationType)) return List.of(anno);
+			for (String bn : annotationsToFind) if (typeMatches(bn, node, anno.annotationType)) return List.of(anno);
 		}
 		
 		ListBuffer<JCAnnotation> result = new ListBuffer<JCAnnotation>();
@@ -1545,7 +1559,7 @@ public class JavacHandlerUtil {
 			if (child.getKind() == Kind.ANNOTATION) {
 				JCAnnotation annotation = (JCAnnotation) child.get();
 				boolean match = false;
-				if (!match) for (String bn : COPY_TO_SETTER_ANNOTATIONS) if (typeMatches(bn, node, annotation.annotationType)) {
+				if (!match) for (String bn : annotationsToFind) if (typeMatches(bn, node, annotation.annotationType)) {
 					result.append(annotation);
 					break;
 				}

--- a/test/stubs/com/fasterxml/jackson/annotation/JsonAnySetter.java
+++ b/test/stubs/com/fasterxml/jackson/annotation/JsonAnySetter.java
@@ -1,0 +1,12 @@
+package com.fasterxml.jackson.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonAnySetter {
+	boolean enabled() default true;
+}

--- a/test/transform/resource/after-delombok/JacksonBuilderSingular.java
+++ b/test/transform/resource/after-delombok/JacksonBuilderSingular.java
@@ -1,0 +1,177 @@
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonBuilderSingular.JacksonBuilderSingularBuilder.class)
+public class JacksonBuilderSingular {
+	@JsonAnySetter
+	private Map<String, Object> any;
+	@JsonProperty("v_a_l_u_e_s")
+	private List<String> values;
+	@JsonAnySetter
+	private ImmutableMap<String, Object> guavaAny;
+	@JsonProperty("guava_v_a_l_u_e_s")
+	private ImmutableList<String> guavaValues;
+	@java.lang.SuppressWarnings("all")
+	JacksonBuilderSingular(final Map<String, Object> any, final List<String> values, final ImmutableMap<String, Object> guavaAny, final ImmutableList<String> guavaValues) {
+		this.any = any;
+		this.values = values;
+		this.guavaAny = guavaAny;
+		this.guavaValues = guavaValues;
+	}
+	@java.lang.SuppressWarnings("all")
+	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+	public static class JacksonBuilderSingularBuilder {
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<String> any$key;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<Object> any$value;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<String> values;
+		@java.lang.SuppressWarnings("all")
+		private com.google.common.collect.ImmutableMap.Builder<String, Object> guavaAny;
+		@java.lang.SuppressWarnings("all")
+		private com.google.common.collect.ImmutableList.Builder<String> guavaValues;
+		@java.lang.SuppressWarnings("all")
+		JacksonBuilderSingularBuilder() {
+		}
+		@JsonAnySetter
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder any(final String anyKey, final Object anyValue) {
+			if (this.any$key == null) {
+				this.any$key = new java.util.ArrayList<String>();
+				this.any$value = new java.util.ArrayList<Object>();
+			}
+			this.any$key.add(anyKey);
+			this.any$value.add(anyValue);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder any(final java.util.Map<? extends String, ? extends Object> any) {
+			if (any == null) {
+				throw new java.lang.NullPointerException("any cannot be null");
+			}
+			if (this.any$key == null) {
+				this.any$key = new java.util.ArrayList<String>();
+				this.any$value = new java.util.ArrayList<Object>();
+			}
+			for (final java.util.Map.Entry<? extends String, ? extends Object> $lombokEntry : any.entrySet()) {
+				this.any$key.add($lombokEntry.getKey());
+				this.any$value.add($lombokEntry.getValue());
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder clearAny() {
+			if (this.any$key != null) {
+				this.any$key.clear();
+				this.any$value.clear();
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder value(final String value) {
+			if (this.values == null) this.values = new java.util.ArrayList<String>();
+			this.values.add(value);
+			return this;
+		}
+		@JsonProperty("v_a_l_u_e_s")
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder values(final java.util.Collection<? extends String> values) {
+			if (values == null) {
+				throw new java.lang.NullPointerException("values cannot be null");
+			}
+			if (this.values == null) this.values = new java.util.ArrayList<String>();
+			this.values.addAll(values);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder clearValues() {
+			if (this.values != null) this.values.clear();
+			return this;
+		}
+		@JsonAnySetter
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaAny(final String key, final Object value) {
+			if (this.guavaAny == null) this.guavaAny = com.google.common.collect.ImmutableMap.builder();
+			this.guavaAny.put(key, value);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaAny(final java.util.Map<? extends String, ? extends Object> guavaAny) {
+			if (guavaAny == null) {
+				throw new java.lang.NullPointerException("guavaAny cannot be null");
+			}
+			if (this.guavaAny == null) this.guavaAny = com.google.common.collect.ImmutableMap.builder();
+			this.guavaAny.putAll(guavaAny);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder clearGuavaAny() {
+			this.guavaAny = null;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaValue(final String guavaValue) {
+			if (this.guavaValues == null) this.guavaValues = com.google.common.collect.ImmutableList.builder();
+			this.guavaValues.add(guavaValue);
+			return this;
+		}
+		@JsonProperty("guava_v_a_l_u_e_s")
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaValues(final java.lang.Iterable<? extends String> guavaValues) {
+			if (guavaValues == null) {
+				throw new java.lang.NullPointerException("guavaValues cannot be null");
+			}
+			if (this.guavaValues == null) this.guavaValues = com.google.common.collect.ImmutableList.builder();
+			this.guavaValues.addAll(guavaValues);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular.JacksonBuilderSingularBuilder clearGuavaValues() {
+			this.guavaValues = null;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public JacksonBuilderSingular build() {
+			java.util.Map<String, Object> any;
+			switch (this.any$key == null ? 0 : this.any$key.size()) {
+			case 0: 
+				any = java.util.Collections.emptyMap();
+				break;
+			case 1: 
+				any = java.util.Collections.singletonMap(this.any$key.get(0), this.any$value.get(0));
+				break;
+			default: 
+				any = new java.util.LinkedHashMap<String, Object>(this.any$key.size() < 1073741824 ? 1 + this.any$key.size() + (this.any$key.size() - 3) / 3 : java.lang.Integer.MAX_VALUE);
+				for (int $i = 0; $i < this.any$key.size(); $i++) any.put(this.any$key.get($i), (Object) this.any$value.get($i));
+				any = java.util.Collections.unmodifiableMap(any);
+			}
+			java.util.List<String> values;
+			switch (this.values == null ? 0 : this.values.size()) {
+			case 0: 
+				values = java.util.Collections.emptyList();
+				break;
+			case 1: 
+				values = java.util.Collections.singletonList(this.values.get(0));
+				break;
+			default: 
+				values = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(this.values));
+			}
+			com.google.common.collect.ImmutableMap<String, Object> guavaAny = this.guavaAny == null ? com.google.common.collect.ImmutableMap.<String, Object>of() : this.guavaAny.build();
+			com.google.common.collect.ImmutableList<String> guavaValues = this.guavaValues == null ? com.google.common.collect.ImmutableList.<String>of() : this.guavaValues.build();
+			return new JacksonBuilderSingular(any, values, guavaAny, guavaValues);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "JacksonBuilderSingular.JacksonBuilderSingularBuilder(any$key=" + this.any$key + ", any$value=" + this.any$value + ", values=" + this.values + ", guavaAny=" + this.guavaAny + ", guavaValues=" + this.guavaValues + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	public static JacksonBuilderSingular.JacksonBuilderSingularBuilder builder() {
+		return new JacksonBuilderSingular.JacksonBuilderSingularBuilder();
+	}
+}

--- a/test/transform/resource/after-ecj/JacksonBuilderSingular.java
+++ b/test/transform/resource/after-ecj/JacksonBuilderSingular.java
@@ -1,0 +1,164 @@
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.extern.jackson.Jacksonized;
+public @Jacksonized @Builder @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonBuilderSingular.JacksonBuilderSingularBuilder.class) class JacksonBuilderSingular {
+  public static @java.lang.SuppressWarnings("all") @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class JacksonBuilderSingularBuilder {
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> any$key;
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<Object> any$value;
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> values;
+    private @java.lang.SuppressWarnings("all") com.google.common.collect.ImmutableMap.Builder<String, Object> guavaAny;
+    private @java.lang.SuppressWarnings("all") com.google.common.collect.ImmutableList.Builder<String> guavaValues;
+    @java.lang.SuppressWarnings("all") JacksonBuilderSingularBuilder() {
+      super();
+    }
+    public @JsonAnySetter @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder any(final String anyKey, final Object anyValue) {
+      if ((this.any$key == null))
+          {
+            this.any$key = new java.util.ArrayList<String>();
+            this.any$value = new java.util.ArrayList<Object>();
+          }
+      this.any$key.add(anyKey);
+      this.any$value.add(anyValue);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder any(final java.util.Map<? extends String, ? extends Object> any) {
+      if ((any == null))
+          {
+            throw new java.lang.NullPointerException("any cannot be null");
+          }
+      if ((this.any$key == null))
+          {
+            this.any$key = new java.util.ArrayList<String>();
+            this.any$value = new java.util.ArrayList<Object>();
+          }
+      for (java.util.Map.Entry<? extends String, ? extends Object> $lombokEntry : any.entrySet()) 
+        {
+          this.any$key.add($lombokEntry.getKey());
+          this.any$value.add($lombokEntry.getValue());
+        }
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder clearAny() {
+      if ((this.any$key != null))
+          {
+            this.any$key.clear();
+            this.any$value.clear();
+          }
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder value(final String value) {
+      if ((this.values == null))
+          this.values = new java.util.ArrayList<String>();
+      this.values.add(value);
+      return this;
+    }
+    public @JsonProperty("v_a_l_u_e_s") @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder values(final java.util.Collection<? extends String> values) {
+      if ((values == null))
+          {
+            throw new java.lang.NullPointerException("values cannot be null");
+          }
+      if ((this.values == null))
+          this.values = new java.util.ArrayList<String>();
+      this.values.addAll(values);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder clearValues() {
+      if ((this.values != null))
+          this.values.clear();
+      return this;
+    }
+    public @JsonAnySetter @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaAny(final String key, final Object value) {
+      if ((this.guavaAny == null))
+          this.guavaAny = com.google.common.collect.ImmutableMap.builder();
+      this.guavaAny.put(key, value);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaAny(final java.util.Map<? extends String, ? extends Object> guavaAny) {
+      if ((guavaAny == null))
+          {
+            throw new java.lang.NullPointerException("guavaAny cannot be null");
+          }
+      if ((this.guavaAny == null))
+          this.guavaAny = com.google.common.collect.ImmutableMap.builder();
+      this.guavaAny.putAll(guavaAny);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder clearGuavaAny() {
+      this.guavaAny = null;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaValue(final String guavaValue) {
+      if ((this.guavaValues == null))
+          this.guavaValues = com.google.common.collect.ImmutableList.builder();
+      this.guavaValues.add(guavaValue);
+      return this;
+    }
+    public @JsonProperty("guava_v_a_l_u_e_s") @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder guavaValues(final java.lang.Iterable<? extends String> guavaValues) {
+      if ((guavaValues == null))
+          {
+            throw new java.lang.NullPointerException("guavaValues cannot be null");
+          }
+      if ((this.guavaValues == null))
+          this.guavaValues = com.google.common.collect.ImmutableList.builder();
+      this.guavaValues.addAll(guavaValues);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder clearGuavaValues() {
+      this.guavaValues = null;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") JacksonBuilderSingular build() {
+      java.util.Map<String, Object> any;
+      switch (((this.any$key == null) ? 0 : this.any$key.size())) {
+      case 0 :
+          any = java.util.Collections.emptyMap();
+          break;
+      case 1 :
+          any = java.util.Collections.singletonMap(this.any$key.get(0), this.any$value.get(0));
+          break;
+      default :
+          any = new java.util.LinkedHashMap<String, Object>(((this.any$key.size() < 0x40000000) ? ((1 + this.any$key.size()) + ((this.any$key.size() - 3) / 3)) : java.lang.Integer.MAX_VALUE));
+          for (int $i = 0;; ($i < this.any$key.size()); $i ++) 
+            any.put(this.any$key.get($i), this.any$value.get($i));
+          any = java.util.Collections.unmodifiableMap(any);
+      }
+      java.util.List<String> values;
+      switch (((this.values == null) ? 0 : this.values.size())) {
+      case 0 :
+          values = java.util.Collections.emptyList();
+          break;
+      case 1 :
+          values = java.util.Collections.singletonList(this.values.get(0));
+          break;
+      default :
+          values = java.util.Collections.unmodifiableList(new java.util.ArrayList<String>(this.values));
+      }
+      com.google.common.collect.ImmutableMap<String, Object> guavaAny = ((this.guavaAny == null) ? com.google.common.collect.ImmutableMap.<String, Object>of() : this.guavaAny.build());
+      com.google.common.collect.ImmutableList<String> guavaValues = ((this.guavaValues == null) ? com.google.common.collect.ImmutableList.<String>of() : this.guavaValues.build());
+      return new JacksonBuilderSingular(any, values, guavaAny, guavaValues);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((((((((("JacksonBuilderSingular.JacksonBuilderSingularBuilder(any$key=" + this.any$key) + ", any$value=") + this.any$value) + ", values=") + this.values) + ", guavaAny=") + this.guavaAny) + ", guavaValues=") + this.guavaValues) + ")");
+    }
+  }
+  private @JsonAnySetter @Singular("any") Map<String, Object> any;
+  private @JsonProperty("v_a_l_u_e_s") @Singular List<String> values;
+  private @JsonAnySetter @Singular("guavaAny") ImmutableMap<String, Object> guavaAny;
+  private @JsonProperty("guava_v_a_l_u_e_s") @Singular ImmutableList<String> guavaValues;
+  @java.lang.SuppressWarnings("all") JacksonBuilderSingular(final Map<String, Object> any, final List<String> values, final ImmutableMap<String, Object> guavaAny, final ImmutableList<String> guavaValues) {
+    super();
+    this.any = any;
+    this.values = values;
+    this.guavaAny = guavaAny;
+    this.guavaValues = guavaValues;
+  }
+  public static @java.lang.SuppressWarnings("all") JacksonBuilderSingular.JacksonBuilderSingularBuilder builder() {
+    return new JacksonBuilderSingular.JacksonBuilderSingularBuilder();
+  }
+}

--- a/test/transform/resource/before/JacksonBuilderSingular.java
+++ b/test/transform/resource/before/JacksonBuilderSingular.java
@@ -1,0 +1,31 @@
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import lombok.Builder;
+import lombok.Singular;
+import lombok.extern.jackson.Jacksonized;
+
+@Jacksonized
+@Builder
+public class JacksonBuilderSingular {
+	@JsonAnySetter
+	@Singular("any")
+	private Map<String, Object> any;
+
+	@JsonProperty("v_a_l_u_e_s")
+	@Singular
+	private List<String> values;
+
+	@JsonAnySetter
+	@Singular("guavaAny")
+	private ImmutableMap<String, Object> guavaAny;
+
+	@JsonProperty("guava_v_a_l_u_e_s")
+	@Singular
+	private ImmutableList<String> guavaValues;
+}


### PR DESCRIPTION
In #2419, we investigated which further Jackson annotations should be copied: `@JacksonXmlProperty`, `@JsonDeserialize`, `@JsonIgnore`, and `@JacksonInject`; details in the issue discussion. 

(There are probably a few more of those annotation in the JAXB annotation package, but I never worked with those, so I'm not sure for which of these annotations copying would be always correct.)

Furthermore, with this PR, annotations are copied to `@Singular` methods. Most copyable annotations are put on the "regular" plural method, as this is what Jackson expects. The only exception is `@JsonAnySetter`, which is copied to the singular method (it only works on that).