### PR TITLE
Compare full line instead of ignoring the last character

### DIFF
--- a/test/core/src/lombok/AbstractRunTests.java
+++ b/test/core/src/lombok/AbstractRunTests.java
@@ -285,7 +285,7 @@ public abstract class AbstractRunTests {
 			endIdx--;
 		}
 		
-		return in.substring(0, endIdx);
+		return in.substring(0, endIdx + 1);
 	}
 	
 	private static String[] removeBlanks(String[] in) {

--- a/test/transform/resource/after-delombok/GetterSetterJavadoc.java
+++ b/test/transform/resource/after-delombok/GetterSetterJavadoc.java
@@ -115,7 +115,7 @@ class GetterSetterJavadoc4 {
 	/**
 	 * Some text
 	 * 
-	 * @param fieldName Hello, World5
+	 * @param fieldName Hello, World4
 	 * @return {@code this}.
 	 */
 	@java.lang.SuppressWarnings("all")


### PR DESCRIPTION
By chance I noticed that one of the test cases contains an error. During debugging I figured out that the `trimRight` method always removes the last character of the passed string.