### PR TITLE
Write classes only once

### DIFF
--- a/src/core/lombok/core/PostCompiler.java
+++ b/src/core/lombok/core/PostCompiler.java
@@ -22,6 +22,7 @@
 package lombok.core;
 
 import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -67,7 +68,7 @@ public final class PostCompiler {
 	
 	public static OutputStream wrapOutputStream(final OutputStream originalStream, final String fileName, final DiagnosticsReceiver diagnostics) throws IOException {
 		if (System.getProperty("lombok.disablePostCompiler", null) != null) return originalStream;
-		return new ByteArrayOutputStream() {
+		return new FilterOutputStream(new ByteArrayOutputStream() {
 			@Override public void close() throws IOException {
 				// no need to call super
 				byte[] original = toByteArray();
@@ -88,6 +89,6 @@ public final class PostCompiler {
 				originalStream.write(copy);
 				originalStream.close(); 
 			}
-		};
+		});
 	}
 }


### PR DESCRIPTION
This PR fixes https://github.com/mplushnikov/lombok-intellij-plugin/issues/969.

In
https://github.com/eclipse/eclipse.jdt.core/blob/b3cc25e26a9b327ef6e79fbec3cde4d4fbeb60fc/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompilerImpl.java#L444-L448
the stream gets closed twice. By wrapping the `ByteArrayOutputStream` in a `FilterOutputStream` the second close no longer perform any action.

@rzwitserloot After merging your latest Tycho changes I get a `java.lang.IllegalArgumentException: argument type mismatch` error. InteliJ does not print a full stacktrace so I do not know what exactly is broken.