### PR TITLE
Update Fake.class to support OpenJ9 Field Layout

### DIFF
--- a/src/utils/lombok/permit/Permit.java
+++ b/src/utils/lombok/permit/Permit.java
@@ -95,6 +95,7 @@ public class Permit {
 	
 	static class Fake {
 		boolean override;
+		Object accessCheckCache;
 	}
 	
 	public static Method getMethod(Class<?> c, String mName, Class<?>... parameterTypes) throws NoSuchMethodException {


### PR DESCRIPTION
Currently lombok crashes when building with OpenJ9 JDK as described in #2414 
It is due to the `override` field offset from Fake.class doesn't match actual offset value for AccessibleObject.class in OpenJ9 

This change is to support the OpenJ9 Field layout algorithm.