### PR TITLE
Enum.values() requires enumConstantsCounter to be set

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleFieldNameConstants.java
+++ b/src/core/lombok/eclipse/handlers/HandleFieldNameConstants.java
@@ -136,9 +136,8 @@ public class HandleFieldNameConstants extends EclipseAnnotationHandler<FieldName
 		EclipseNode fieldsType = findInnerClass(typeNode, innerTypeName.getName());
 		boolean genConstr = false, genClinit = false;
 		char[] name = innerTypeName.getCharArray();
-		TypeDeclaration generatedInnerType = null;
 		if (fieldsType == null) {
-			generatedInnerType = new TypeDeclaration(parent.compilationResult);
+			TypeDeclaration generatedInnerType = new TypeDeclaration(parent.compilationResult);
 			generatedInnerType.bits |= Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
 			generatedInnerType.modifiers = toEclipseModifier(level) | (asEnum ? ClassFileConstants.AccEnum : (ClassFileConstants.AccStatic | ClassFileConstants.AccFinal));
 			generatedInnerType.name = name;
@@ -194,6 +193,7 @@ public class HandleFieldNameConstants extends EclipseAnnotationHandler<FieldName
 				ac.sourceEnd = source.sourceEnd;
 				constantField.initialization = ac;
 				constantField.modifiers = 0;
+				((TypeDeclaration) fieldsType.get()).enumConstantsCounter++;
 			} else {
 				constantField.type = new QualifiedTypeReference(TypeConstants.JAVA_LANG_STRING, new long[] {p, p, p});
 				constantField.initialization = new StringLiteral(field.name, pS, pE, 0);


### PR DESCRIPTION
This PR resolves #1969. The field `enumConstantsCounter` must be set to the field count, otherwise `Enum.values()` returns an incomplete list