### PR TITLE
update javadoc on Builder.java

### DIFF
--- a/src/core/lombok/Builder.java
+++ b/src/core/lombok/Builder.java
@@ -32,8 +32,8 @@ import java.lang.annotation.Target;
  * that contains a member which is annotated with {@code @Builder}.
  * <p>
  * If a member is annotated, it must be either a constructor or a method. If a class is annotated,
- * then a private constructor is generated with all fields as arguments
- * (as if {@code @AllArgsConstructor(access = AccessLevel.PRIVATE)} is present
+ * then a package-private constructor is generated with all fields as arguments
+ * (as if {@code @AllArgsConstructor(access = AccessLevel.PACKAGE)} is present
  * on the class), and it is as if this constructor has been annotated with {@code @Builder} instead.
  * Note that this constructor is only generated if you haven't written any constructors and also haven't
  * added any explicit {@code @XArgsConstructor} annotations. In those cases, lombok will assume an all-args


### PR DESCRIPTION
The javadoc on Builder.java says it generates a private constructor, which is the typo. it need to be updated, because the official document, [here](https://projectlombok.org/features/Builder), says:
> applying @Builder to a class is as if you added @AllArgsConstructor(access = AccessLevel.PACKAGE) to the class.  

we can make sure `@Builder` on the class generates a package-private constructor by running the following Junit test. **see carefully the package declaration**.
```java
package lombok.learning.builder;
import lombok.Builder;
@Builder
public class Student {
    private String name;
    private Integer height;
}
```

```java
package lombok.learning.builder;
import org.junit.Test;
public class StudentTest {
    @Test
    public void canAccessToPackagePrivateConstructor() {
        Student student = new Student("inherithandle", 175);
    }
}
```

```java
package lombok.learning.notbuilder;
import lombok.learning.builder.Student;
import org.junit.Test;
public class StudentTest {
    @Test
    public void cannotAccessToPackagePrivateConstructor() {
        // compile error. can't call the package-private constructor.
        // new Student("inherithanle", 170);
    }
}
```