### PR TITLE
SuperBuilder: consider lombok.builder.className for builder extends clause

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -202,8 +202,12 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		}
 		
 		String replaceBuilderClassName(char[] name) {
-			if (builderClassName.indexOf('*') == -1) return builderClassName;
-			return builderClassName.replace("*", new String(name));
+			return replaceBuilderClassName(name, builderClassName);
+		}
+
+		String replaceBuilderClassName(char[] name, String template) {
+			if (template.indexOf('*') == -1) return template;
+			return template.replace("*", new String(name));
 		}
 		
 		String replaceBuilderClassName(String name) {

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -183,14 +183,14 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 			
 			builderMethodName = ann.builderMethodName();
 			buildMethodName = ann.buildMethodName();
-			setBuilderClassName(fixBuilderClassName(node, ann.builderClassName()));
+			setBuilderClassName(getBuilderClassNameTemplate(node, ann.builderClassName()));
 			toBuilder = ann.toBuilder();
 			
 			if (builderMethodName == null) builderMethodName = "builder";
 			if (buildMethodName == null) buildMethodName = "build";
 		}
 		
-		static String fixBuilderClassName(EclipseNode node, String override) {
+		static String getBuilderClassNameTemplate(EclipseNode node, String override) {
 			if (override != null && !override.isEmpty()) return override;
 			override = node.getAst().readConfiguration(ConfigurationKeys.BUILDER_CLASS_NAME);
 			if (override != null && !override.isEmpty()) return override;

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -123,7 +123,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 			
 			if (builderMethodName == null) builderMethodName = "builder";
 			if (buildMethodName == null) buildMethodName = "build";
-			builderClassName = fixBuilderClassName(node, "");
+			builderClassName = getBuilderClassNameTemplate(node, null);
 		}
 		
 		EclipseNode builderAbstractType;
@@ -273,7 +273,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		if (extendsClause instanceof QualifiedTypeReference) {
 			QualifiedTypeReference qualifiedTypeReference = (QualifiedTypeReference)extendsClause;
 			char[] superclassClassName = qualifiedTypeReference.getLastToken();
-			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, null);
+			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(superclassClassName, builderClassNameTemplate);
 			
 			char[][] tokens = Arrays.copyOf(qualifiedTypeReference.tokens, qualifiedTypeReference.tokens.length + 1);
@@ -291,7 +291,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 			superclassBuilderClass = new ParameterizedQualifiedTypeReference(tokens, typeArgsForTokens, 0, poss);
 		} else if (extendsClause != null) {
 			char[] superclassClassName = extendsClause.getTypeName()[0];
-			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(superclassClassName, builderClassNameTemplate);
 			
 			char[][] tokens = new char[][] {superclassClassName, superclassBuilderClassName.toCharArray()};

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -272,8 +272,9 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		};
 		if (extendsClause instanceof QualifiedTypeReference) {
 			QualifiedTypeReference qualifiedTypeReference = (QualifiedTypeReference)extendsClause;
-			String superclassClassName = String.valueOf(qualifiedTypeReference.getLastToken());
-			String superclassBuilderClassName = job.replaceBuilderClassName(superclassClassName);
+			char[] superclassClassName = qualifiedTypeReference.getLastToken();
+			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String superclassBuilderClassName = job.replaceBuilderClassName(superclassClassName, builderClassNameTemplate);
 			
 			char[][] tokens = Arrays.copyOf(qualifiedTypeReference.tokens, qualifiedTypeReference.tokens.length + 1);
 			tokens[tokens.length-1] = superclassBuilderClassName.toCharArray();
@@ -289,10 +290,11 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 			
 			superclassBuilderClass = new ParameterizedQualifiedTypeReference(tokens, typeArgsForTokens, 0, poss);
 		} else if (extendsClause != null) {
-			String superClass = String.valueOf(extendsClause.getTypeName()[0]);
-			String superclassBuilderClassName = superClass + "Builder";
+			char[] superclassClassName = extendsClause.getTypeName()[0];
+			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String superclassBuilderClassName = job.replaceBuilderClassName(superclassClassName, builderClassNameTemplate);
 			
-			char[][] tokens = new char[][] {superClass.toCharArray(), superclassBuilderClassName.toCharArray()};
+			char[][] tokens = new char[][] {superclassClassName, superclassBuilderClassName.toCharArray()};
 			long[] poss = new long[tokens.length];
 			Arrays.fill(poss, job.getPos());
 			

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -273,7 +273,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		if (extendsClause instanceof QualifiedTypeReference) {
 			QualifiedTypeReference qualifiedTypeReference = (QualifiedTypeReference)extendsClause;
 			char[] superclassClassName = qualifiedTypeReference.getLastToken();
-			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(superclassClassName, builderClassNameTemplate);
 			
 			char[][] tokens = Arrays.copyOf(qualifiedTypeReference.tokens, qualifiedTypeReference.tokens.length + 1);

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -132,7 +132,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			
 			builderMethodName = ann.builderMethodName();
 			buildMethodName = ann.buildMethodName();
-			builderClassName = fixBuilderClassName(node, ann.builderClassName());
+			builderClassName = getBuilderClassNameTemplate(node, ann.builderClassName());
 			toBuilder = ann.toBuilder();
 			
 			if (builderMethodName == null) builderMethodName = "builder";
@@ -140,7 +140,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			if (builderClassName == null) builderClassName = "";
 		}
 		
-		static String fixBuilderClassName(JavacNode node, String override) {
+		static String getBuilderClassNameTemplate(JavacNode node, String override) {
 			if (override != null && !override.isEmpty()) return override;
 			override = node.getAst().readConfiguration(ConfigurationKeys.BUILDER_CLASS_NAME);
 			if (override != null && !override.isEmpty()) return override;

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -148,8 +148,12 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		}
 		
 		String replaceBuilderClassName(Name name) {
-			if (builderClassName.indexOf('*') == -1) return builderClassName;
-			return builderClassName.replace("*", name.toString());
+			return replaceBuilderClassName(name.toString(), builderClassName);
+		}
+		
+		String replaceBuilderClassName(String name, String template) {
+			if (template.indexOf('*') == -1) return template;
+			return template.replace("*", name);
 		}
 		
 		JCExpression createBuilderParentTypeReference() {

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -113,7 +113,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			
 			if (builderMethodName == null) builderMethodName = "builder";
 			if (buildMethodName == null) buildMethodName = "build";
-			builderClassName = fixBuilderClassName(node, "");
+			builderClassName = getBuilderClassNameTemplate(node, null);
 		}
 		
 		void setBuilderToImpl() {
@@ -257,11 +257,11 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		}
 		if (extendsClause instanceof JCFieldAccess) {
 			Name superclassName = ((JCFieldAccess) extendsClause).getIdentifier();
-			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(superclassName.toString(), builderClassNameTemplate);
 			superclassBuilderClass = parent.getTreeMaker().Select((JCFieldAccess) extendsClause, parent.toName(superclassBuilderClassName));
 		} else if (extendsClause != null) {
-			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(extendsClause.toString(), builderClassNameTemplate);
 			superclassBuilderClass = chainDots(parent, extendsClause.toString(), superclassBuilderClassName);
 		}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -257,10 +257,12 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		}
 		if (extendsClause instanceof JCFieldAccess) {
 			Name superclassName = ((JCFieldAccess) extendsClause).getIdentifier();
-			String superclassBuilderClassName = superclassName.toString() + "Builder";
+			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String superclassBuilderClassName = job.replaceBuilderClassName(superclassName.toString(), builderClassNameTemplate);
 			superclassBuilderClass = parent.getTreeMaker().Select((JCFieldAccess) extendsClause, parent.toName(superclassBuilderClassName));
 		} else if (extendsClause != null) {
-			String superclassBuilderClassName = extendsClause.toString() + "Builder";
+			String builderClassNameTemplate = BuilderJob.fixBuilderClassName(annotationNode, "");
+			String superclassBuilderClassName = job.replaceBuilderClassName(extendsClause.toString(), builderClassNameTemplate);
 			superclassBuilderClass = chainDots(parent, extendsClause.toString(), superclassBuilderClassName);
 		}
 		

--- a/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderClassName.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderClassName.java
@@ -1,0 +1,79 @@
+class SuperBuilderWithCustomBuilderClassName {
+	static class SuperClass {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class Builder<C extends SuperBuilderWithCustomBuilderClassName.SuperClass, B extends SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<C, B>> {
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithCustomBuilderClassName.SuperClass.Builder()";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class BuilderImpl extends SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<SuperBuilderWithCustomBuilderClassName.SuperClass, SuperBuilderWithCustomBuilderClassName.SuperClass.BuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private BuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected SuperBuilderWithCustomBuilderClassName.SuperClass.BuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public SuperBuilderWithCustomBuilderClassName.SuperClass build() {
+				return new SuperBuilderWithCustomBuilderClassName.SuperClass(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected SuperClass(final SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<?, ?> b) {
+		}
+		@java.lang.SuppressWarnings("all")
+		public static SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<?, ?> builder() {
+			return new SuperBuilderWithCustomBuilderClassName.SuperClass.BuilderImpl();
+		}
+	}
+	static class SubClass extends SuperClass {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class Builder<C extends SuperBuilderWithCustomBuilderClassName.SubClass, B extends SuperBuilderWithCustomBuilderClassName.SubClass.Builder<C, B>> extends SuperClass.Builder<C, B> {
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithCustomBuilderClassName.SubClass.Builder(super=" + super.toString() + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class BuilderImpl extends SuperBuilderWithCustomBuilderClassName.SubClass.Builder<SuperBuilderWithCustomBuilderClassName.SubClass, SuperBuilderWithCustomBuilderClassName.SubClass.BuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private BuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected SuperBuilderWithCustomBuilderClassName.SubClass.BuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public SuperBuilderWithCustomBuilderClassName.SubClass build() {
+				return new SuperBuilderWithCustomBuilderClassName.SubClass(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected SubClass(final SuperBuilderWithCustomBuilderClassName.SubClass.Builder<?, ?> b) {
+			super(b);
+		}
+		@java.lang.SuppressWarnings("all")
+		public static SuperBuilderWithCustomBuilderClassName.SubClass.Builder<?, ?> builder() {
+			return new SuperBuilderWithCustomBuilderClassName.SubClass.BuilderImpl();
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderClassName.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderClassName.java
@@ -1,0 +1,63 @@
+class SuperBuilderWithCustomBuilderClassName {
+  static @lombok.experimental.SuperBuilder class SuperClass {
+    public static abstract @java.lang.SuppressWarnings("all") class Builder<C extends SuperBuilderWithCustomBuilderClassName.SuperClass, B extends SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<C, B>> {
+      public Builder() {
+        super();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return "SuperBuilderWithCustomBuilderClassName.SuperClass.Builder()";
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class BuilderImpl extends SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<SuperBuilderWithCustomBuilderClassName.SuperClass, SuperBuilderWithCustomBuilderClassName.SuperClass.BuilderImpl> {
+      private BuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithCustomBuilderClassName.SuperClass.BuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithCustomBuilderClassName.SuperClass build() {
+        return new SuperBuilderWithCustomBuilderClassName.SuperClass(this);
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") SuperClass(final SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<?, ?> b) {
+      super();
+    }
+    public static @java.lang.SuppressWarnings("all") SuperBuilderWithCustomBuilderClassName.SuperClass.Builder<?, ?> builder() {
+      return new SuperBuilderWithCustomBuilderClassName.SuperClass.BuilderImpl();
+    }
+  }
+  static @lombok.experimental.SuperBuilder class SubClass extends SuperClass {
+    public static abstract @java.lang.SuppressWarnings("all") class Builder<C extends SuperBuilderWithCustomBuilderClassName.SubClass, B extends SuperBuilderWithCustomBuilderClassName.SubClass.Builder<C, B>> extends SuperClass.Builder<C, B> {
+      public Builder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderWithCustomBuilderClassName.SubClass.Builder(super=" + super.toString()) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class BuilderImpl extends SuperBuilderWithCustomBuilderClassName.SubClass.Builder<SuperBuilderWithCustomBuilderClassName.SubClass, SuperBuilderWithCustomBuilderClassName.SubClass.BuilderImpl> {
+      private BuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithCustomBuilderClassName.SubClass.BuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithCustomBuilderClassName.SubClass build() {
+        return new SuperBuilderWithCustomBuilderClassName.SubClass(this);
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") SubClass(final SuperBuilderWithCustomBuilderClassName.SubClass.Builder<?, ?> b) {
+      super(b);
+    }
+    public static @java.lang.SuppressWarnings("all") SuperBuilderWithCustomBuilderClassName.SubClass.Builder<?, ?> builder() {
+      return new SuperBuilderWithCustomBuilderClassName.SubClass.BuilderImpl();
+    }
+  }
+  SuperBuilderWithCustomBuilderClassName() {
+    super();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderWithCustomBuilderClassName.java
+++ b/test/transform/resource/before/SuperBuilderWithCustomBuilderClassName.java
@@ -1,0 +1,9 @@
+//CONF: lombok.builder.className=Builder
+class SuperBuilderWithCustomBuilderClassName {
+	@lombok.experimental.SuperBuilder
+	static class SuperClass {
+	}
+	@lombok.experimental.SuperBuilder
+	static class SubClass extends SuperClass {
+	}
+}


### PR DESCRIPTION
`@SuperBuilder` now correctly considers `lombok.builder.className` when generating the `extends` clause for the abstract builder class.
This PR fixes #2647.