### PR TITLE
The Object Construction Checker has been renamed the Called Methods Checker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Maarten Mulders <mthmulders@users.noreply.github.com>
 Mark Haynes <markhaynes.work@gmail.com>
 Mart Hagenaars <marthagenaars@gmail.com>
 Mateusz Matela <mateusz.matela@gmail.com>
+Michael Ernst <mernst@alum.mit.edu>
 Michiel Verheul <cheelio@gmail.com>
 Pascal Bihler <pascal@qfs.de>
 Peter Grant <petercgrant@users.noreply.github.com>

--- a/src/core/lombok/core/configuration/CheckerFrameworkVersion.java
+++ b/src/core/lombok/core/configuration/CheckerFrameworkVersion.java
@@ -33,8 +33,8 @@ public final class CheckerFrameworkVersion implements ConfigurationValueType {
 	public static final String NAME__PURE = "org.checkerframework.dataflow.qual.Pure";
 	public static final String NAME__UNIQUE = "org.checkerframework.common.aliasing.qual.Unique";
 	public static final String NAME__RETURNS_RECEIVER = "org.checkerframework.common.returnsreceiver.qual.This";
-	public static final String NAME__NOT_CALLED = "org.checkerframework.checker.objectconstruction.qual.NotCalledMethods";
-	public static final String NAME__CALLED = "org.checkerframework.checker.objectconstruction.qual.CalledMethods";
+	public static final String NAME__NOT_CALLED = "org.checkerframework.checker.calledmethods.qual.NotCalledMethods";
+	public static final String NAME__CALLED = "org.checkerframework.checker.calledmethods.qual.CalledMethods";
 	
 	public static final CheckerFrameworkVersion NONE = new CheckerFrameworkVersion(0);
 	

--- a/test/stubs/org/checkerframework/checker/objectconstruction/qual/CalledMethods.java
+++ b/test/stubs/org/checkerframework/checker/objectconstruction/qual/CalledMethods.java
@@ -1,4 +1,4 @@
-package org.checkerframework.checker.objectconstruction.qual;
+package org.checkerframework.checker.calledmethods.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/test/stubs/org/checkerframework/checker/objectconstruction/qual/NotCalledMethods.java
+++ b/test/stubs/org/checkerframework/checker/objectconstruction/qual/NotCalledMethods.java
@@ -1,4 +1,4 @@
-package org.checkerframework.checker.objectconstruction.qual;
+package org.checkerframework.checker.calledmethods.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/test/transform/resource/after-delombok/CheckerFrameworkBuilder.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkBuilder.java
@@ -33,20 +33,20 @@ class CheckerFrameworkBuilder {
 		}
 		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("x") CheckerFrameworkBuilderBuilder this, final int x) {
+		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("x") CheckerFrameworkBuilderBuilder this, final int x) {
 			this.x$value = x;
 			x$set = true;
 			return this;
 		}
 		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("y") CheckerFrameworkBuilderBuilder this, final int y) {
+		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("y") CheckerFrameworkBuilderBuilder this, final int y) {
 			this.y = y;
 			return this;
 		}
 		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("z") CheckerFrameworkBuilderBuilder this, final int z) {
+		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("z") CheckerFrameworkBuilderBuilder this, final int z) {
 			this.z = z;
 			return this;
 		}
@@ -75,7 +75,7 @@ class CheckerFrameworkBuilder {
 		}
 		@org.checkerframework.dataflow.qual.SideEffectFree
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder build(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) CheckerFrameworkBuilderBuilder this) {
+		public CheckerFrameworkBuilder build(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) CheckerFrameworkBuilderBuilder this) {
 			java.util.List<String> names;
 			switch (this.names == null ? 0 : this.names.size()) {
 			case 0: 

--- a/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
@@ -28,23 +28,23 @@ class CheckerFrameworkSuperBuilder {
 			protected abstract B self();
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.SuppressWarnings("all")
-			public abstract C build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
+			public abstract C build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
 			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B x(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("x") ParentBuilder<C, B> this, final int x) {
+			public B x(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("x") ParentBuilder<C, B> this, final int x) {
 				this.x$value = x;
 				x$set = true;
 				return self();
 			}
 			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B y(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("y") ParentBuilder<C, B> this, final int y) {
+			public B y(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("y") ParentBuilder<C, B> this, final int y) {
 				this.y = y;
 				return self();
 			}
 			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B z(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("z") ParentBuilder<C, B> this, final int z) {
+			public B z(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("z") ParentBuilder<C, B> this, final int z) {
 				this.z = z;
 				return self();
 			}
@@ -93,7 +93,7 @@ class CheckerFrameworkSuperBuilder {
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			public CheckerFrameworkSuperBuilder.Parent build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) ParentBuilderImpl this) {
+			public CheckerFrameworkSuperBuilder.Parent build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilderImpl this) {
 				return new CheckerFrameworkSuperBuilder.Parent(this);
 			}
 		}
@@ -146,17 +146,17 @@ class CheckerFrameworkSuperBuilder {
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			public abstract C build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.objectconstruction.qual.CalledMethods("b") ZChildBuilder<C, B> this);
+			public abstract C build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
 			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B a(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("a") ZChildBuilder<C, B> this, final int a) {
+			public B a(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("a") ZChildBuilder<C, B> this, final int a) {
 				this.a$value = a;
 				a$set = true;
 				return self();
 			}
 			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B b(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("b") ZChildBuilder<C, B> this, final int b) {
+			public B b(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("b") ZChildBuilder<C, B> this, final int b) {
 				this.b = b;
 				return self();
 			}
@@ -182,7 +182,7 @@ class CheckerFrameworkSuperBuilder {
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			public CheckerFrameworkSuperBuilder.ZChild build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.objectconstruction.qual.CalledMethods("b") ZChildBuilderImpl this) {
+			public CheckerFrameworkSuperBuilder.ZChild build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilderImpl this) {
 				return new CheckerFrameworkSuperBuilder.ZChild(this);
 			}
 		}

--- a/test/transform/resource/after-ecj/CheckerFrameworkBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkBuilder.java
@@ -11,16 +11,16 @@ import lombok.Singular;
     @java.lang.SuppressWarnings("all") CheckerFrameworkBuilderBuilder() {
       super();
     }
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("x") CheckerFrameworkBuilderBuilder this, final int x) {
+    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("x") CheckerFrameworkBuilderBuilder this, final int x) {
       this.x$value = x;
       x$set = true;
       return this;
     }
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("y") CheckerFrameworkBuilderBuilder this, final int y) {
+    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("y") CheckerFrameworkBuilderBuilder this, final int y) {
       this.y = y;
       return this;
     }
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("z") CheckerFrameworkBuilderBuilder this, final int z) {
+    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.NotCalledMethods("z") CheckerFrameworkBuilderBuilder this, final int z) {
       this.z = z;
       return this;
     }
@@ -45,7 +45,7 @@ import lombok.Singular;
           this.names.clear();
       return this;
     }
-    public @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder build(CheckerFrameworkBuilder.@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) CheckerFrameworkBuilderBuilder this) {
+    public @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder build(CheckerFrameworkBuilder.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) CheckerFrameworkBuilderBuilder this) {
       java.util.List<String> names;
       switch (((this.names == null) ? 0 : this.names.size())) {
       case 0 :

--- a/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
@@ -12,17 +12,17 @@ class CheckerFrameworkSuperBuilder {
         super();
       }
       protected abstract @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
-      public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B x(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("x") ParentBuilder<C, B> this, final int x) {
+      public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
+      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B x(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("x") ParentBuilder<C, B> this, final int x) {
         this.x$value = x;
         x$set = true;
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B y(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("y") ParentBuilder<C, B> this, final int y) {
+      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B y(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("y") ParentBuilder<C, B> this, final int y) {
         this.y = y;
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B z(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("z") ParentBuilder<C, B> this, final int z) {
+      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B z(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("z") ParentBuilder<C, B> this, final int z) {
         this.z = z;
         return self();
       }
@@ -58,7 +58,7 @@ class CheckerFrameworkSuperBuilder {
       protected @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl self() {
         return this;
       }
-      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.objectconstruction.qual.CalledMethods({"y", "z"}) ParentBuilderImpl this) {
+      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilderImpl this) {
         return new CheckerFrameworkSuperBuilder.Parent(this);
       }
     }
@@ -103,13 +103,13 @@ class CheckerFrameworkSuperBuilder {
         super();
       }
       protected abstract @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.objectconstruction.qual.CalledMethods("b") ZChildBuilder<C, B> this);
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B a(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("a") ZChildBuilder<C, B> this, final int a) {
+      public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
+      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B a(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("a") ZChildBuilder<C, B> this, final int a) {
         this.a$value = a;
         a$set = true;
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B b(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.objectconstruction.qual.NotCalledMethods("b") ZChildBuilder<C, B> this, final int b) {
+      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B b(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("b") ZChildBuilder<C, B> this, final int b) {
         this.b = b;
         return self();
       }
@@ -124,7 +124,7 @@ class CheckerFrameworkSuperBuilder {
       protected @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl self() {
         return this;
       }
-      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.objectconstruction.qual.CalledMethods("b") ZChildBuilderImpl this) {
+      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilderImpl this) {
         return new CheckerFrameworkSuperBuilder.ZChild(this);
       }
     }


### PR DESCRIPTION
This pull request updates the names of annotations used by the Checker Framework.
The old versions continue to be supported by the Checker Framework, but it's better to use the current version.