### PR TITLE
Skip type resolution in isDelegate

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -57,6 +57,7 @@ import org.eclipse.jdt.internal.compiler.ast.ParameterizedSingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedAllocationExpression;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedThisReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.Receiver;
 import org.eclipse.jdt.internal.compiler.ast.ReturnStatement;
 import org.eclipse.jdt.internal.compiler.ast.SingleMemberAnnotation;
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
@@ -683,7 +684,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		return decl;
 	}
 	
-	static Argument[] generateBuildArgs(CheckerFrameworkVersion cfv, EclipseNode type, List<BuilderFieldData> builderFields, ASTNode source) {
+	static Receiver generateBuildReceiver(CheckerFrameworkVersion cfv, EclipseNode type, List<BuilderFieldData> builderFields, ASTNode source) {
 		if (!cfv.generateCalledMethods()) return null;
 		
 		List<char[]> mandatories = new ArrayList<char[]>();
@@ -706,9 +707,11 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 			}
 			ann.memberValue = arr;
 		}
-		Argument arg = new Argument(new char[] { 't', 'h', 'i', 's' }, 0, generateTypeReference(type, source.sourceStart), Modifier.FINAL);
-		arg.annotations = new Annotation[] {ann};
-		return new Argument[] {arg};
+
+		QualifiedTypeReference typeReference = (QualifiedTypeReference) generateTypeReference(type, source.sourceStart);
+		typeReference.annotations = new Annotation[typeReference.tokens.length][];
+		typeReference.annotations[0] = new Annotation[] {ann};
+		return new Receiver(new char[] { 't', 'h', 'i', 's' }, 0, typeReference, null, Modifier.FINAL);
 	}
 	
 	public MethodDeclaration generateBuildMethod(CheckerFrameworkVersion cfv, EclipseNode tdParent, boolean isStatic, String name, char[] staticName, TypeReference returnType, List<BuilderFieldData> builderFields, EclipseNode type, TypeReference[] thrownExceptions, boolean addCleaning, ASTNode source, AccessLevel access) {
@@ -802,7 +805,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		if (cfv.generateSideEffectFree()) {
 			out.annotations = new Annotation[] {generateNamedAnnotation(source, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE)};
 		}
-		out.arguments = generateBuildArgs(cfv, type, builderFields, source);
+		out.receiver = generateBuildReceiver(cfv, type, builderFields, source);
 		if (staticName == null) createRelevantNonNullAnnotation(type, out);
 		out.traverse(new SetGeneratedByVisitor(source), (ClassScope) null);
 		return out;
@@ -953,16 +956,14 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		MethodDeclaration setter = HandleSetter.createSetter(td, deprecate, fieldNode, setterName, paramName, nameOfSetFlag, chain, toEclipseModifier(access),
 			sourceNode, methodAnnsList, annotations != null ? Arrays.asList(copyAnnotations(source, annotations)) : Collections.<Annotation>emptyList());
 		if (cfv.generateCalledMethods()) {
-			Argument[] arr = setter.arguments == null ? new Argument[0] : setter.arguments;
-			Argument[] newArr = new Argument[arr.length + 1];
-			System.arraycopy(arr, 0, newArr, 1, arr.length);
-			newArr[0] = new Argument(new char[] { 't', 'h', 'i', 's' }, 0, generateTypeReference(builderType, 0), Modifier.FINAL);
 			char[][] nameNotCalled = fromQualifiedName(CheckerFrameworkVersion.NAME__NOT_CALLED);
-			SingleMemberAnnotation ann = new SingleMemberAnnotation(new QualifiedTypeReference(nameNotCalled, poss(
-					source, nameNotCalled.length)), source.sourceStart);
+			SingleMemberAnnotation ann = new SingleMemberAnnotation(new QualifiedTypeReference(nameNotCalled, poss(source, nameNotCalled.length)), source.sourceStart);
 			ann.memberValue = new StringLiteral(setterName.toCharArray(), 0, 0, 0);
-			newArr[0].annotations = new Annotation[] {ann};
-			setter.arguments = newArr;
+			
+			QualifiedTypeReference typeReference = (QualifiedTypeReference) generateTypeReference(builderType, 0);
+			typeReference.annotations = new Annotation[typeReference.tokens.length][];
+			typeReference.annotations[0] = new Annotation[] {ann};
+			setter.receiver = new Receiver(new char[] { 't', 'h', 'i', 's' }, 0, typeReference, null, Modifier.FINAL);
 		}
 		injectMethod(builderType, setter);
 	}

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchDelegate.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchDelegate.java
@@ -321,6 +321,8 @@ public class PatchDelegate {
 	
 	private static boolean isDelegate(Annotation ann, TypeDeclaration decl) {
 		if (ann.type == null) return false;
+		if (!charArrayEquals("Delegate", ann.type.getLastToken())) return false;
+		
 		TypeBinding tb = ann.type.resolveType(decl.initializerScope);
 		if (tb == null) return false;
 		if (!charArrayEquals("lombok", tb.qualifiedPackageName()) && !charArrayEquals("lombok.experimental", tb.qualifiedPackageName())) return false;

--- a/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
@@ -9,6 +9,7 @@ class CheckerFrameworkSuperBuilder {
       private @java.lang.SuppressWarnings("all") int z;
       private @java.lang.SuppressWarnings("all") java.util.ArrayList<String> names;
       public ParentBuilder() {
+        super();
       }
       protected abstract @org.checkerframework.checker.builder.qual.ReturnsReceiver @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
       public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(final @org.checkerframework.checker.builder.qual.CalledMethods({"y", "z"}) CheckerFrameworkSuperBuilder.Parent.ParentBuilder this);
@@ -52,6 +53,7 @@ class CheckerFrameworkSuperBuilder {
     }
     private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends CheckerFrameworkSuperBuilder.Parent.ParentBuilder<CheckerFrameworkSuperBuilder.Parent, CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl> {
       private ParentBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @org.checkerframework.checker.builder.qual.ReturnsReceiver @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl self() {
         return this;
@@ -98,6 +100,7 @@ class CheckerFrameworkSuperBuilder {
       private @java.lang.SuppressWarnings("all") boolean a$set;
       private @java.lang.SuppressWarnings("all") int b;
       public ChildBuilder() {
+        super();
       }
       protected abstract @java.lang.Override @org.checkerframework.checker.builder.qual.ReturnsReceiver @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
       public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(final @org.checkerframework.checker.builder.qual.CalledMethods("b") CheckerFrameworkSuperBuilder.Child.ChildBuilder this);
@@ -116,6 +119,7 @@ class CheckerFrameworkSuperBuilder {
     }
     private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends CheckerFrameworkSuperBuilder.Child.ChildBuilder<CheckerFrameworkSuperBuilder.Child, CheckerFrameworkSuperBuilder.Child.ChildBuilderImpl> {
       private ChildBuilderImpl() {
+        super();
       }
       protected @java.lang.Override @org.checkerframework.checker.builder.qual.ReturnsReceiver @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Child.ChildBuilderImpl self() {
         return this;
@@ -142,5 +146,6 @@ class CheckerFrameworkSuperBuilder {
     }
   }
   CheckerFrameworkSuperBuilder() {
+    super();
   }
 }

--- a/test/transform/resource/after-ecj/SimpleTypeResolution.java
+++ b/test/transform/resource/after-ecj/SimpleTypeResolution.java
@@ -1,11 +1,13 @@
 class SimpleTypeResolutionFail {
   private @Getter int x;
   SimpleTypeResolutionFail() {
+    super();
   }
 }
 class SimpleTypeResolutionSuccess {
   private @lombok.Getter int x;
   SimpleTypeResolutionSuccess() {
+    super();
   }
   public @java.lang.SuppressWarnings("all") int getX() {
     return this.x;

--- a/test/transform/resource/messages-ecj/CheckerFrameworkBasic.java.messages
+++ b/test/transform/resource/messages-ecj/CheckerFrameworkBasic.java.messages
@@ -1,1 +1,1 @@
-8 org.checkerframework cannot be resolved to a type
+6 org.checkerframework.common cannot be resolved to a type

--- a/test/transform/resource/messages-ecj/CheckerFrameworkSuperBuilder.java.messages
+++ b/test/transform/resource/messages-ecj/CheckerFrameworkSuperBuilder.java.messages
@@ -1,1 +1,1 @@
-6 org.checkerframework cannot be resolved to a type
+6 org.checkerframework.common cannot be resolved to a type


### PR DESCRIPTION
During profiling I noticed that `PatchDelegate.isDelegate()` consumes some time during compilation. I noticed that the type resolution of the annotation is responsible for that. Even if I'm not sure if that this increases the compilation time I added an additional check that returns early.

This causes some interesting side effects as it broke some unrelated test cases. After checking out why, I think that the unsuccessful type resolution (due to the unknown ckeckerframework annotation) stops compilation to early and hides the underlying problem. It seems like the `this` parameter have to be set as `Receiver` instead of an `Argument` in eclipse. Otherwise it fails with `Only the first formal parameter may be declared explicitly as 'this'`.

I think I fixed that but couldn't test it in a real world scenario.