### PR TITLE
Use the correct field to query parent type parameters in Builder

### DIFF
--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -371,7 +371,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 				}
 				
 				List<JCTypeParameter> tpOnMethod = jmd.typarams;
-				List<JCTypeParameter> tpOnType = ((JCClassDecl) job.builderType.get()).typarams;
+				List<JCTypeParameter> tpOnType = ((JCClassDecl) job.parentType.get()).typarams;
 				typeArgsForToBuilder = new ArrayList<Name>();
 				
 				for (JCTypeParameter tp : tpOnMethod) {

--- a/test/transform/resource/after-delombok/BuilderWithToBuilder.java
+++ b/test/transform/resource/after-delombok/BuilderWithToBuilder.java
@@ -148,3 +148,51 @@ class ConstructorWithToBuilder<T> {
 		return new ConstructorWithToBuilder.ConstructorWithToBuilderBuilder<T>().mOne(this.mOne).baz(this.foo).bars(this.bars);
 	}
 }
+class StaticMethodWithToBuilder<T> {
+	private T foo;
+	
+	public StaticMethodWithToBuilder(T foo) {
+		this.foo = foo;
+	}
+
+	public static <T> StaticMethodWithToBuilder<T> of(T foo) {
+		return new StaticMethodWithToBuilder<T>(foo);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static class StaticMethodWithToBuilderBuilder<T> {
+		@java.lang.SuppressWarnings("all")
+		private T foo;
+
+		@java.lang.SuppressWarnings("all")
+		StaticMethodWithToBuilderBuilder() {
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T> foo(final T foo) {
+			this.foo = foo;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public StaticMethodWithToBuilder<T> build() {
+			return StaticMethodWithToBuilder.<T>of(this.foo);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder(foo=" + this.foo + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static <T> StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T> builder() {
+		return new StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T>();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T> toBuilder() {
+		return new StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T>().foo(this.foo);
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderWithToBuilder.java
+++ b/test/transform/resource/after-ecj/BuilderWithToBuilder.java
@@ -126,3 +126,35 @@ import lombok.Builder;
     return new ConstructorWithToBuilder.ConstructorWithToBuilderBuilder<T>().mOne(this.mOne).baz(this.foo).bars(this.bars);
   }
 }
+class StaticMethodWithToBuilder<T> {
+  public static @java.lang.SuppressWarnings("all") class StaticMethodWithToBuilderBuilder<T> {
+    private @java.lang.SuppressWarnings("all") T foo;
+    @java.lang.SuppressWarnings("all") StaticMethodWithToBuilderBuilder() {
+      super();
+    }
+    public @java.lang.SuppressWarnings("all") StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T> foo(final T foo) {
+      this.foo = foo;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") StaticMethodWithToBuilder<T> build() {
+      return StaticMethodWithToBuilder.<T>of(this.foo);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder(foo=" + this.foo) + ")");
+    }
+  }
+  private T foo;
+  public StaticMethodWithToBuilder(T foo) {
+    super();
+    this.foo = foo;
+  }
+  public static @Builder(toBuilder = true) <T>StaticMethodWithToBuilder<T> of(T foo) {
+    return new StaticMethodWithToBuilder<T>(foo);
+  }
+  public static @java.lang.SuppressWarnings("all") <T>StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T> builder() {
+    return new StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T>();
+  }
+  public @java.lang.SuppressWarnings("all") StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T> toBuilder() {
+    return new StaticMethodWithToBuilder.StaticMethodWithToBuilderBuilder<T>().foo(this.foo);
+  }
+}

--- a/test/transform/resource/before/BuilderWithToBuilder.java
+++ b/test/transform/resource/before/BuilderWithToBuilder.java
@@ -18,3 +18,16 @@ class ConstructorWithToBuilder<T> {
 	public ConstructorWithToBuilder(String mOne, @Builder.ObtainVia(field = "foo") T baz, com.google.common.collect.ImmutableList<T> bars) {
 	}
 }
+
+class StaticMethodWithToBuilder<T> {
+	private T foo;
+	
+	public StaticMethodWithToBuilder(T foo) {
+		this.foo = foo;
+	}
+
+    @Builder(toBuilder = true)
+    public static <T> StaticMethodWithToBuilder<T> of(T foo) {
+        return new StaticMethodWithToBuilder<T>(foo);
+    }
+}


### PR DESCRIPTION
This PR fixes #2657.

The latest refactoring introduced this error by using the wrong field. I also added a test case to cover `@Builder(toBuilder=true)` on a static method.