### PR TITLE
Reduce memory usage

### DIFF
--- a/src/core/lombok/javac/JavacTransformer.java
+++ b/src/core/lombok/javac/JavacTransformer.java
@@ -21,6 +21,7 @@
  */
 package lombok.javac;
 
+import java.util.List;
 import java.util.SortedSet;
 
 import javax.annotation.processing.Messager;
@@ -33,7 +34,6 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.List;
 
 import lombok.ConfigurationKeys;
 import lombok.core.CleanupRegistry;
@@ -56,17 +56,7 @@ public class JavacTransformer {
 		return handlers.getPrioritiesRequiringResolutionReset();
 	}
 	
-	public void transform(long priority, Context context, java.util.List<JCCompilationUnit> compilationUnitsRaw, CleanupRegistry cleanup) {
-		List<JCCompilationUnit> compilationUnits;
-		if (compilationUnitsRaw instanceof List<?>) {
-			compilationUnits = (List<JCCompilationUnit>) compilationUnitsRaw;
-		} else {
-			compilationUnits = List.nil();
-			for (int i = compilationUnitsRaw.size() -1; i >= 0; i--) {
-				compilationUnits = compilationUnits.prepend(compilationUnitsRaw.get(i));
-			}
-		}
-		
+	public void transform(long priority, Context context, List<JCCompilationUnit> compilationUnits, CleanupRegistry cleanup) {
 		for (JCCompilationUnit unit : compilationUnits) {
 			if (!Boolean.TRUE.equals(LombokConfiguration.read(ConfigurationKeys.LOMBOK_DISABLE, JavacAST.getAbsoluteFileLocation(unit)))) {
 				JavacAST ast = new JavacAST(messager, context, unit, cleanup);


### PR DESCRIPTION
While analyzing heap dumps for #2240 I noticed that lombok keeps some unnecessary objects in memory. This PR changes that.

I also removed some old code that copies a list into a new one which actualy does not change anything. This snippet was part of an old experiment and even contains an if condition that can never be true.