### PR TITLE
[fixes #2469] Support static reference as logger topic

### DIFF
--- a/src/core/lombok/core/AnnotationValues.java
+++ b/src/core/lombok/core/AnnotationValues.java
@@ -411,6 +411,14 @@ public class AnnotationValues<A extends Annotation> {
 		List<Object> l = getActualExpressions(annotationMethodName);
 		return l.isEmpty() ? null : l.get(0);
 	}
+
+	/**
+	 * Returns the guessed value for the provided {@code annotationMethodName}.
+	 */
+	public Object getValueGuess(String annotationMethodName) {
+		AnnotationValue v = values.get(annotationMethodName);
+		return v == null || v.valueGuesses.isEmpty() ? null : v.valueGuesses.get(0);
+	}
 	
 	/** Generates an error message on the stated annotation value (you should only call this method if you know it's there!) */
 	public void setError(String annotationMethodName, String message) {

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -49,6 +49,7 @@ import org.eclipse.jdt.internal.compiler.ast.ArrayInitializer;
 import org.eclipse.jdt.internal.compiler.ast.ArrayQualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ArrayTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.AssertStatement;
+import org.eclipse.jdt.internal.compiler.ast.BinaryExpression;
 import org.eclipse.jdt.internal.compiler.ast.Block;
 import org.eclipse.jdt.internal.compiler.ast.CastExpression;
 import org.eclipse.jdt.internal.compiler.ast.CharLiteral;
@@ -380,7 +381,7 @@ public class EclipseHandlerUtil {
 		}
 	}
 	
-	private static Expression copyAnnotationMemberValue(Expression in) {
+	public static Expression copyAnnotationMemberValue(Expression in) {
 		Expression out = copyAnnotationMemberValue0(in);
 		out.constant = in.constant;
 		return out;
@@ -421,12 +422,11 @@ public class EclipseHandlerUtil {
 		
 		if (in instanceof SingleNameReference) {
 			SingleNameReference snr = (SingleNameReference) in;
-			long p = (long) s << 32 | e;
-			return new SingleNameReference(snr.token, p);
+			return new SingleNameReference(snr.token, pos(in));
 		}
 		if (in instanceof QualifiedNameReference) {
 			QualifiedNameReference qnr = (QualifiedNameReference) in;
-			return new QualifiedNameReference(qnr.tokens, qnr.sourcePositions, s, e);
+			return new QualifiedNameReference(qnr.tokens, poss(in, qnr.tokens.length), s, e);
 		}
 		
 		// class refs
@@ -442,8 +442,19 @@ public class EclipseHandlerUtil {
 			out.sourceEnd = e;
 			out.bits = in.bits;
 			out.implicitConversion = in.implicitConversion;
-			out.statementEnd = in.statementEnd;
+			out.statementEnd = e;
 			out.expressions = copy;
+			return out;
+		}
+		
+		if (in instanceof BinaryExpression) {
+			BinaryExpression be = (BinaryExpression) in;
+			BinaryExpression out = new BinaryExpression(be);
+			out.left = copyAnnotationMemberValue(be.left);
+			out.right = copyAnnotationMemberValue(be.right);
+			out.sourceStart = s;
+			out.sourceEnd = e;
+			out.statementEnd = e;
 			return out;
 		}
 		

--- a/test/transform/resource/after-delombok/LoggerCommons.java
+++ b/test/transform/resource/after-delombok/LoggerCommons.java
@@ -10,3 +10,8 @@ class LoggerCommonsWithDifferentName {
 	@java.lang.SuppressWarnings("all")
 	private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog("DifferentName");
 }
+class LoggerCommonsWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/after-delombok/LoggerCustomWithTopicAndName.java
+++ b/test/transform/resource/after-delombok/LoggerCustomWithTopicAndName.java
@@ -3,6 +3,12 @@ class LoggerCustomLog {
 	private static final MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLog.class.getName(), "t", null, LoggerCustomLog.class, "t");
 }
 
+class LoggerCustomLogWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLogWithStaticField.class.getName(), LoggerCustomLogWithStaticField.TOPIC, null, LoggerCustomLogWithStaticField.class, LoggerCustomLogWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}
+
 class MyLoggerFactory {
 	static MyLoggerFactory create(String name, String t1, Object o, Class<?> clazz, String t2) {
 		return null;

--- a/test/transform/resource/after-delombok/LoggerJBossLog.java
+++ b/test/transform/resource/after-delombok/LoggerJBossLog.java
@@ -17,3 +17,9 @@ class LoggerJBossLogWithDifferentLoggerName {
 	@java.lang.SuppressWarnings("all")
 	private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger("DifferentLogger");
 }
+
+class LoggerJBossLogWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/after-delombok/LoggerJul.java
+++ b/test/transform/resource/after-delombok/LoggerJul.java
@@ -10,3 +10,8 @@ class LoggerJulWithDifferentName {
 	@java.lang.SuppressWarnings("all")
 	private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger("DifferentName");
 }
+class LoggerJulWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/after-delombok/LoggerLog4j.java
+++ b/test/transform/resource/after-delombok/LoggerLog4j.java
@@ -10,3 +10,8 @@ class LoggerLog4jWithDifferentName {
 	@java.lang.SuppressWarnings("all")
 	private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger("DifferentName");
 }
+class LoggerLog4jWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/after-delombok/LoggerLog4j2.java
+++ b/test/transform/resource/after-delombok/LoggerLog4j2.java
@@ -10,3 +10,8 @@ class LoggerLog4j2WithDifferentName {
 	@java.lang.SuppressWarnings("all")
 	private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger("DifferentName");
 }
+class LoggerLog4j2WithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/after-delombok/LoggerSlf4j.java
+++ b/test/transform/resource/after-delombok/LoggerSlf4j.java
@@ -17,3 +17,20 @@ class LoggerSlf4jWithDifferentLoggerName {
 	@java.lang.SuppressWarnings("all")
 	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger("DifferentLogger");
 }
+
+class LoggerSlf4jWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}
+
+class LoggerSlf4jWithTwoStaticFields {
+	@java.lang.SuppressWarnings("all")
+	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC);
+	static final String TOPIC = "StaticField";
+}
+
+class LoggerSlf4jWithTwoLiterals {
+	@java.lang.SuppressWarnings("all")
+	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger("A" + "B");
+}

--- a/test/transform/resource/after-delombok/LoggerSlf4jInvalidTopic.java
+++ b/test/transform/resource/after-delombok/LoggerSlf4jInvalidTopic.java
@@ -1,0 +1,5 @@
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = 42)
+class LoggerSlf4jWithIntegerTopic {
+}

--- a/test/transform/resource/after-delombok/LoggerXSlf4j.java
+++ b/test/transform/resource/after-delombok/LoggerXSlf4j.java
@@ -10,3 +10,8 @@ class LoggerXSlf4jWithDifferentName {
 	@java.lang.SuppressWarnings("all")
 	private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger("DifferentName");
 }
+class LoggerXSlf4jWithStaticField {
+	@java.lang.SuppressWarnings("all")
+	private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4jWithStaticField.TOPIC);
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/after-ecj/LoggerCommons.java
+++ b/test/transform/resource/after-ecj/LoggerCommons.java
@@ -23,3 +23,12 @@ import lombok.extern.apachecommons.CommonsLog;
     super();
   }
 }
+@CommonsLog(topic = LoggerCommonsWithStaticField.TOPIC) class LoggerCommonsWithStaticField {
+  private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerCommonsWithStaticField() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerCustomWithTopicAndName.java
+++ b/test/transform/resource/after-ecj/LoggerCustomWithTopicAndName.java
@@ -6,6 +6,15 @@
     super();
   }
 }
+@lombok.CustomLog(topic = LoggerCustomLogWithStaticField.TOPIC) class LoggerCustomLogWithStaticField {
+  private static final MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLogWithStaticField.class.getName(), LoggerCustomLogWithStaticField.TOPIC, null, LoggerCustomLogWithStaticField.class, LoggerCustomLogWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerCustomLogWithStaticField() {
+    super();
+  }
+}
 class MyLoggerFactory {
   MyLoggerFactory() {
     super();

--- a/test/transform/resource/after-ecj/LoggerJBossLog.java
+++ b/test/transform/resource/after-ecj/LoggerJBossLog.java
@@ -36,3 +36,12 @@ class LoggerJBossLogOuter {
     super();
   }
 }
+@JBossLog(topic = LoggerJBossLogWithStaticField.TOPIC) class LoggerJBossLogWithStaticField {
+  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerJBossLogWithStaticField() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerJul.java
+++ b/test/transform/resource/after-ecj/LoggerJul.java
@@ -23,3 +23,12 @@ import lombok.extern.java.Log;
     super();
   }
 }
+@Log(topic = LoggerJulWithStaticField.TOPIC) class LoggerJulWithStaticField {
+  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerJulWithStaticField() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerLog4j.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j.java
@@ -23,3 +23,12 @@ import lombok.extern.log4j.Log4j;
     super();
   }
 }
+@Log4j(topic = LoggerLog4jWithStaticField.TOPIC) class LoggerLog4jWithStaticField {
+  private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerLog4jWithStaticField() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerLog4j2.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j2.java
@@ -23,3 +23,12 @@ import lombok.extern.log4j.Log4j2;
     super();
   }
 }
+@Log4j2(topic = LoggerLog4j2WithStaticField.TOPIC) class LoggerLog4j2WithStaticField {
+  private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerLog4j2WithStaticField() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerSlf4j.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4j.java
@@ -37,3 +37,30 @@ class LoggerSlf4jOuter {
     super();
   }
 }
+
+@Slf4j(topic = LoggerSlf4jWithStaticField.TOPIC) class LoggerSlf4jWithStaticField {
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerSlf4jWithStaticField() {
+    super();
+  }
+}
+@Slf4j(topic = (LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC)) class LoggerSlf4jWithTwoStaticFields {
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger((LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC));
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerSlf4jWithTwoStaticFields() {
+    super();
+  }
+}
+@Slf4j(topic = ExtendedStringLiteral{AB}) class LoggerSlf4jWithTwoLiterals {
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger("AB");
+  <clinit>() {
+  }
+  LoggerSlf4jWithTwoLiterals() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerSlf4jInvalidTopic.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jInvalidTopic.java
@@ -1,0 +1,9 @@
+import lombok.extern.slf4j.Slf4j;
+@Slf4j(topic = 42) class LoggerSlf4jWithIntegerTopic {
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(42);
+  <clinit>() {
+  }
+  LoggerSlf4jWithIntegerTopic() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerXSlf4j.java
+++ b/test/transform/resource/after-ecj/LoggerXSlf4j.java
@@ -23,3 +23,12 @@ import lombok.extern.slf4j.XSlf4j;
     super();
   }
 }
+@XSlf4j(topic = LoggerXSlf4jWithStaticField.TOPIC) class LoggerXSlf4jWithStaticField {
+  private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4jWithStaticField.TOPIC);
+  static final String TOPIC = "StaticField";
+  <clinit>() {
+  }
+  LoggerXSlf4jWithStaticField() {
+    super();
+  }
+}

--- a/test/transform/resource/before/LoggerCommons.java
+++ b/test/transform/resource/before/LoggerCommons.java
@@ -11,3 +11,8 @@ class LoggerCommonsWithImport {
 @CommonsLog(topic="DifferentName")
 class LoggerCommonsWithDifferentName {
 }
+
+@CommonsLog(topic=LoggerCommonsWithStaticField.TOPIC)
+class LoggerCommonsWithStaticField {
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/before/LoggerCustomWithTopicAndName.java
+++ b/test/transform/resource/before/LoggerCustomWithTopicAndName.java
@@ -3,6 +3,11 @@
 class LoggerCustomLog {
 }
 
+@lombok.CustomLog(topic=LoggerCustomLogWithStaticField.TOPIC)
+class LoggerCustomLogWithStaticField {
+	static final String TOPIC = "StaticField";
+}
+
 class MyLoggerFactory {
 	static MyLoggerFactory create(String name, String t1, Object o, Class<?> clazz, String t2) {
 		return null;

--- a/test/transform/resource/before/LoggerJBossLog.java
+++ b/test/transform/resource/before/LoggerJBossLog.java
@@ -18,3 +18,8 @@ class LoggerJBossLogOuter {
 @JBossLog(topic="DifferentLogger")
 class LoggerJBossLogWithDifferentLoggerName {
 }
+
+@JBossLog(topic=LoggerJBossLogWithStaticField.TOPIC)
+class LoggerJBossLogWithStaticField {
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/before/LoggerJul.java
+++ b/test/transform/resource/before/LoggerJul.java
@@ -11,3 +11,8 @@ class LoggerJulWithImport {
 @Log(topic="DifferentName")
 class LoggerJulWithDifferentName {
 }
+
+@Log(topic=LoggerJulWithStaticField.TOPIC)
+class LoggerJulWithStaticField {
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/before/LoggerLog4j.java
+++ b/test/transform/resource/before/LoggerLog4j.java
@@ -11,3 +11,8 @@ class LoggerLog4jWithImport {
 @Log4j(topic="DifferentName")
 class LoggerLog4jWithDifferentName {
 }
+
+@Log4j(topic=LoggerLog4jWithStaticField.TOPIC)
+class LoggerLog4jWithStaticField {
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/before/LoggerLog4j2.java
+++ b/test/transform/resource/before/LoggerLog4j2.java
@@ -11,3 +11,8 @@ class LoggerLog4j2WithImport {
 @Log4j2(topic="DifferentName")
 class LoggerLog4j2WithDifferentName {
 }
+
+@Log4j2(topic=LoggerLog4j2WithStaticField.TOPIC)
+class LoggerLog4j2WithStaticField {
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/before/LoggerSlf4j.java
+++ b/test/transform/resource/before/LoggerSlf4j.java
@@ -18,3 +18,17 @@ class LoggerSlf4jOuter {
 @Slf4j(topic="DifferentLogger")
 class LoggerSlf4jWithDifferentLoggerName {
 }
+
+@Slf4j(topic=LoggerSlf4jWithStaticField.TOPIC)
+class LoggerSlf4jWithStaticField {
+	static final String TOPIC = "StaticField";
+}
+
+@Slf4j(topic=LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC)
+class LoggerSlf4jWithTwoStaticFields {
+	static final String TOPIC = "StaticField";
+}
+
+@Slf4j(topic="A"+"B")
+class LoggerSlf4jWithTwoLiterals {
+}

--- a/test/transform/resource/before/LoggerSlf4jInvalidTopic.java
+++ b/test/transform/resource/before/LoggerSlf4jInvalidTopic.java
@@ -1,0 +1,5 @@
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic=42)
+class LoggerSlf4jWithIntegerTopic {
+}

--- a/test/transform/resource/before/LoggerXSlf4j.java
+++ b/test/transform/resource/before/LoggerXSlf4j.java
@@ -11,3 +11,8 @@ class LoggerXSlf4jWithImport {
 @XSlf4j(topic="DifferentName")
 class LoggerXSlf4jWithDifferentName {
 }
+
+@XSlf4j(topic=LoggerXSlf4jWithStaticField.TOPIC)
+class LoggerXSlf4jWithStaticField {
+	static final String TOPIC = "StaticField";
+}

--- a/test/transform/resource/messages-delombok/LoggerSlf4jInvalidTopic.java.messages
+++ b/test/transform/resource/messages-delombok/LoggerSlf4jInvalidTopic.java.messages
@@ -1,0 +1,2 @@
+3 incompatible types: int cannot be converted to java.lang.String
+-1 not flagged modified

--- a/test/transform/resource/messages-ecj/LoggerSlf4jInvalidTopic.java.messages
+++ b/test/transform/resource/messages-ecj/LoggerSlf4jInvalidTopic.java.messages
@@ -1,0 +1,1 @@
+3 Type mismatch: cannot convert from int to String

--- a/test/transform/resource/messages-idempotent/LoggerSlf4jInvalidTopic.java.messages
+++ b/test/transform/resource/messages-idempotent/LoggerSlf4jInvalidTopic.java.messages
@@ -1,0 +1,1 @@
+3 incompatible types: int cannot be converted to java.lang.String


### PR DESCRIPTION
This PR fixes #2469. Instead of parsing the topic value it now copies the original expression to the creation method.