### PR TITLE
[Feature request] @EqualsAndHashCode Flexibility for rank properties for equal/hashcode method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Robbert Jan Grootjans <grootjans@gmail.com>
 Robert Wertman <robert.wertman@gmail.com>
 Roel Spilker <r.spilker@gmail.com>
 Roland Praml <pram@gmx.de>
+Samuel Pereira <samuel.p.araujo@gmail.com>
 Sander Koning <askoning@gmail.com>
 Szymon Pacanowski <spacanowski@gmail.com>
 Taiki Sugawara <buzz.taiki@gmail.com>

--- a/src/core/lombok/EqualsAndHashCode.java
+++ b/src/core/lombok/EqualsAndHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 The Project Lombok Authors.
+ * Copyright (C) 2009-2020 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -122,5 +122,12 @@ public @interface EqualsAndHashCode {
 		 * @return If present, this method serves as replacement for the named field.
 		 */
 		String replaces() default "";
+
+		/**
+		 * Higher ranks are considered first. Members of the same rank are considered in the order they appear in the source file.
+		 *
+		 * @return ordering within the generating {@code equals} and {@code hashCode} methods; higher numbers are considered first.
+		 */
+		int rank() default 0;
 	}
 }

--- a/src/core/lombok/core/handlers/InclusionExclusionUtils.java
+++ b/src/core/lombok/core/handlers/InclusionExclusionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 The Project Lombok Authors.
+ * Copyright (C) 2009-2020 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -207,22 +207,37 @@ public class InclusionExclusionUtils {
 			@Override public int compare(Included<L, ToString.Include> a, Included<L, ToString.Include> b) {
 				int ra = a.getInc() == null ? 0 : a.getInc().rank();
 				int rb = b.getInc() == null ? 0 : b.getInc().rank();
-				if (ra < rb) return +1;
-				if (ra > rb) return -1;
-				
-				int pa = a.getNode().getStartPos();
-				int pb = b.getNode().getStartPos();
-				
-				if (pa < pb) return -1;
-				if (pa > pb) return +1;
-				
-				return 0;
+
+				return compareRankOrPosition(ra, rb, a.getNode(), b.getNode());
 			}
 		});
 		return members;
 	}
 	
 	public static <A extends AST<A, L, N>, L extends LombokNode<A, L, N>, N> List<Included<L, EqualsAndHashCode.Include>> handleEqualsAndHashCodeMarking(LombokNode<A, L, N> typeNode, AnnotationValues<EqualsAndHashCode> annotation, LombokNode<A, L, N> annotationNode) {
-		return handleIncludeExcludeMarking(EqualsAndHashCode.Include.class, "replaces", EqualsAndHashCode.Exclude.class, typeNode, annotation, annotationNode, false);
+		List<Included<L, EqualsAndHashCode.Include>> members = handleIncludeExcludeMarking(EqualsAndHashCode.Include.class, "replaces", EqualsAndHashCode.Exclude.class, typeNode, annotation, annotationNode, false);
+
+		Collections.sort(members, new Comparator<Included<L, EqualsAndHashCode.Include>>() {
+			@Override public int compare(Included<L, EqualsAndHashCode.Include> a, Included<L, EqualsAndHashCode.Include> b) {
+				int ra = a.getInc() == null ? 0 : a.getInc().rank();
+				int rb = b.getInc() == null ? 0 : b.getInc().rank();
+
+				return compareRankOrPosition(ra, rb, a.getNode(), b.getNode());
+			}
+		});
+		return members;
+	}
+
+	private static <A extends AST<A, L, N>, L extends LombokNode<A, L, N>, N> int compareRankOrPosition(int ra, int rb, LombokNode<A, L, N> nodeA, LombokNode<A, L, N> nodeB) {
+		if (ra < rb) return +1;
+		if (ra > rb) return -1;
+
+		int pa = nodeA.getStartPos();
+		int pb = nodeB.getStartPos();
+
+		if (pa < pb) return -1;
+		if (pa > pb) return +1;
+
+		return 0;
 	}
 }

--- a/test/transform/resource/after-delombok/EqualsAndHashCodeRank.java
+++ b/test/transform/resource/after-delombok/EqualsAndHashCodeRank.java
@@ -1,0 +1,31 @@
+public class EqualsAndHashCodeRank {
+	int a;
+	int b;
+	int c;
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public boolean equals(final java.lang.Object o) {
+		if (o == this) return true;
+		if (!(o instanceof EqualsAndHashCodeRank)) return false;
+		final EqualsAndHashCodeRank other = (EqualsAndHashCodeRank) o;
+		if (!other.canEqual((java.lang.Object) this)) return false;
+		if (this.b != other.b) return false;
+		if (this.a != other.a) return false;
+		if (this.c != other.c) return false;
+		return true;
+	}
+	@java.lang.SuppressWarnings("all")
+	protected boolean canEqual(final java.lang.Object other) {
+		return other instanceof EqualsAndHashCodeRank;
+	}
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public int hashCode() {
+		final int PRIME = 59;
+		int result = 1;
+		result = result * PRIME + this.b;
+		result = result * PRIME + this.a;
+		result = result * PRIME + this.c;
+		return result;
+	}
+}

--- a/test/transform/resource/after-ecj/EqualsAndHashCodeRank.java
+++ b/test/transform/resource/after-ecj/EqualsAndHashCodeRank.java
@@ -1,0 +1,36 @@
+import lombok.EqualsAndHashCode;
+public @EqualsAndHashCode class EqualsAndHashCodeRank {
+  @EqualsAndHashCode.Include int a;
+  @EqualsAndHashCode.Include(rank = 10) int b;
+  @EqualsAndHashCode.Include int c;
+  public EqualsAndHashCodeRank() {
+    super();
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") boolean equals(final java.lang.Object o) {
+    if (o == this)
+        return true;
+    if (!(o instanceof EqualsAndHashCodeRank))
+        return false;
+    final EqualsAndHashCodeRank other = (EqualsAndHashCodeRank) o;
+    if (!other.canEqual((java.lang.Object) this))
+        return false;
+    if (this.b != other.b)
+        return false;
+    if (this.a != other.a)
+        return false;
+    if (this.c != other.c)
+        return false;
+    return true;
+  }
+  protected @java.lang.SuppressWarnings("all") boolean canEqual(final java.lang.Object other) {
+    return (other instanceof EqualsAndHashCodeRank);
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = result * PRIME + this.b;
+    result = result * PRIME + this.a;
+    result = result * PRIME + this.c;
+    return result;
+  }
+}

--- a/test/transform/resource/before/EqualsAndHashCodeRank.java
+++ b/test/transform/resource/before/EqualsAndHashCodeRank.java
@@ -1,0 +1,7 @@
+import lombok.EqualsAndHashCode;
+@EqualsAndHashCode
+public class EqualsAndHashCodeRank {
+	@EqualsAndHashCode.Include int a;
+	@EqualsAndHashCode.Include(rank = 10) int b;
+	@EqualsAndHashCode.Include int c;
+}


### PR DESCRIPTION
Given some special cases where we need to explicitly order the comparation fields for performance improvement, I have applied the same idea that we have for `@ToString.Include(rank = -1)`. ie.: `@EqualsAndHashCode.Include(rank = -1)`

Also, there are some discussions related to this here (#1543) about the Equals algorithm and performance. So, given this flexibility can help me with some special cases and I believe that can be helpful for more people too. Let me know what you think folks.
