### PR TITLE
Add missing null check

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchJavadoc.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchJavadoc.java
@@ -53,6 +53,7 @@ public class PatchJavadoc {
 			if (iCompilationUnit instanceof CompilationUnit) {
 				CompilationUnit compilationUnit = (CompilationUnit) iCompilationUnit;
 				Map<String, String> docs = EclipseAugments.CompilationUnit_javadoc.get(compilationUnit);
+				if (docs == null) return null;
 				
 				String signature = getSignature(sourceMethod);
 				String rawJavadoc = docs.get(signature);


### PR DESCRIPTION
At some point I removed this necessary null check...

Obviously the javadoc map can be `null` if lombok does not add any comments. Returning `null` is save here, the original method does that too and lombok only tries to add the comment if that happens. Without this fix eclipse will write an error to the error log everytime someone tries to show the javadoc comment e.g. during code completion.