### PR TITLE
Skip PostCompiler for empty byte arrays

### DIFF
--- a/src/core/lombok/core/PostCompiler.java
+++ b/src/core/lombok/core/PostCompiler.java
@@ -72,10 +72,12 @@ public final class PostCompiler {
 				// no need to call super
 				byte[] original = toByteArray();
 				byte[] copy = null;
-				try {
-					copy = applyTransformations(original, fileName, diagnostics);
-				} catch (Exception e) {
-					diagnostics.addWarning(String.format("Error during the transformation of '%s'; no post-compilation has been applied", fileName));
+				if (original.length > 0) {
+					try {
+						copy = applyTransformations(original, fileName, diagnostics);
+					} catch (Exception e) {
+						diagnostics.addWarning(String.format("Error during the transformation of '%s'; no post-compilation has been applied", fileName));
+					}
 				}
 				
 				if (copy == null) {


### PR DESCRIPTION
In some cases (#2539) writing the class file throws an exception. If that happens the stream is empty if it gets closed. This will lead to an exception that hides the original one.