### PR TITLE
Reset inference context for extension methods

### DIFF
--- a/test/transform/resource/after-delombok/ExtensionMethodFunctional.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodFunctional.java
@@ -1,5 +1,8 @@
-import java.util.function.Function;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 class ExtensionMethodFunctional {
 	public void test() {
@@ -7,6 +10,8 @@ class ExtensionMethodFunctional {
 		test = ExtensionMethodFunctional.Extensions.map(test, s -> ExtensionMethodFunctional.Extensions.reverse(s));
 		ExtensionMethodFunctional.Extensions.consume(test, s -> System.out.println("1: " + s), s -> System.out.println("2: " + s));
 		ExtensionMethodFunctional.Extensions.consume(test, System.out::println, System.out::println);
+		ExtensionMethodFunctional.Extensions.toList(Stream.of("a", "b", "c").map(String::toUpperCase));
+		List<Integer> i2 = ExtensionMethodFunctional.Extensions.toList2(Stream.of("a", "b", "c").map(String::toUpperCase));
 	}
 
 	static class Extensions {
@@ -23,6 +28,14 @@ class ExtensionMethodFunctional {
 			for (int i = 0; i < consumer.length; i++) {
 				consumer[i].accept(o);
 			}
+		}
+		
+		public static <T> List<T> toList(Stream<T> stream) {
+			return (List<T>) stream.collect(Collectors.toList());
+		}
+
+		public static <T, U> List<U> toList2(Stream<T> stream) {
+			return null;
 		}
 	}
 }

--- a/test/transform/resource/after-delombok/ExtensionMethodGeneric.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodGeneric.java
@@ -1,0 +1,33 @@
+import java.util.List;
+import java.util.Map;
+
+class ExtensionMethodGeneric {
+	public void test() {
+		List<String> stringList = null;
+		List<Number> numberList = null;
+		ExtensionMethodGeneric.Extensions.test(stringList);
+		ExtensionMethodGeneric.Extensions.test(stringList, numberList);
+		ExtensionMethodGeneric.Extensions.test(ExtensionMethodGeneric.Extensions.test(stringList, stringList), numberList);
+		Integer i = ExtensionMethodGeneric.Extensions.test2(stringList);
+		Map<String, Integer> map = null;
+		List<String> l = ExtensionMethodGeneric.Extensions.test(map, stringList, numberList);
+	}
+	
+	static class Extensions {
+		public static <T> List<T> test(List<String> obj, List<T> list) {
+			return null;
+		}
+
+		public static <K, V> K test(Map<String, Integer> obj, K k, V v) {
+			return k;
+		}
+
+		public static <T> T test(List<T> list) {
+			return null;
+		}
+
+		public static <T, U> U test2(List<T> list) {
+			return null;
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodFunctional.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodFunctional.java
@@ -1,7 +1,10 @@
-import java.util.function.Function;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.experimental.ExtensionMethod;
-@ExtensionMethod(ExtensionMethodFunctional.Extensions.class) class ExtensionMethodFunctional {
+@ExtensionMethod(value = ExtensionMethodFunctional.Extensions.class,suppressBaseMethods = false) class ExtensionMethodFunctional {
   static class Extensions {
     Extensions() {
       super();
@@ -18,6 +21,12 @@ import lombok.experimental.ExtensionMethod;
           consumer[i].accept(o);
         }
     }
+    public static <T>List<T> toList(Stream<T> stream) {
+      return (List<T>) stream.collect(Collectors.toList());
+    }
+    public static <T, U>List<U> toList2(Stream<T> stream) {
+      return null;
+    }
   }
   ExtensionMethodFunctional() {
     super();
@@ -27,5 +36,7 @@ import lombok.experimental.ExtensionMethod;
     test = ExtensionMethodFunctional.Extensions.map(test, (<no type> s) -> ExtensionMethodFunctional.Extensions.reverse(s));
     ExtensionMethodFunctional.Extensions.consume(test, (<no type> s) -> System.out.println(("1: " + s)), (<no type> s) -> System.out.println(("2: " + s)));
     ExtensionMethodFunctional.Extensions.consume(test, System.out::println, System.out::println);
+    ExtensionMethodFunctional.Extensions.toList(Stream.of("a", "b", "c").map(String::toUpperCase));
+    List<Integer> i2 = ExtensionMethodFunctional.Extensions.toList2(Stream.of("a", "b", "c").map(String::toUpperCase));
   }
 }

--- a/test/transform/resource/after-ecj/ExtensionMethodGeneric.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodGeneric.java
@@ -1,0 +1,35 @@
+import java.util.List;
+import java.util.Map;
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(ExtensionMethodGeneric.Extensions.class) class ExtensionMethodGeneric {
+  static class Extensions {
+    Extensions() {
+      super();
+    }
+    public static <T>List<T> test(List<String> obj, List<T> list) {
+      return null;
+    }
+    public static <K, V>K test(Map<String, Integer> obj, K k, V v) {
+      return k;
+    }
+    public static <T>T test(List<T> list) {
+      return null;
+    }
+    public static <T, U>U test2(List<T> list) {
+      return null;
+    }
+  }
+  ExtensionMethodGeneric() {
+    super();
+  }
+  public void test() {
+    List<String> stringList = null;
+    List<Number> numberList = null;
+    ExtensionMethodGeneric.Extensions.test(stringList);
+    ExtensionMethodGeneric.Extensions.test(stringList, numberList);
+    ExtensionMethodGeneric.Extensions.test(ExtensionMethodGeneric.Extensions.test(stringList, stringList), numberList);
+    Integer i = ExtensionMethodGeneric.Extensions.test2(stringList);
+    Map<String, Integer> map = null;
+    List<String> l = ExtensionMethodGeneric.Extensions.test(map, stringList, numberList);
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodFunctional.java
+++ b/test/transform/resource/before/ExtensionMethodFunctional.java
@@ -1,10 +1,13 @@
 // version 8:
-import java.util.function.Function;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.experimental.ExtensionMethod;
 
-@ExtensionMethod(ExtensionMethodFunctional.Extensions.class)
+@ExtensionMethod(value = ExtensionMethodFunctional.Extensions.class, suppressBaseMethods = false)
 class ExtensionMethodFunctional {
 	public void test() {
 		String test = "test";
@@ -12,6 +15,9 @@ class ExtensionMethodFunctional {
 		
 		test.consume(s -> System.out.println("1: " + s), s -> System.out.println("2: " + s));
 		test.consume(System.out::println, System.out::println);
+		
+		Stream.of("a", "b", "c").map(String::toUpperCase).toList();
+		List<Integer> i2 = Stream.of("a", "b", "c").map(String::toUpperCase).toList2();
 	}
 	
 	static class Extensions {
@@ -28,6 +34,14 @@ class ExtensionMethodFunctional {
 			for (int i = 0; i < consumer.length; i++) {
 				consumer[i].accept(o);
 			}
+		}
+		
+		public static <T> List<T> toList(Stream<T> stream) {
+			return (List<T>) stream.collect(Collectors.toList());
+		}
+		
+		public static <T, U> List<U> toList2(Stream<T> stream) {
+			return null;
 		}
 	}
 }

--- a/test/transform/resource/before/ExtensionMethodGeneric.java
+++ b/test/transform/resource/before/ExtensionMethodGeneric.java
@@ -1,0 +1,34 @@
+import java.util.List;
+import java.util.Map;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(ExtensionMethodGeneric.Extensions.class)
+class ExtensionMethodGeneric {
+	public void test() {
+		List<String> stringList = null;
+		List<Number> numberList = null;
+		stringList.test();
+		stringList.test(numberList);
+		stringList.test(stringList).test(numberList);
+		Integer i = stringList.test2();
+		
+		Map<String, Integer> map = null;
+		List<String> l = map.test(stringList, numberList);
+	}
+	
+	static class Extensions {
+		public static <T> List<T> test(List<String> obj, List<T> list) {
+			return null;
+		}
+		public static <K,V> K test(Map<String, Integer> obj, K k, V v) {
+			return k;
+		}
+		public static <T> T test(List<T> list) {
+			return null;
+		}
+		public static <T,U> U test2(List<T> list) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #2648.

In Java >= 8 ecj uses the inference context to resolve the generic information. This one is already set before lombok tries rewrite the method call. Simply copying the information does not cover all the different cases but reseting the inference contexts and running type inference again does.