### PR TITLE
Fix suppressBaseMethods in ecj/eclipse

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -774,6 +774,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 		final String METHOD_BINDING_SIG = "org.eclipse.jdt.internal.compiler.lookup.MethodBinding";
 		final String COMPLETION_PROPOSAL_COLLECTOR_SIG = "org.eclipse.jdt.ui.text.java.CompletionProposalCollector";
 		final String I_JAVA_COMPLETION_PROPOSAL_SIG = "org.eclipse.jdt.ui.text.java.IJavaCompletionProposal[]";
+		final String AST_NODE = "org.eclipse.jdt.internal.compiler.ast.ASTNode";
 		
 		sm.addScript(wrapReturnValue()
 			.target(new MethodTarget(MESSAGE_SEND_SIG, "resolveType", TYPE_BINDING_SIG, BLOCK_SCOPE_SIG))
@@ -800,6 +801,13 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 			.target(new MethodTarget(MESSAGE_SEND_SIG, "resolveType", TYPE_BINDING_SIG, BLOCK_SCOPE_SIG))
 			.methodToReplace(new Hook(PROBLEM_REPORTER_SIG, "invalidMethod", "void", MESSAGE_SEND_SIG, METHOD_BINDING_SIG, SCOPE_SIG))
 			.replacementMethod(new Hook(PATCH_EXTENSIONMETHOD, "invalidMethod", "void", PROBLEM_REPORTER_SIG, MESSAGE_SEND_SIG, METHOD_BINDING_SIG, SCOPE_SIG))
+			.build());
+		
+		sm.addScript(replaceMethodCall()
+			.target(new MethodTarget(MESSAGE_SEND_SIG, "resolveType", TYPE_BINDING_SIG, BLOCK_SCOPE_SIG))
+			.methodToReplace(new Hook(PROBLEM_REPORTER_SIG, "nonStaticAccessToStaticMethod", "void", AST_NODE, METHOD_BINDING_SIG))
+			.replacementMethod(new Hook(PATCH_EXTENSIONMETHOD, "nonStaticAccessToStaticMethod", "void", PROBLEM_REPORTER_SIG, AST_NODE, METHOD_BINDING_SIG, MESSAGE_SEND_SIG))
+			.requestExtra(StackRequest.THIS)
 			.build());
 		
 		if (!ecj) {

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -56,7 +56,6 @@ import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
-import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
@@ -138,6 +137,22 @@ public class PatchExtensionMethod {
 		}
 	}
 	
+	private static class PostponedNonStaticAccessToStaticMethodError implements PostponedError {
+		private final ProblemReporter problemReporter;
+		private ASTNode location;
+		private MethodBinding method;
+		
+		PostponedNonStaticAccessToStaticMethodError(ProblemReporter problemReporter, ASTNode location, MethodBinding method) {
+			this.problemReporter = problemReporter;
+			this.location = location;
+			this.method = method;
+		}
+
+		public void fire() {
+			problemReporter.nonStaticAccessToStaticMethod(location, method);
+		}
+	}
+	
 	private static interface PostponedError {
 		public void fire();
 	}
@@ -200,15 +215,12 @@ public class PatchExtensionMethod {
 			TypeBinding receiverType) {
 		
 		List<MethodBinding> extensionMethods = new ArrayList<MethodBinding>();
-		CompilationUnitScope cuScope = ((CompilationUnitDeclaration) typeNode.top().get()).scope;
 		for (MethodBinding method : extensionMethodProviderBinding.methods()) {
 			if (!method.isStatic()) continue;
 			if (!method.isPublic()) continue;
 			if (method.parameters == null || method.parameters.length == 0) continue;
 			TypeBinding firstArgType = method.parameters[0];
 			if (receiverType.isProvablyDistinct(firstArgType) && !receiverType.isCompatibleWith(firstArgType.erasure())) continue;
-			TypeBinding[] argumentTypes = Arrays.copyOfRange(method.parameters, 1, method.parameters.length);
-			if ((receiverType instanceof ReferenceBinding) && ((ReferenceBinding) receiverType).getExactMethod(method.selector, argumentTypes, cuScope) != null) continue;
 			extensionMethods.add(method);
 		}
 		return extensionMethods;
@@ -226,6 +238,10 @@ public class PatchExtensionMethod {
 	
 	public static void invalidMethod(ProblemReporter problemReporter, MessageSend messageSend, MethodBinding method, Scope scope) {
 		MessageSend_postponedErrors.set(messageSend, new PostponedInvalidMethodError(problemReporter, messageSend, method, scope));
+	}
+	
+	public static void nonStaticAccessToStaticMethod(ProblemReporter problemReporter, ASTNode location, MethodBinding method, MessageSend messageSend) {
+		MessageSend_postponedErrors.set(messageSend, new PostponedNonStaticAccessToStaticMethodError(problemReporter, location, method));
 	}
 	
 	public static TypeBinding resolveType(TypeBinding resolvedType, MessageSend methodCall, BlockScope scope) {

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -271,6 +272,7 @@ final class PatchFixesHider {
 		private static final Method RESOLVE_TYPE;
 		private static final Method ERROR_NO_METHOD_FOR;
 		private static final Method INVALID_METHOD, INVALID_METHOD2;
+		private static final Method NON_STATIC_ACCESS_TO_STATIC_METHOD;
 		
 		static {
 			Class<?> shadowed = Util.shadowLoadClass("lombok.eclipse.agent.PatchExtensionMethod");
@@ -278,6 +280,7 @@ final class PatchFixesHider {
 			ERROR_NO_METHOD_FOR = Util.findMethod(shadowed, "errorNoMethodFor", ProblemReporter.class, MessageSend.class, TypeBinding.class, TypeBinding[].class);
 			INVALID_METHOD = Util.findMethod(shadowed, "invalidMethod", ProblemReporter.class, MessageSend.class, MethodBinding.class);
 			INVALID_METHOD2 = Util.findMethod(shadowed, "invalidMethod", ProblemReporter.class, MessageSend.class, MethodBinding.class, Scope.class);
+			NON_STATIC_ACCESS_TO_STATIC_METHOD = Util.findMethod(shadowed, "nonStaticAccessToStaticMethod", ProblemReporter.class, ASTNode.class, MethodBinding.class, MessageSend.class);
 		}
 		
 		public static TypeBinding resolveType(TypeBinding resolvedType, MessageSend methodCall, BlockScope scope) {
@@ -294,6 +297,10 @@ final class PatchFixesHider {
 		
 		public static void invalidMethod(ProblemReporter problemReporter, MessageSend messageSend, MethodBinding method, Scope scope) {
 			Util.invokeMethod(INVALID_METHOD2, problemReporter, messageSend, method, scope);
+		}
+		
+		public static void nonStaticAccessToStaticMethod(ProblemReporter problemReporter, ASTNode location, MethodBinding method, MessageSend messageSend) {
+			Util.invokeMethod(NON_STATIC_ACCESS_TO_STATIC_METHOD, problemReporter, location, method, messageSend);
 		}
 	}
 	

--- a/test/transform/resource/after-delombok/ExtensionMethodSuppress.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodSuppress.java
@@ -1,0 +1,33 @@
+class ExtensionMethodSuppress {
+	public void test() {
+		Test.staticMethod();
+		Test test = new Test();
+		Extensions.instanceMethod(test);
+		Extensions.staticMethod(test);
+	}
+}
+
+class ExtensionMethodKeep {
+	public void test() {
+		Test.staticMethod();
+		Test test = new Test();
+		test.instanceMethod();
+		test.staticMethod();
+	}
+}
+
+class Test {
+	public static void staticMethod() {
+	}
+	
+	public void instanceMethod() {
+	}
+}
+
+class Extensions {
+	public static void staticMethod(Test test) {
+	}
+	
+	public static void instanceMethod(Test test) {
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodSuppress.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodSuppress.java
@@ -1,0 +1,41 @@
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(Extensions.class) class ExtensionMethodSuppress {
+  ExtensionMethodSuppress() {
+    super();
+  }
+  public void test() {
+    Test.staticMethod();
+    Test test = new Test();
+    Extensions.instanceMethod(test);
+    Extensions.staticMethod(test);
+  }
+}
+@ExtensionMethod(value = Extensions.class,suppressBaseMethods = false) class ExtensionMethodKeep {
+  ExtensionMethodKeep() {
+    super();
+  }
+  public void test() {
+    Test.staticMethod();
+    Test test = new Test();
+    test.instanceMethod();
+    test.staticMethod();
+  }
+}
+class Test {
+  Test() {
+    super();
+  }
+  public static void staticMethod() {
+  }
+  public void instanceMethod() {
+  }
+}
+class Extensions {
+  Extensions() {
+    super();
+  }
+  public static void staticMethod(Test test) {
+  }
+  public static void instanceMethod(Test test) {
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodSuppress.java
+++ b/test/transform/resource/before/ExtensionMethodSuppress.java
@@ -1,0 +1,43 @@
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(Extensions.class)
+class ExtensionMethodSuppress {
+	public void test() {
+		Test.staticMethod();
+		
+		Test test = new Test();
+		test.instanceMethod();
+		test.staticMethod();
+	}
+}
+
+@ExtensionMethod(value = Extensions.class, suppressBaseMethods = false)
+class ExtensionMethodKeep {
+	public void test() {
+		Test.staticMethod();
+		
+		Test test = new Test();
+		test.instanceMethod();
+		test.staticMethod();
+	}
+}
+
+class Test {
+	public static void staticMethod() {
+		
+	}
+	
+	public void instanceMethod() {
+		
+	}
+}
+
+class Extensions {
+	public static void staticMethod(Test test) {
+		
+	}
+	
+	public static void instanceMethod(Test test) {
+		
+	}
+}

--- a/test/transform/resource/messages-ecj/ExtensionMethodSuppress.java.messages
+++ b/test/transform/resource/messages-ecj/ExtensionMethodSuppress.java.messages
@@ -1,0 +1,1 @@
+21 The static method staticMethod() from the type Test should be accessed in a static way


### PR DESCRIPTION
The `@ExtensionMethod` feature to suppress base methods was broken, this PR resolves that.