### PR TITLE
Add generated delegate methods to eclipse outline

### DIFF
--- a/src/core/lombok/eclipse/EclipseAugments.java
+++ b/src/core/lombok/eclipse/EclipseAugments.java
@@ -21,9 +21,14 @@
  */
 package lombok.eclipse;
 
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
+import org.eclipse.jdt.internal.core.CompilationUnit;
+import org.eclipse.jdt.internal.core.SourceMethod;
 
 import lombok.core.FieldAugment;
 
@@ -36,4 +41,5 @@ public final class EclipseAugments {
 	public static final FieldAugment<ASTNode, Boolean> ASTNode_handled = FieldAugment.augment(ASTNode.class, boolean.class, "lombok$handled");
 	public static final FieldAugment<ASTNode, ASTNode> ASTNode_generatedBy = FieldAugment.augment(ASTNode.class, ASTNode.class, "$generatedBy");
 	public static final FieldAugment<Annotation, Boolean> Annotation_applied = FieldAugment.augment(Annotation.class, boolean.class, "lombok$applied");
+	public static final FieldAugment<CompilationUnit, ConcurrentMap<String, List<SourceMethod>>> CompilationUnit_delegateMethods = FieldAugment.augment(CompilationUnit.class, ConcurrentMap.class, "$delegateMethods");
 }

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -655,6 +655,26 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.request(StackRequest.THIS)
 				.decisionMethod(new Hook("lombok.launch.PatchFixesHider$Delegate", "handleDelegateForType", "boolean", "java.lang.Object"))
 				.build());
+		
+		sm.addScript(ScriptBuilder.setSymbolDuringMethodCall()
+		        .target(new MethodTarget("org.eclipse.jdt.internal.core.SelectionRequestor", "acceptSourceMethod"))
+		        .callToWrap(new Hook("org.eclipse.jdt.core.IType", "getMethods", "org.eclipse.jdt.core.IMethod[]"))
+		        .symbol("lombok.skipdelegates")
+		        .build());
+		
+		sm.addScript(ScriptBuilder.addField()
+				.fieldName("$delegateMethods")
+				.fieldType("Ljava/util/Map;")
+				.setPublic()
+				.setTransient()
+				.targetClass("org.eclipse.jdt.internal.core.CompilationUnit")
+				.build());
+		
+		sm.addScript(ScriptBuilder.wrapReturnValue()
+				.target(new MethodTarget("org.eclipse.jdt.internal.core.SourceTypeElementInfo", "getChildren", "org.eclipse.jdt.core.IJavaElement[]"))
+				.request(StackRequest.RETURN_VALUE, StackRequest.THIS)
+				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$Delegate", "getChildren", "java.lang.Object[]", "java.lang.Object", "java.lang.Object"))
+				.build());
 	}
 	
 	private static void addPatchesForValEclipse(ScriptManager sm) {

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchDelegate.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 The Project Lombok Authors.
+ * Copyright (C) 2010-2020 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +22,8 @@
 package lombok.eclipse.agent;
 
 import static lombok.eclipse.Eclipse.*;
+import static lombok.eclipse.EclipseAugments.*;
 import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
-import static lombok.eclipse.EclipseAugments.Annotation_applied;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -34,14 +34,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
-import lombok.core.AST.Kind;
-import lombok.eclipse.Eclipse;
-import lombok.eclipse.EclipseAST;
-import lombok.eclipse.EclipseNode;
-import lombok.eclipse.TransformEclipseAST;
-import lombok.eclipse.handlers.SetGeneratedByVisitor;
-
+import org.eclipse.jdt.core.ElementChangedEvent;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ILocalVariable;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
@@ -81,8 +83,27 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.UnresolvedReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.WildcardBinding;
+import org.eclipse.jdt.internal.core.CompilationUnit;
+import org.eclipse.jdt.internal.core.DeltaProcessor;
+import org.eclipse.jdt.internal.core.JavaElement;
+import org.eclipse.jdt.internal.core.JavaElementDelta;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.LocalVariable;
+import org.eclipse.jdt.internal.core.SourceMethod;
+import org.eclipse.jdt.internal.core.SourceMethodInfo;
+import org.eclipse.jdt.internal.core.SourceType;
+import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
+
+import lombok.core.AST.Kind;
+import lombok.eclipse.Eclipse;
+import lombok.eclipse.EclipseAST;
+import lombok.eclipse.EclipseNode;
+import lombok.eclipse.TransformEclipseAST;
+import lombok.eclipse.handlers.SetGeneratedByVisitor;
+import lombok.patcher.Symbols;
 
 public class PatchDelegate {
+
 	private static class ClassScopeEntry {
 		ClassScopeEntry(ClassScope scope) {
 			this.scope = scope;
@@ -123,6 +144,12 @@ public class PatchDelegate {
 	
 	public static boolean handleDelegateForType(ClassScope scope) {
 		if (TransformEclipseAST.disableLombok) return false;
+		
+		CompilationUnitDeclaration cud = scope.compilationUnitScope().referenceContext;
+		if (scope == scope.compilationUnitScope().topLevelTypes[0].scope) {
+			cleanupDelegateMethods(cud);
+		}
+		
 		if (!hasDelegateMarkedFieldsOrMethods(scope.referenceContext)) return false;
 		
 		List<ClassScopeEntry> stack = visited.get();
@@ -149,7 +176,6 @@ public class PatchDelegate {
 			try {
 				TypeDeclaration decl = scope.referenceContext;
 				if (decl != null) {
-					CompilationUnitDeclaration cud = scope.compilationUnitScope().referenceContext;
 					EclipseAST eclipseAst = TransformEclipseAST.getAST(cud, true);
 					List<BindingTuple> methodsToDelegate = new ArrayList<BindingTuple>();
 					fillMethodBindingsForFields(cud, scope, methodsToDelegate);
@@ -168,10 +194,23 @@ public class PatchDelegate {
 				}
 			} finally {
 				stack.remove(stack.size() - 1);
+				if (stack.isEmpty()) {
+					notifyDelegateMethodsAdded(cud);
+				}
 			}
 		}
 		
 		return false;
+	}
+	
+	public static IJavaElement[] getChildren(IJavaElement[] returnValue, SourceTypeElementInfo javaElement) {
+		if (Symbols.hasSymbol("lombok.skipdelegates")) return returnValue;
+		
+		List<SourceMethod> delegateMethods = getDelegateMethods((SourceType) javaElement.getHandle());
+		if (delegateMethods != null) {
+			return concat(returnValue, delegateMethods.toArray(new IJavaElement[0]), IJavaElement.class);
+		}
+		return returnValue;
 	}
 	
 	/**
@@ -419,6 +458,11 @@ public class PatchDelegate {
 	
 	private static void generateDelegateMethods(EclipseNode typeNode, List<BindingTuple> methods, DelegateReceiver delegateReceiver) {
 		CompilationUnitDeclaration top = (CompilationUnitDeclaration) typeNode.top().get();
+		
+		String qualifiedName = new String(CharOperation.concatWith(getQualifiedInnerName(typeNode.up(), typeNode.getName().toCharArray()), '$'));
+		SourceType sourceType = getSourceType(top, qualifiedName);
+		List<SourceMethod> delegateSourceMethods = getDelegateMethods(sourceType);
+		
 		for (BindingTuple pair : methods) {
 			EclipseNode annNode = typeNode.getAst().get(pair.responsible);
 			MethodDeclaration method = createDelegateMethod(pair.fieldName, typeNode, pair, top.compilationResult, annNode, delegateReceiver);
@@ -426,6 +470,10 @@ public class PatchDelegate {
 				SetGeneratedByVisitor visitor = new SetGeneratedByVisitor(annNode.get());
 				method.traverse(visitor, ((TypeDeclaration)typeNode.get()).scope);
 				injectMethod(typeNode, method);
+				
+				if (delegateSourceMethods != null) {
+					delegateSourceMethods.add(DelegateSourceMethod.forMethodDeclaration(sourceType, method));
+				}
 			}
 		}
 	}
@@ -671,6 +719,129 @@ public class PatchDelegate {
 		
 		method.statements = new Statement[] {body};
 		return method;
+	}
+	
+	private static void cleanupDelegateMethods(CompilationUnitDeclaration cud) {
+		CompilationUnit compilationUnit = getCompilationUnit(cud);
+		if (compilationUnit != null) {
+			CompilationUnit_delegateMethods.clear(compilationUnit);
+		}
+	}
+	
+	private static boolean javaModelManagerAvailable = true;
+	private static void notifyDelegateMethodsAdded(CompilationUnitDeclaration cud) {
+		CompilationUnit compilationUnit = getCompilationUnit(cud);
+		if (compilationUnit != null && javaModelManagerAvailable) {
+			try {
+				DeltaProcessor deltaProcessor = JavaModelManager.getJavaModelManager().getDeltaProcessor();
+				deltaProcessor.fire(new JavaElementDelta(compilationUnit), ElementChangedEvent.POST_CHANGE);
+			} catch (NoClassDefFoundError e) {
+				javaModelManagerAvailable = false;
+			}
+		}
+	}
+	
+	private static CompilationUnit getCompilationUnit(Object iCompilationUnit) {
+		if (iCompilationUnit instanceof CompilationUnit) {
+			CompilationUnit compilationUnit = (CompilationUnit) iCompilationUnit;
+			return compilationUnit.originalFromClone();
+		}
+		return null;
+	}
+	
+	private static CompilationUnit getCompilationUnit(CompilationUnitDeclaration cud) {
+		return getCompilationUnit(cud.compilationResult.compilationUnit);
+	}
+	
+	private static final class DelegateSourceMethod extends SourceMethod {
+		private DelegateSourceMethodInfo sourceMethodInfo;
+
+		private static DelegateSourceMethod forMethodDeclaration(JavaElement parent, MethodDeclaration method) {
+			Argument[] arguments = method.arguments != null ? method.arguments : new Argument[0];
+			String[] parameterTypes = new String[arguments.length];
+			for (int i = 0; i < arguments.length; i++) {
+				parameterTypes[i] = Signature.createTypeSignature(CharOperation.concatWith(arguments[i].type.getParameterizedTypeName(), '.'), false);
+			}
+			return new DelegateSourceMethod(parent, new String(method.selector), parameterTypes, method);
+		}
+		
+		private DelegateSourceMethod(JavaElement parent, String name, String[] parameterTypes, MethodDeclaration md) {
+			super(parent, name, parameterTypes);
+			sourceMethodInfo = new DelegateSourceMethodInfo(this, md);
+		}
+		
+		@Override public Object getElementInfo() throws JavaModelException {
+			return sourceMethodInfo;
+		}
+		
+		/**
+		 * Disable refactoring for delegate methods
+		 */
+		@Override public boolean isReadOnly() {
+			return true;
+		}
+		
+		/**
+		 * This is required to prevent duplicate entries in the outline
+		 */
+		@Override public boolean equals(Object o) {
+			return this == o;
+		}
+		
+		public static final class DelegateSourceMethodInfo extends SourceMethodInfo {
+			DelegateSourceMethodInfo(DelegateSourceMethod delegateSourceMethod, MethodDeclaration md) {
+				int pS = md.sourceStart;
+				int pE = md.sourceEnd;
+				
+				Argument[] methodArguments = md.arguments != null ? md.arguments : new Argument[0];
+				char[][] argumentNames = new char[methodArguments.length][];
+				arguments = new ILocalVariable[methodArguments.length];
+				for (int i = 0; i < methodArguments.length; i++) {
+					Argument argument = methodArguments[i];
+					argumentNames[i] = argument.name;
+					arguments[i] = new LocalVariable(delegateSourceMethod, new String(argument.name), pS, pE, pS, pS, delegateSourceMethod.getParameterTypes()[i], argument.annotations, argument.modifiers, true);
+				}
+				setArgumentNames(argumentNames);
+				
+				setSourceRangeStart(pS);
+				setSourceRangeEnd(pE);
+				setNameSourceStart(pS);
+				setNameSourceEnd(pE);
+				
+				setExceptionTypeNames(CharOperation.NO_CHAR_CHAR);
+				setReturnType(md.returnType == null ? new char[]{'v', 'o','i', 'd'} : CharOperation.concatWith(md.returnType.getParameterizedTypeName(), '.'));
+				setFlags(md.modifiers);
+			}
+		}
+	}
+	
+	private static List<SourceMethod> getDelegateMethods(SourceType sourceType) {
+		if (sourceType != null) {
+			CompilationUnit compilationUnit = getCompilationUnit(sourceType.getCompilationUnit());
+			if (compilationUnit != null) {
+				ConcurrentMap<String, List<SourceMethod>> map = CompilationUnit_delegateMethods.setIfAbsent(compilationUnit, new ConcurrentHashMap<String, List<SourceMethod>>());
+				List<SourceMethod> newList = new ArrayList<SourceMethod>();
+				List<SourceMethod> oldList = map.putIfAbsent(sourceType.getTypeQualifiedName(), newList);
+				return oldList != null ? oldList : newList;
+			}
+		}
+		return null;
+	}
+	
+	private static SourceType getSourceType(CompilationUnitDeclaration cud, String typeName) {
+		CompilationUnit compilationUnit = getCompilationUnit(cud);
+		if (compilationUnit != null) {
+			try {
+				for (IType type : compilationUnit.getAllTypes()) {
+					if (type instanceof SourceType && type.getTypeQualifiedName().equals(typeName)) {
+						return (SourceType) type;
+					}
+				}
+			} catch (JavaModelException e) {
+				// Ignore
+			}
+		}
+		return null;
 	}
 	
 	private static final class Reflection {

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchDelegatePortal.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchDelegatePortal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Project Lombok Authors.
+ * Copyright (C) 2012-2020 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,8 @@ import lombok.Lombok;
 
 public class PatchDelegatePortal {
 	static final String CLASS_SCOPE = "org.eclipse.jdt.internal.compiler.lookup.ClassScope";
+	static final String I_JAVA_ELEMENT_ARRAY = "[Lorg.eclipse.jdt.core.IJavaElement;";
+	static final String SOURCE_TYPE_ELEMENT_INFO = "org.eclipse.jdt.internal.core.SourceTypeElementInfo";
 	
 	public static boolean handleDelegateForType(Object classScope) {
 		try {
@@ -51,21 +53,46 @@ public class PatchDelegatePortal {
 		}
 	}
 	
+	public static Object[] getChildren(Object returnValue, Object javaElement) {
+		try {
+			return (Object[]) Reflection.getChildren.invoke(null, returnValue, javaElement);
+		} catch (NoClassDefFoundError e) {
+			//ignore, we don't have access to the correct ECJ classes, so lombok can't possibly
+			//do anything useful here.
+			return (Object[]) returnValue;
+		} catch (IllegalAccessException e) {
+			throw Lombok.sneakyThrow(e);
+		} catch (InvocationTargetException e) {
+			throw Lombok.sneakyThrow(e.getCause());
+		} catch (NullPointerException e) {
+			if (!"false".equals(System.getProperty("lombok.debug.reflection", "false"))) {
+				e.initCause(Reflection.problem);
+				throw e;
+			}
+			//ignore, we don't have access to the correct ECJ classes, so lombok can't possibly
+			//do anything useful here.
+			return (Object[]) returnValue;
+		}
+	}
+	
 	private static final class Reflection {
 		public static final Method handleDelegateForType;
+		public static final Method getChildren;
 		public static final Throwable problem;
 		
 		static {
-			Method m = null;
+			Method m = null, n = null;
 			Throwable problem_ = null;
 			try {
 				m = PatchDelegate.class.getMethod("handleDelegateForType", Class.forName(CLASS_SCOPE));
+				n = PatchDelegate.class.getMethod("getChildren", Class.forName(I_JAVA_ELEMENT_ARRAY), Class.forName(SOURCE_TYPE_ELEMENT_INFO));
 			} catch (Throwable t) {
 				// That's problematic, but as long as no local classes are used we don't actually need it.
 				// Better fail on local classes than crash altogether.
 				problem_ = t;
 			}
 			handleDelegateForType = m;
+			getChildren = n;
 			problem = problem_;
 		}
 	}

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -191,14 +191,20 @@ final class PatchFixesHider {
 	/** Contains patch code to support {@code @Delegate} */
 	public static final class Delegate {
 		private static final Method HANDLE_DELEGATE_FOR_TYPE;
+		private static final Method GET_CHILDREN;
 		
 		static {
 			Class<?> shadowed = Util.shadowLoadClass("lombok.eclipse.agent.PatchDelegatePortal");
 			HANDLE_DELEGATE_FOR_TYPE = Util.findMethod(shadowed, "handleDelegateForType", Object.class);
+			GET_CHILDREN = Util.findMethod(shadowed, "getChildren", Object.class, Object.class);
 		}
 		
 		public static boolean handleDelegateForType(Object classScope) {
 			return (Boolean) Util.invokeMethod(HANDLE_DELEGATE_FOR_TYPE, classScope);
+		}
+		
+		public static Object[] getChildren(Object returnValue, Object javaElement) {
+			return (Object[]) Util.invokeMethod(GET_CHILDREN, returnValue, javaElement);
 		}
 	}
 	


### PR DESCRIPTION
This PR adds the generated delegate methods to the outline view in eclipse.

Eclipse creates an internal representation for the open file (`SourceType`) and displays all the children in the outline view. This PR patches this `getChildren` method to add new `SourceMethod` objects. These method objects gets stored in the compilation unit by the delegate handler. In some cases the delegate handler runs after eclipse calls `getChildren`, thats why the handler now fires an event to trigger an update of the outline view.

I also successfully tested these changes in an old eclipse version.

Fixes #1455