### PR TITLE
Add Java 15 support for delombok

### DIFF
--- a/src/delombok/lombok/delombok/Delombok.java
+++ b/src/delombok/lombok/delombok/Delombok.java
@@ -701,8 +701,12 @@ public class Delombok {
 			
 			if (!disablePreview && Javac.getJavaCompilerVersion() >= 11) argsList.add("--enable-preview");
 			
-			String[] argv = argsList.toArray(new String[0]);
-			args.init("javac", argv);
+			if (Javac.getJavaCompilerVersion() < 15) {
+				String[] argv = argsList.toArray(new String[0]);
+				args.init("javac", argv);
+			} else {
+				args.init("javac", argsList);
+			}
 			options.put("diags.legacy", "TRUE");
 			options.put("allowStringFolding", "FALSE");
 		} else {

--- a/src/stubs/com/sun/tools/javac/main/Arguments.java
+++ b/src/stubs/com/sun/tools/javac/main/Arguments.java
@@ -10,4 +10,7 @@ public class Arguments {
 	public void init(String ownName, String... argv) {}
 	public Map<Option, String> getDeferredFileManagerOptions() { return null; }
 	public boolean validate() { return false; }
+	
+	// JDK15
+	public void init(String ownName, Iterable<String> args) {}
 }


### PR DESCRIPTION
This PR fixes #2586.

The `init` method signature changed from `init(String, String...)` to `init(String, Iterable<String>)`.