### PR TITLE
Fix missing parameter names, annotations in following annotation processors 2

### DIFF
--- a/src/stubs/com/sun/tools/javac/code/Symbol.java
+++ b/src/stubs/com/sun/tools/javac/code/Symbol.java
@@ -24,7 +24,7 @@ import com.sun.tools.javac.util.Name;
 public abstract class Symbol implements Element {
 	public Type type;
 	public Name name;
-	
+
 	public long flags() { return 0; }
 	public boolean isStatic() { return false; }
 	public boolean isConstructor() { return false; }
@@ -38,7 +38,9 @@ public abstract class Symbol implements Element {
 	@Override public Name getSimpleName() { return null; }
 	@Override public java.util.List<Symbol> getEnclosedElements() { return null; }
 	@Override public Element getEnclosingElement() { return null; }
-	
+	public void appendAttributes(List<Attribute.Compound> l) {
+	}
+
 	public static abstract class TypeSymbol extends Symbol {}
 	
 	public static class MethodSymbol extends Symbol implements ExecutableElement {
@@ -60,6 +62,8 @@ public abstract class Symbol implements Element {
 	
 	public static class VarSymbol extends Symbol implements VariableElement {
 		public Type type;
+		public VarSymbol(long flags, Name name, Type type, Symbol owner) {
+		}
 		@Override public ElementKind getKind() { return null; }
 		@Override public Set<Modifier> getModifiers() { return null; }
 		@Override public <R, P> R accept(ElementVisitor<R, P> v, P p) { return null; }

--- a/src/stubs/com/sun/tools/javac/code/Symtab.java
+++ b/src/stubs/com/sun/tools/javac/code/Symtab.java
@@ -5,6 +5,7 @@ package com.sun.tools.javac.code;
 
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.util.Context;
 
 public class Symtab {
@@ -14,6 +15,7 @@ public class Symtab {
 	public Type objectType;
 	public static Symtab instance(Context context) {return null;}
 	public Type unknownType;
+	public TypeSymbol noSymbol;
 	
 	// JDK 9
 	public ModuleSymbol unnamedModule;


### PR DESCRIPTION
Second attempt to fix it after https://github.com/rzwitserloot/lombok/pull/2497

I have tested it and parameter names and annotations are correctly propagated now.
Fixed https://github.com/micronaut-projects/micronaut-core/issues/3918