### PR TITLE
VarSymbol.adr is required for flow analysis in Netbeans

### DIFF
--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1241,6 +1241,7 @@ public class JavacHandlerUtil {
 				if (param.sym == null) {
 					Type paramType = paramTypes == null ? param.getType().type : paramTypes.get(i);
 					VarSymbol varSymbol = new VarSymbol(param.mods.flags, param.name, paramType, symtab.noSymbol);
+					varSymbol.adr = i;
 					List<JCAnnotation> annotations = param.getModifiers().getAnnotations();
 					if (annotations != null && !annotations.isEmpty()) {
 						ListBuffer<Attribute.Compound> newAnnotations = new ListBuffer<Attribute.Compound>();

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1275,6 +1275,9 @@ public class JavacHandlerUtil {
 		MethodSymbol methodSymbol = new MethodSymbol(access, methodName, new MethodType(paramTypes, returnType, List.<Type>nil(), Symtab.instance(context).methodClass), cs);
 		if (params != null && !params.isEmpty()) {
 			methodSymbol.params = params;
+			for (VarSymbol varSymbol : params) {
+				varSymbol.owner = methodSymbol;
+			}
 		}
 		ClassSymbolMembersField.enter(cs, methodSymbol);
 	}

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1241,7 +1241,7 @@ public class JavacHandlerUtil {
 				if (param.sym == null) {
 					Type paramType = paramTypes == null ? param.getType().type : paramTypes.get(i);
 					VarSymbol varSymbol = new VarSymbol(param.mods.flags, param.name, paramType, symtab.noSymbol);
-					varSymbol.adr = i;
+					varSymbol.adr = 1 << i;
 					List<JCAnnotation> annotations = param.getModifiers().getAnnotations();
 					if (annotations != null && !annotations.isEmpty()) {
 						ListBuffer<Attribute.Compound> newAnnotations = new ListBuffer<Attribute.Compound>();

--- a/src/stubs/com/sun/tools/javac/code/Symbol.java
+++ b/src/stubs/com/sun/tools/javac/code/Symbol.java
@@ -62,6 +62,7 @@ public abstract class Symbol implements Element {
 	
 	public static class VarSymbol extends Symbol implements VariableElement {
 		public Type type;
+		public int adr;
 		public VarSymbol(long flags, Name name, Type type, Symbol owner) {
 		}
 		@Override public ElementKind getKind() { return null; }

--- a/src/stubs/com/sun/tools/javac/code/Symbol.java
+++ b/src/stubs/com/sun/tools/javac/code/Symbol.java
@@ -24,6 +24,7 @@ import com.sun.tools.javac.util.Name;
 public abstract class Symbol implements Element {
 	public Type type;
 	public Name name;
+	public Symbol owner;
 
 	public long flags() { return 0; }
 	public boolean isStatic() { return false; }


### PR DESCRIPTION
The `adr` field has to be set for the new `VarSymbol`. The field should be there in every supported Java version, it is unchanged for 13 years.

This is a potential fix for #2612 .