### PR TITLE
Fixing reading files in sbt 1.4+ subprojects

### DIFF
--- a/src/core/lombok/javac/JavacAST.java
+++ b/src/core/lombok/javac/JavacAST.java
@@ -174,7 +174,14 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 		if (sbtMappedVirtualFileRootsField == null) return null;
 		
 		String encodedPath = (String) sbtMappedVirtualFilePathField.get(mappedVirtualFile);
-		if (!encodedPath.startsWith("${")) return null;
+		if (!encodedPath.startsWith("${")) {
+			File maybeAbsoluteFile = new File(encodedPath);
+			if (maybeAbsoluteFile.exists()) {
+				return maybeAbsoluteFile.toURI();
+			} else {
+				return null;
+			}
+		}
 		int idx = encodedPath.indexOf('}');
 		if (idx == -1) return null;
 		String base = encodedPath.substring(2, idx);


### PR DESCRIPTION
I did some testing with the current edge release, and found a bug:
[The fix](https://github.com/rzwitserloot/lombok/commit/e1f82ac4d132769cfc272dccfc916aeba7181718) for #2645 is not working when using [sbt subprojects](https://www.scala-sbt.org/1.x/docs/Multi-Project.html).
In my case I have a subproject, which pulls in and uses lombok, and a parent (root) project (which depends on the subproject).
Now when running sbt in the root project and start compiling that root project, which in turn also compiles the subproject, the `lombok.config` (located in the subproject) is, again, ignored, resulting in compiling errors in the subproject.

After some debugging it turns out that the URI reported by sbt for the subproject has the format:

```
vf://tmp//home/mkurz/myproject/src/main/java/example/Main.java
```

instead of the format

```
vf://tmp/$%7BBASE%7D/src/main/java/example/Main.java
```

when using a normal, single root project with lombok.

That makes sense, because the files of the subproject are obviously not located within the root project (=`BASE`, where relative paths like `${BASE}/src/main/java/example/Main.java` are used), therefore absolut paths are used (`/home/mkurz/myproject/src/main/java/example/Main.java`).

The fix is quite easy: When the file path doesn't start with `${` (when looking for `${BASE}`), we can assume the path is very likely an absolute one, so we just use it.

I can confirm this fixes our compiler errors and the app runs smoothly.