### PR TITLE
[fixes #2006] Delegate now excludes already implemented methods

### DIFF
--- a/src/core/lombok/javac/handlers/HandleDelegate.java
+++ b/src/core/lombok/javac/handlers/HandleDelegate.java
@@ -48,6 +48,7 @@ import org.mangosdk.spi.ProviderFor;
 import com.sun.tools.javac.code.Attribute.Compound;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ClassType;
@@ -175,14 +176,14 @@ public class HandleDelegate extends JavacAnnotationHandler<Delegate> {
 		List<MethodSig> signaturesToExclude = new ArrayList<MethodSig>();
 		Set<String> banList = new HashSet<String>();
 		banList.addAll(METHODS_IN_OBJECT);
-		/* To exclude all methods in the class itself, try this:
-		for (Symbol member : ((JCClassDecl)typeNode.get()).sym.getEnclosedElements()) {
-			if (member instanceof MethodSymbol) {
-				MethodSymbol method = (MethodSymbol) member;
-				banList.add(printSig((ExecutableType) method.asType(), method.name, annotationNode.getTypesUtil()));
+		
+		// Add already implemented methods to ban list
+		JavacNode typeNode = upToTypeNode(annotationNode);
+		for (Symbol m : ((JCClassDecl)typeNode.get()).sym.getEnclosedElements()) {
+			if (m instanceof MethodSymbol) {
+				banList.add(printSig((ExecutableType) m.asType(), m.name, annotationNode.getTypesUtil()));
 			}
 		}
-		 */
 		
 		try {
 			for (Type t : toExclude) {

--- a/test/transform/resource/after-delombok/DelegateAlreadyImplemented.java
+++ b/test/transform/resource/after-delombok/DelegateAlreadyImplemented.java
@@ -1,0 +1,43 @@
+public class DelegateAlreadyImplemented<T> {
+	private A<Integer, T> a;
+
+	public void a() {
+	}
+
+	public void b(java.util.List<String> l) {
+	}
+
+	public void c(java.util.List<Integer> l, String[] a, Integer... varargs) {
+	}
+
+	public void d(String[][][][] d) {
+	}
+
+	public <Y> void e(Y x) {
+	}
+
+	@SuppressWarnings("unchecked")
+	public void f(T s, java.util.List<T> l, T[] a, T... varargs) {
+	}
+
+	public void g(Number g) {
+	}
+}
+
+interface A<T, T2> {
+	void a();
+
+	void b(java.util.List<T> l);
+
+	@SuppressWarnings("unchecked")
+	void c(java.util.List<T> l, String[] a, T... varargs);
+
+	void d(String[][][][] d);
+
+	<X> X e(X x);
+
+	@SuppressWarnings("unchecked")
+	void f(T2 s, java.util.List<T2> l, T2[] a, T2... varargs);
+
+	<G extends Number> void g(G g);
+}

--- a/test/transform/resource/after-ecj/DelegateAlreadyImplemented.java
+++ b/test/transform/resource/after-ecj/DelegateAlreadyImplemented.java
@@ -1,0 +1,29 @@
+public class DelegateAlreadyImplemented<T> {
+  private @lombok.experimental.Delegate A<Integer, T> a;
+  public DelegateAlreadyImplemented() {
+    super();
+  }
+  public void a() {
+  }
+  public void b(java.util.List<String> l) {
+  }
+  public void c(java.util.List<Integer> l, String[] a, Integer... varargs) {
+  }
+  public void d(String[][][][] d) {
+  }
+  public <Y>void e(Y x) {
+  }
+  public @SuppressWarnings("unchecked") void f(T s, java.util.List<T> l, T[] a, T... varargs) {
+  }
+  public void g(Number g) {
+  }
+}
+interface A<T, T2> {
+  public void a();
+  public void b(java.util.List<T> l);
+  public @SuppressWarnings("unchecked") void c(java.util.List<T> l, String[] a, T... varargs);
+  public void d(String[][][][] d);
+  public <X>X e(X x);
+  public @SuppressWarnings("unchecked") void f(T2 s, java.util.List<T2> l, T2[] a, T2... varargs);
+  public <G extends Number>void g(G g);
+}

--- a/test/transform/resource/before/DelegateAlreadyImplemented.java
+++ b/test/transform/resource/before/DelegateAlreadyImplemented.java
@@ -1,0 +1,45 @@
+public class DelegateAlreadyImplemented<T> {
+	
+	@lombok.experimental.Delegate
+	private A<Integer, T> a;
+	
+	public void a() {
+	}
+	
+	public void b(java.util.List<String> l) {
+	}
+	
+	public void c(java.util.List<Integer> l, String[] a, Integer... varargs) {
+	}
+	
+	public void d(String[][][][] d) {
+	}
+	
+	public <Y> void e(Y x) {
+	}
+	
+	@SuppressWarnings("unchecked")
+	public void f(T s, java.util.List<T> l, T[] a, T... varargs) {
+	}
+	
+	public void g(Number g) {
+	}
+}
+
+interface A<T, T2> {
+	public void a();
+	
+	public void b(java.util.List<T> l);
+	
+	@SuppressWarnings("unchecked")
+	public void c(java.util.List<T> l, String[] a, T... varargs);
+	
+	public void d(String[][][][] d);
+	
+	public <X> X e(X x);
+	
+	@SuppressWarnings("unchecked")
+	public void f(T2 s, java.util.List<T2> l, T2[] a, T2... varargs);
+	
+	public <G extends Number> void g(G g);
+}


### PR DESCRIPTION
All implemeted method signatures gets added to `banList`. The javac code was already there, I only added the eclipse code.
This PR resolves #2006.