### PR TITLE
FEATURE: Set config file via system property "lombok.configUri"

### DIFF
--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -4,6 +4,7 @@ Lombok Changelog
 ### v1.18.17 "Edgy Guinea Pig"
 * BUGFIX: Netbeans would not work with 1.18.16 anymore. [Issue #2612](https://github.com/rzwitserloot/lombok/issues/2612)
 * (potential) BUGFIX: Using lombok with Maven Tycho now works. With assistance from [Rabea Gransberger](https://github.com/rgra). [Issue #285](https://github.com/rzwitserloot/lombok/issues/285)
+* FEATURE: You can now pass a [`config file`](https://projectlombok.org/features/configuration) via the system property `lombok.configUri` (e.g. when using Eclipse, passing `-Dlombok.configUri=/path/to/lombok.config` in `eclipse.ini` or, in general, setting it via the `JAVA_TOOL_OPTIONS` environment variable so `javac` picks it up). This might be useful if the used build tool uses some exotic path system. E.g. starting with version 1.4, sbt (https://www.scala-sbt.org/) uses `vf:` instead of `file:`, which [lombok couldn't handle](https://github.com/sbt/sbt/issues/5968).
 
 ### v1.18.16 (October 15th, 2020)
 * BUGFIX: Version 1.18.14 could not be installed in Eclipse, it would break Eclipse.

--- a/src/core/lombok/core/LombokConfiguration.java
+++ b/src/core/lombok/core/LombokConfiguration.java
@@ -51,6 +51,8 @@ public class LombokConfiguration {
 					return NULL_RESOLVER;
 				}
 			};
+		} else if (System.getProperty("lombok.configUri") != null) {
+			configurationResolverFactory = createSystemPropertyConfigUriResolverFactory(URI.create(System.getProperty("lombok.configUri")));
 		}
 		else {
 			configurationResolverFactory = createFileSystemBubblingResolverFactory();
@@ -78,6 +80,16 @@ public class LombokConfiguration {
 		return new ConfigurationResolverFactory() {
 			@Override public ConfigurationResolver createResolver(URI sourceLocation) {
 				return new BubblingConfigurationResolver(cache.forUri(sourceLocation), fileToSource);
+			}
+		};
+	}
+
+	private static ConfigurationResolverFactory createSystemPropertyConfigUriResolverFactory(URI configUri) {
+		final ConfigurationFileToSource fileToSource = cache.fileToSource(new ConfigurationParser(ConfigurationProblemReporter.CONSOLE));
+		final ConfigurationResolver systemPropertyConfigUriResolver = new BubblingConfigurationResolver(cache.forUri(configUri), fileToSource);
+		return new ConfigurationResolverFactory() {
+			@Override public ConfigurationResolver createResolver(URI sourceLocation) {
+				return systemPropertyConfigUriResolver;
 			}
 		};
 	}


### PR DESCRIPTION
I think the added changelog entry says it all:

---

* FEATURE: You can now pass a [`config file`](https://projectlombok.org/features/configuration) via the system property `lombok.configUri` (e.g. when using Eclipse, passing `-Dlombok.configUri=/path/to/lombok.config` in `eclipse.ini` or, in general, setting it via the `JAVA_TOOL_OPTIONS` environment variable so `javac` picks it up). This might be useful if the used build tool uses some exotic path system. E.g. starting with version 1.4, sbt (https://www.scala-sbt.org/) uses `vf:` instead of `file:`, which [lombok couldn't handle](https://github.com/sbt/sbt/issues/5968).

---

So as you can see sbt 1.4 introduces a virtual file system, so the "files" lombok "receives" from sbt are all prefixed with `vf:` (and also have a virtual path, which is different than the actual path on the file system), which lombok just ignores. However Lombok itself works fine, only the config is broken, meaning all `lombok.config` files are ignored (https://github.com/sbt/sbt/issues/5968). The relevant code in Lombok [can be found here](https://github.com/rzwitserloot/lombok/blob/v1.18.16/src/core/lombok/core/configuration/FileSystemSourceCache.java#L67-L87) (see the lengthy comment in this code snippet):
https://github.com/rzwitserloot/lombok/blob/737dc6e4333c09a0848d2f5b0d621a27a8039a70/src/core/lombok/core/configuration/FileSystemSourceCache.java#L67-L87

This fairly easy fix gives us a workaround, so we can just set the `lombok.configUri` env variable in `build.sbt` and the specified `lombok.config` gets picked up. I know with this environment variable we can only define just one config file instead of putting many different config files in different packages/folders, but IMHO having at least a "global" config file is good enough to set at least global config keys. Also, because I re-use the `BubblingConfigurationResolver` (mainly because it already handles imports inside a lombok config), bubbling up the directory tree still works.