### PR TITLE
Various performance fixes

### DIFF
--- a/src/core/lombok/eclipse/EclipseAST.java
+++ b/src/core/lombok/eclipse/EclipseAST.java
@@ -318,6 +318,7 @@ public class EclipseAST extends AST<EclipseAST, EclipseNode, ASTNode> {
 			Field f = EcjReflectionCheck.typeReferenceAnnotations;
 			if (f == null) return null;
 			annss = (Annotation[][]) f.get(tr);
+			if (annss == null) return null;
 			return annss[annss.length - 1];
 		} catch (Throwable t) {
 			return null;

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -233,14 +233,7 @@ public class EclipseHandlerUtil {
 	 * @param typeRef A type reference to check.
 	 */
 	public static boolean typeMatches(Class<?> type, EclipseNode node, TypeReference typeRef) {
-		if (typeRef == null || typeRef.getTypeName() == null || typeRef.getTypeName().length == 0) return false;
-		String lastPartA = new String(typeRef.getTypeName()[typeRef.getTypeName().length -1]);
-		String lastPartB = type.getSimpleName();
-		if (!lastPartA.equals(lastPartB)) return false;
-		String typeName = toQualifiedName(typeRef.getTypeName());
-		
-		TypeResolver resolver = new TypeResolver(node.getImportList());
-		return resolver.typeMatches(node, type.getName(), typeName);
+		return typeMatches(type.getName(), node, typeRef);
 	}
 	
 	/**
@@ -254,7 +247,7 @@ public class EclipseHandlerUtil {
 		char[][] tn = typeRef == null ? null : typeRef.getTypeName();
 		if (tn == null || tn.length == 0) return false;
 		char[] lastPartA = tn[tn.length - 1];
-		int lastIndex = type.lastIndexOf('.') + 1;
+		int lastIndex = Math.max(type.lastIndexOf('.'), type.lastIndexOf('$')) + 1;
 		if (lastPartA.length != type.length() - lastIndex) return false;
 		for (int i = 0; i < lastPartA.length; i++) if (lastPartA[i] != type.charAt(i + lastIndex)) return false;
 		String typeName = toQualifiedName(tn);

--- a/src/core/lombok/javac/JavacAST.java
+++ b/src/core/lombok/javac/JavacAST.java
@@ -258,7 +258,7 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 		
 		if (typeUse == null) return null;
 		
-		if (typeUse.getClass().getSimpleName().equals("JCAnnotatedType")) {
+		if (typeUse.getClass().getName().equals("com.sun.tools.javac.tree.JCTree$JCAnnotatedType")) {
 			initJcAnnotatedType(typeUse.getClass());
 			Collection<?> anns = Permit.permissiveReadField(Collection.class, JCANNOTATEDTYPE_ANNOTATIONS, typeUse);
 			JCExpression underlying = Permit.permissiveReadField(JCExpression.class, JCANNOTATEDTYPE_UNDERLYINGTYPE, typeUse);
@@ -381,7 +381,7 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 		if (statement instanceof JCClassDecl) return buildType((JCClassDecl) statement);
 		if (statement instanceof JCVariableDecl) return buildLocalVar((JCVariableDecl) statement, Kind.LOCAL);
 		if (statement instanceof JCTry) return buildTry((JCTry) statement);
-		if (statement.getClass().getSimpleName().equals("JCLambda")) return buildLambda(statement);
+		if (statement.getClass().getName().equals("com.sun.tools.javac.tree.JCTree$JCLambda")) return buildLambda(statement);
 		if (setAndGetAsHandled(statement)) return null;
 		
 		return drill(statement);

--- a/src/core/lombok/javac/JavacAST.java
+++ b/src/core/lombok/javac/JavacAST.java
@@ -79,6 +79,8 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 	private final Log log;
 	private final ErrorLog errorLogger;
 	private final Context context;
+	private static final URI NOT_CALCULATED_MARKER = URI.create("https://projectlombok.org/not/calculated");
+	private URI memoizedAbsoluteFileLocation = NOT_CALCULATED_MARKER;
 	
 	/**
 	 * Creates a new JavacAST of the provided Compilation Unit.
@@ -102,7 +104,10 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 	}
 	
 	@Override public URI getAbsoluteFileLocation() {
-		return getAbsoluteFileLocation((JCCompilationUnit) top().get());
+		if (memoizedAbsoluteFileLocation == NOT_CALCULATED_MARKER) {
+			memoizedAbsoluteFileLocation = getAbsoluteFileLocation((JCCompilationUnit) top().get());
+		}
+		return memoizedAbsoluteFileLocation;
 	}
 	
 	public static URI getAbsoluteFileLocation(JCCompilationUnit cu) {


### PR DESCRIPTION
This PR contains 3 commits that address some performance related things I noticed while profiling builds for #2489 .

The first one replaces `Class.getSimpleName()` with `Class.getName()` because the former is slow.
JDK Bug: https://bugs.openjdk.java.net/browse/JDK-8187123
Before:
![img](https://user-images.githubusercontent.com/5850477/85613950-b51b5280-b65a-11ea-8cd1-a94521ed1dc8.png)
After:
![img](https://user-images.githubusercontent.com/5850477/85614013-c82e2280-b65a-11ea-8e61-7143e790dfea.png)

The second one caches the absoulte file location of the compilation unit. `File.toURI()` requires a disk access and can take some time.
Before:
![img](https://user-images.githubusercontent.com/5850477/85614619-599d9480-b65b-11ea-9e30-c220e6903500.png)
After:
![img](https://user-images.githubusercontent.com/5850477/85614649-628e6600-b65b-11ea-84c9-1fd39b612c9b.png)

The last one is trivial and simply removes a NPE