### PR TITLE
Handle generic supertypes

### DIFF
--- a/src/core/lombok/javac/handlers/HandleDelegate.java
+++ b/src/core/lombok/javac/handlers/HandleDelegate.java
@@ -389,10 +389,11 @@ public class HandleDelegate extends JavacAnnotationHandler<Delegate> {
 			boolean isDeprecated = (member.flags() & DEPRECATED) != 0;
 			signatures.add(new MethodSig(member.name, methodType, isDeprecated, exElem));
 		}
-		
-		if (ct.supertype_field instanceof ClassType) addMethodBindings(signatures, (ClassType) ct.supertype_field, types, banList);
-		if (ct.interfaces_field != null) for (Type iface : ct.interfaces_field) {
-			if (iface instanceof ClassType) addMethodBindings(signatures, (ClassType) iface, types, banList);
+
+		for (Type type : types.directSupertypes(ct)) {
+			if (type instanceof ClassType) {
+				addMethodBindings(signatures, (ClassType) type, types, banList);
+			}
 		}
 	}
 	

--- a/test/transform/resource/after-delombok/DelegateGenerics.java
+++ b/test/transform/resource/after-delombok/DelegateGenerics.java
@@ -1,0 +1,32 @@
+public class DelegateGenerics<T> {
+	I1<T> target;
+
+	@java.lang.SuppressWarnings("all")
+	public java.lang.Integer t(final java.lang.Integer t) {
+		return this.target.t(t);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public java.lang.String i(final java.lang.String a) {
+		return this.target.i(a);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public T a(final T a) {
+		return this.target.a(a);
+	}
+}
+
+interface I1<T> extends I2<T, Integer, String> {
+}
+
+interface I2<A, T, I> extends I3<Integer, I, A> {
+}
+
+interface I3<T, I, A> {
+	T t(T t);
+
+	I i(I a);
+
+	A a(A a);
+}

--- a/test/transform/resource/after-ecj/DelegateGenerics.java
+++ b/test/transform/resource/after-ecj/DelegateGenerics.java
@@ -1,0 +1,24 @@
+public class DelegateGenerics<T> {
+  @lombok.experimental.Delegate I1<T> target;
+  public DelegateGenerics() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") T a(final T a) {
+    return this.target.a(a);
+  }
+  public @java.lang.SuppressWarnings("all") java.lang.String i(final java.lang.String a) {
+    return this.target.i(a);
+  }
+  public @java.lang.SuppressWarnings("all") java.lang.Integer t(final java.lang.Integer t) {
+    return this.target.t(t);
+  }
+}
+interface I1<T> extends I2<T, Integer, String> {
+}
+interface I2<A, T, I> extends I3<Integer, I, A> {
+}
+interface I3<T, I, A> {
+  public T t(T t);
+  public I i(I a);
+  public A a(A a);
+}

--- a/test/transform/resource/before/DelegateGenerics.java
+++ b/test/transform/resource/before/DelegateGenerics.java
@@ -1,0 +1,14 @@
+public class DelegateGenerics<T> {
+	@lombok.experimental.Delegate
+	I1<T> target;
+}
+
+interface I1<T> extends I2<T, Integer, String> {
+}
+interface I2<A, T, I> extends I3<Integer, I, A> {
+}
+interface I3<T, I, A> {
+	public T t(T t);
+	public I i(I a);
+	public A a(A a);
+}


### PR DESCRIPTION
This PR resolves #2382. 
`supertype_field` and `interfaces_field` are empty if the parent uses generics. The method `types.directSupertypes` returns the parent and sets the generic type information properly.