### PR TITLE
Detect static method access properly

### DIFF
--- a/src/core/lombok/javac/handlers/HandleExtensionMethod.java
+++ b/src/core/lombok/javac/handlers/HandleExtensionMethod.java
@@ -28,6 +28,7 @@ import static lombok.javac.handlers.JavacResolver.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.lang.model.element.ElementKind;
 
@@ -37,12 +38,14 @@ import lombok.core.HandlerPriority;
 import lombok.experimental.ExtensionMethod;
 import lombok.javac.JavacAnnotationHandler;
 import lombok.javac.JavacNode;
+import lombok.javac.JavacResolution;
 
 import org.mangosdk.spi.ProviderFor;
 
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Type;
@@ -51,6 +54,7 @@ import com.sun.tools.javac.code.Type.ErrorType;
 import com.sun.tools.javac.code.Type.ForAll;
 import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
@@ -166,13 +170,25 @@ public class HandleExtensionMethod extends JavacAnnotationHandler<ExtensionMetho
 			JCExpression receiver = receiverOf(methodCall);
 			String methodName = methodNameOf(methodCall);
 			
-			if ("this".equals(methodName) || "super".equals(methodName)) return;
-			Type resolvedMethodCall = CLASS_AND_METHOD.resolveMember(methodCallNode, methodCall);
-			if (resolvedMethodCall == null) return;
-			if (!suppressBaseMethods && !(resolvedMethodCall instanceof ErrorType)) return;
-			Type receiverType = CLASS_AND_METHOD.resolveMember(methodCallNode, receiver);
-			if (receiverType == null) return;
-			if (receiverType.tsym.toString().endsWith(receiver.toString())) return;
+			if ("this".equals(receiver.toString()) || "this".equals(methodName) || "super".equals(methodName)) return;
+			Map<JCTree, JCTree> resolution = new JavacResolution(methodCallNode.getContext()).resolveMethodMember(methodCallNode);
+			
+			JCTree resolvedMethodCall = resolution.get(methodCall);
+			if (resolvedMethodCall == null || resolvedMethodCall.type == null) return;
+			if (!suppressBaseMethods && !(resolvedMethodCall.type instanceof ErrorType)) return;
+			
+			JCTree resolvedReceiver = resolution.get(receiver);
+			if (resolvedReceiver == null || resolvedReceiver.type == null) return;
+			Type receiverType = resolvedReceiver.type;
+			
+			// Skip static method access
+			Symbol sym = null;
+			if (resolvedReceiver instanceof JCIdent) {
+				sym = ((JCIdent) resolvedReceiver).sym;
+			} else if (resolvedReceiver instanceof JCFieldAccess) {
+				sym = ((JCFieldAccess) resolvedReceiver).sym;
+			}
+			if (sym instanceof ClassSymbol) return;
 			
 			Types types = Types.instance(annotationNode.getContext());
 			for (Extension extension : extensions) {

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -774,6 +774,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 		final String METHOD_BINDING_SIG = "org.eclipse.jdt.internal.compiler.lookup.MethodBinding";
 		final String COMPLETION_PROPOSAL_COLLECTOR_SIG = "org.eclipse.jdt.ui.text.java.CompletionProposalCollector";
 		final String I_JAVA_COMPLETION_PROPOSAL_SIG = "org.eclipse.jdt.ui.text.java.IJavaCompletionProposal[]";
+		final String AST_NODE = "org.eclipse.jdt.internal.compiler.ast.ASTNode";
 		
 		sm.addScript(wrapReturnValue()
 			.target(new MethodTarget(MESSAGE_SEND_SIG, "resolveType", TYPE_BINDING_SIG, BLOCK_SCOPE_SIG))
@@ -800,6 +801,13 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 			.target(new MethodTarget(MESSAGE_SEND_SIG, "resolveType", TYPE_BINDING_SIG, BLOCK_SCOPE_SIG))
 			.methodToReplace(new Hook(PROBLEM_REPORTER_SIG, "invalidMethod", "void", MESSAGE_SEND_SIG, METHOD_BINDING_SIG, SCOPE_SIG))
 			.replacementMethod(new Hook(PATCH_EXTENSIONMETHOD, "invalidMethod", "void", PROBLEM_REPORTER_SIG, MESSAGE_SEND_SIG, METHOD_BINDING_SIG, SCOPE_SIG))
+			.build());
+		
+		sm.addScript(replaceMethodCall()
+			.target(new MethodTarget(MESSAGE_SEND_SIG, "resolveType", TYPE_BINDING_SIG, BLOCK_SCOPE_SIG))
+			.methodToReplace(new Hook(PROBLEM_REPORTER_SIG, "nonStaticAccessToStaticMethod", "void", AST_NODE, METHOD_BINDING_SIG))
+			.replacementMethod(new Hook(PATCH_EXTENSIONMETHOD, "nonStaticAccessToStaticMethod", "void", PROBLEM_REPORTER_SIG, AST_NODE, METHOD_BINDING_SIG, MESSAGE_SEND_SIG))
+			.requestExtra(StackRequest.THIS)
 			.build());
 		
 		if (!ecj) {

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -56,7 +56,6 @@ import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
-import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
@@ -138,6 +137,22 @@ public class PatchExtensionMethod {
 		}
 	}
 	
+	private static class PostponedNonStaticAccessToStaticMethodError implements PostponedError {
+		private final ProblemReporter problemReporter;
+		private ASTNode location;
+		private MethodBinding method;
+		
+		PostponedNonStaticAccessToStaticMethodError(ProblemReporter problemReporter, ASTNode location, MethodBinding method) {
+			this.problemReporter = problemReporter;
+			this.location = location;
+			this.method = method;
+		}
+
+		public void fire() {
+			problemReporter.nonStaticAccessToStaticMethod(location, method);
+		}
+	}
+	
 	private static interface PostponedError {
 		public void fire();
 	}
@@ -200,15 +215,12 @@ public class PatchExtensionMethod {
 			TypeBinding receiverType) {
 		
 		List<MethodBinding> extensionMethods = new ArrayList<MethodBinding>();
-		CompilationUnitScope cuScope = ((CompilationUnitDeclaration) typeNode.top().get()).scope;
 		for (MethodBinding method : extensionMethodProviderBinding.methods()) {
 			if (!method.isStatic()) continue;
 			if (!method.isPublic()) continue;
 			if (method.parameters == null || method.parameters.length == 0) continue;
 			TypeBinding firstArgType = method.parameters[0];
 			if (receiverType.isProvablyDistinct(firstArgType) && !receiverType.isCompatibleWith(firstArgType.erasure())) continue;
-			TypeBinding[] argumentTypes = Arrays.copyOfRange(method.parameters, 1, method.parameters.length);
-			if ((receiverType instanceof ReferenceBinding) && ((ReferenceBinding) receiverType).getExactMethod(method.selector, argumentTypes, cuScope) != null) continue;
 			extensionMethods.add(method);
 		}
 		return extensionMethods;
@@ -226,6 +238,10 @@ public class PatchExtensionMethod {
 	
 	public static void invalidMethod(ProblemReporter problemReporter, MessageSend messageSend, MethodBinding method, Scope scope) {
 		MessageSend_postponedErrors.set(messageSend, new PostponedInvalidMethodError(problemReporter, messageSend, method, scope));
+	}
+	
+	public static void nonStaticAccessToStaticMethod(ProblemReporter problemReporter, ASTNode location, MethodBinding method, MessageSend messageSend) {
+		MessageSend_postponedErrors.set(messageSend, new PostponedNonStaticAccessToStaticMethodError(problemReporter, location, method));
 	}
 	
 	public static TypeBinding resolveType(TypeBinding resolvedType, MessageSend methodCall, BlockScope scope) {

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -271,6 +272,7 @@ final class PatchFixesHider {
 		private static final Method RESOLVE_TYPE;
 		private static final Method ERROR_NO_METHOD_FOR;
 		private static final Method INVALID_METHOD, INVALID_METHOD2;
+		private static final Method NON_STATIC_ACCESS_TO_STATIC_METHOD;
 		
 		static {
 			Class<?> shadowed = Util.shadowLoadClass("lombok.eclipse.agent.PatchExtensionMethod");
@@ -278,6 +280,7 @@ final class PatchFixesHider {
 			ERROR_NO_METHOD_FOR = Util.findMethod(shadowed, "errorNoMethodFor", ProblemReporter.class, MessageSend.class, TypeBinding.class, TypeBinding[].class);
 			INVALID_METHOD = Util.findMethod(shadowed, "invalidMethod", ProblemReporter.class, MessageSend.class, MethodBinding.class);
 			INVALID_METHOD2 = Util.findMethod(shadowed, "invalidMethod", ProblemReporter.class, MessageSend.class, MethodBinding.class, Scope.class);
+			NON_STATIC_ACCESS_TO_STATIC_METHOD = Util.findMethod(shadowed, "nonStaticAccessToStaticMethod", ProblemReporter.class, ASTNode.class, MethodBinding.class, MessageSend.class);
 		}
 		
 		public static TypeBinding resolveType(TypeBinding resolvedType, MessageSend methodCall, BlockScope scope) {
@@ -294,6 +297,10 @@ final class PatchFixesHider {
 		
 		public static void invalidMethod(ProblemReporter problemReporter, MessageSend messageSend, MethodBinding method, Scope scope) {
 			Util.invokeMethod(INVALID_METHOD2, problemReporter, messageSend, method, scope);
+		}
+		
+		public static void nonStaticAccessToStaticMethod(ProblemReporter problemReporter, ASTNode location, MethodBinding method, MessageSend messageSend) {
+			Util.invokeMethod(NON_STATIC_ACCESS_TO_STATIC_METHOD, problemReporter, location, method, messageSend);
 		}
 	}
 	

--- a/test/transform/resource/after-delombok/ExtensionMethodNames.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodNames.java
@@ -1,0 +1,27 @@
+package a;
+
+class ExtensionMethodNames {
+	
+	public void instanceCalls() {
+		a.Extensions.ext((new Test()));
+		Test t = new Test();
+		a.Extensions.ext(t);
+		Test Test = new Test();
+		a.Extensions.ext(Test);
+	}
+	
+	public void staticCalls() {
+		Test.ext();
+		a.Test.ext();
+	}
+}
+
+class Extensions {
+	public static void ext(Test t) {
+	}
+}
+
+class Test {
+	public static void ext() {
+	}
+}

--- a/test/transform/resource/after-delombok/ExtensionMethodSuppress.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodSuppress.java
@@ -1,0 +1,33 @@
+class ExtensionMethodSuppress {
+	public void test() {
+		Test.staticMethod();
+		Test test = new Test();
+		Extensions.instanceMethod(test);
+		Extensions.staticMethod(test);
+	}
+}
+
+class ExtensionMethodKeep {
+	public void test() {
+		Test.staticMethod();
+		Test test = new Test();
+		test.instanceMethod();
+		test.staticMethod();
+	}
+}
+
+class Test {
+	public static void staticMethod() {
+	}
+	
+	public void instanceMethod() {
+	}
+}
+
+class Extensions {
+	public static void staticMethod(Test test) {
+	}
+	
+	public static void instanceMethod(Test test) {
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodNames.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodNames.java
@@ -1,0 +1,32 @@
+package a;
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(Extensions.class) class ExtensionMethodNames {
+  ExtensionMethodNames() {
+    super();
+  }
+  public void instanceCalls() {
+    a.Extensions.ext(new Test());
+    Test t = new Test();
+    a.Extensions.ext(t);
+    Test Test = new Test();
+    a.Extensions.ext(Test);
+  }
+  public void staticCalls() {
+    Test.ext();
+    a.Test.ext();
+  }
+}
+class Extensions {
+  Extensions() {
+    super();
+  }
+  public static void ext(Test t) {
+  }
+}
+class Test {
+  Test() {
+    super();
+  }
+  public static void ext() {
+  }
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodSuppress.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodSuppress.java
@@ -1,0 +1,41 @@
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(Extensions.class) class ExtensionMethodSuppress {
+  ExtensionMethodSuppress() {
+    super();
+  }
+  public void test() {
+    Test.staticMethod();
+    Test test = new Test();
+    Extensions.instanceMethod(test);
+    Extensions.staticMethod(test);
+  }
+}
+@ExtensionMethod(value = Extensions.class,suppressBaseMethods = false) class ExtensionMethodKeep {
+  ExtensionMethodKeep() {
+    super();
+  }
+  public void test() {
+    Test.staticMethod();
+    Test test = new Test();
+    test.instanceMethod();
+    test.staticMethod();
+  }
+}
+class Test {
+  Test() {
+    super();
+  }
+  public static void staticMethod() {
+  }
+  public void instanceMethod() {
+  }
+}
+class Extensions {
+  Extensions() {
+    super();
+  }
+  public static void staticMethod(Test test) {
+  }
+  public static void instanceMethod(Test test) {
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodNames.java
+++ b/test/transform/resource/before/ExtensionMethodNames.java
@@ -1,0 +1,33 @@
+package a;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(Extensions.class)
+class ExtensionMethodNames {
+	
+	public void instanceCalls() {
+		(new Test()).ext();
+		
+		Test t = new Test();
+		t.ext();
+		
+		Test Test = new Test();
+		Test.ext();
+	}
+	
+	public void staticCalls() {
+		Test.ext();
+		a.Test.ext();
+	}
+}
+
+class Extensions {
+	public static void ext(Test t) {
+	}
+}
+
+class Test {
+	public static void ext() {
+		
+	}
+}

--- a/test/transform/resource/before/ExtensionMethodSuppress.java
+++ b/test/transform/resource/before/ExtensionMethodSuppress.java
@@ -1,0 +1,43 @@
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(Extensions.class)
+class ExtensionMethodSuppress {
+	public void test() {
+		Test.staticMethod();
+		
+		Test test = new Test();
+		test.instanceMethod();
+		test.staticMethod();
+	}
+}
+
+@ExtensionMethod(value = Extensions.class, suppressBaseMethods = false)
+class ExtensionMethodKeep {
+	public void test() {
+		Test.staticMethod();
+		
+		Test test = new Test();
+		test.instanceMethod();
+		test.staticMethod();
+	}
+}
+
+class Test {
+	public static void staticMethod() {
+		
+	}
+	
+	public void instanceMethod() {
+		
+	}
+}
+
+class Extensions {
+	public static void staticMethod(Test test) {
+		
+	}
+	
+	public static void instanceMethod(Test test) {
+		
+	}
+}

--- a/test/transform/resource/messages-ecj/ExtensionMethodSuppress.java.messages
+++ b/test/transform/resource/messages-ecj/ExtensionMethodSuppress.java.messages
@@ -1,0 +1,1 @@
+21 The static method staticMethod() from the type Test should be accessed in a static way


### PR DESCRIPTION
This PR fixes #2261. The branch is based on #2558 because it requires that fix to pass tests. If that one gets merged, this PR should only contain one commit. If you know a better way to create a dependent PR, please let me know and I will modify this one. 

The javac handler for `@ExtensionMethod` tried to detect static method access e.g. `Test.staticMethod()` by comparing the name of the receiver with the type name of the receiver. While that excluded all these calls properly it also excludes valid calls like 
```
Test Test = new Test();
Test.extension();
```
To solve that, lombok now uses the resolution information to figure out if `Test` is a varaible or a class. I also removed one resolution call by reusing the result of the first one, that should slightly improve the performance.