### PR TITLE
Remove multiline Javadoc tags

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -761,11 +761,20 @@ public class HandlerUtil {
 	private static final Pattern SECTION_FINDER = Pattern.compile("^\\s*\\**\\s*[-*][-*]+\\s*([GS]ETTER|WITH(?:ER)?)\\s*[-*][-*]+\\s*\\**\\s*$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 	private static final Pattern LINE_BREAK_FINDER = Pattern.compile("(\\r?\\n)?");
 	
-	public static String stripLinesWithTagFromJavadoc(String javadoc, String regexpFragment) {
+	public enum JavadocTag {
+		PARAM("@param(?:eter)?"),
+		RETURN("@returns?");
+		
+		private Pattern pattern;
+		
+		JavadocTag(String regexpFragment) {
+			pattern = Pattern.compile("\\s?^[ \\t]*\\**[ \\t]*" + regexpFragment + "(\\S|\\s)*?(?=(\\s^\\s*\\**\\s*@|\\Z))", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+		}
+	}
+	
+	public static String stripLinesWithTagFromJavadoc(String javadoc, JavadocTag tag) {
 		if (javadoc == null || javadoc.isEmpty()) return javadoc;
-		Pattern p = Pattern.compile("^\\s*\\**\\s*" + regexpFragment + "\\s*\\**\\s*$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
-		Matcher m = p.matcher(javadoc);
-		return m.replaceAll("");
+		return tag.pattern.matcher(javadoc).replaceAll("");
 	}
 	
 	public static String stripSectionsFromJavadoc(String javadoc) {

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -2688,7 +2688,7 @@ public class EclipseHandlerUtil {
 				String out = getJavadocSection(javadoc, "GETTER");
 				final boolean sectionBased = out != null;
 				if (!sectionBased) {
-					out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), "@param(?:eter)?\\s+.*");
+					out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.PARAM);
 				}
 				return out;
 			}
@@ -2718,7 +2718,7 @@ public class EclipseHandlerUtil {
 			String out = getJavadocSection(javadoc, sectionName);
 			final boolean sectionBased = out != null;
 			if (!sectionBased) {
-				out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), "@returns?\\s+.*");
+				out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.RETURN);
 			}
 			return shouldReturnThis(node) ? addReturnsThisIfNeeded(out) : out;
 		}

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -2044,7 +2044,7 @@ public class JavacHandlerUtil {
 				String out = getJavadocSection(javadoc, "GETTER");
 				final boolean sectionBased = out != null;
 				if (!sectionBased) {
-					out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), "@param(?:eter)?\\s+.*");
+					out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.PARAM);
 				}
 				node.getAst().cleanupTask("javadocfilter-getter", n, new CleanupTask() {
 					@Override public void cleanup() {
@@ -2052,7 +2052,7 @@ public class JavacHandlerUtil {
 						if (javadoc == null || javadoc.isEmpty()) return;
 						javadoc = stripSectionsFromJavadoc(javadoc);
 						if (!sectionBased) {
-							javadoc = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), "@returns?\\s+.*");
+							javadoc = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.RETURN);
 						}
 						Javac.setDocComment(cu, n, javadoc);
 					}
@@ -2085,7 +2085,7 @@ public class JavacHandlerUtil {
 			String out = getJavadocSection(javadoc, sectionName);
 			final boolean sectionBased = out != null;
 			if (!sectionBased) {
-				out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), "@returns?\\s+.*");
+				out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.RETURN);
 			}
 			node.getAst().cleanupTask("javadocfilter-setter", n, new CleanupTask() {
 				@Override public void cleanup() {
@@ -2093,7 +2093,7 @@ public class JavacHandlerUtil {
 					if (javadoc == null || javadoc.isEmpty()) return;
 					javadoc = stripSectionsFromJavadoc(javadoc);
 					if (!sectionBased) {
-						javadoc = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), "@param(?:eter)?\\s+.*");
+						javadoc = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.PARAM);
 					}
 					Javac.setDocComment(cu, n, javadoc);
 				}

--- a/test/transform/resource/after-delombok/BuilderJavadoc.java
+++ b/test/transform/resource/after-delombok/BuilderJavadoc.java
@@ -3,7 +3,6 @@ class BuilderJavadoc<T> {
 	/**
 	 * basic gets only a builder setter.
 	 * @see #getsetwith
-	 *
 	 * @return tag is removed from the setter.
 	 */
 	private final int basic;
@@ -92,7 +91,6 @@ class BuilderJavadoc<T> {
 	}
 	/**
 	 * getsetwith gets a builder setter, an instance getter and setter, and a wither.
-	 *
 	 * @return tag is moved to the getter.
 	 */
 	@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/JavadocMultiline.java
+++ b/test/transform/resource/after-delombok/JavadocMultiline.java
@@ -1,0 +1,51 @@
+class JavadocMultiline {
+    /**
+     * This is a list of booleans.
+     */
+    private java.util.List<Boolean> booleans;
+    /**
+     * This is a list of booleans.
+     */
+    private java.util.List<Boolean> booleans2;
+
+    /**
+     * This is a list of booleans.
+     *
+     * @return A list of booleans to set for this object. This is a Javadoc return that is long
+     *         enough to wrap to multiple lines.
+     */
+    @java.lang.SuppressWarnings("all")
+    public java.util.List<Boolean> getBooleans() {
+        return this.booleans;
+    }
+
+    /**
+     * This is a list of booleans.
+     */
+    @java.lang.SuppressWarnings("all")
+    public java.util.List<Boolean> getBooleans2() {
+        return this.booleans2;
+    }
+
+    /**
+     * This is a list of booleans.
+     *
+     * @param booleans A list of booleans to set for this object. This is a Javadoc param that is
+     *        long enough to wrap to multiple lines.
+     */
+    @java.lang.SuppressWarnings("all")
+    public void setBooleans(final java.util.List<Boolean> booleans) {
+        this.booleans = booleans;
+    }
+
+    /**
+     * This is a list of booleans.
+     *
+     * @param booleans A list of booleans to set for this object. This is a Javadoc param that is
+     *        long enough to wrap to multiple lines.
+     */
+    @java.lang.SuppressWarnings("all")
+    public void setBooleans2(final java.util.List<Boolean> booleans2) {
+        this.booleans2 = booleans2;
+    }
+}

--- a/test/transform/resource/after-ecj/BuilderJavadoc.java
+++ b/test/transform/resource/after-ecj/BuilderJavadoc.java
@@ -58,7 +58,6 @@ import java.util.List;
   }
   /**
    * getsetwith gets a builder setter, an instance getter and setter, and a wither.
-   *
    * @return tag is moved to the getter.
    */
   public @java.lang.SuppressWarnings("all") int getGetsetwith() {

--- a/test/transform/resource/after-ecj/JavadocMultiline.java
+++ b/test/transform/resource/after-ecj/JavadocMultiline.java
@@ -1,0 +1,40 @@
+@lombok.Getter @lombok.Setter class JavadocMultiline {
+  private java.util.List<Boolean> booleans;
+  private java.util.List<Boolean> booleans2;
+  JavadocMultiline() {
+    super();
+  }
+  /**
+   * This is a list of booleans.
+   * 
+   * @return A list of booleans to set for this object. This is a Javadoc return that is long
+   *         enough to wrap to multiple lines.
+   */
+  public @java.lang.SuppressWarnings("all") java.util.List<Boolean> getBooleans() {
+    return this.booleans;
+  }
+  /**
+   * This is a list of booleans.
+   */
+  public @java.lang.SuppressWarnings("all") java.util.List<Boolean> getBooleans2() {
+    return this.booleans2;
+  }
+  /**
+   * This is a list of booleans.
+   * 
+   * @param booleans A list of booleans to set for this object. This is a Javadoc param that is
+   *        long enough to wrap to multiple lines.
+   */
+  public @java.lang.SuppressWarnings("all") void setBooleans(final java.util.List<Boolean> booleans) {
+    this.booleans = booleans;
+  }
+  /**
+   * This is a list of booleans.
+   * 
+   * @param booleans A list of booleans to set for this object. This is a Javadoc param that is
+   *        long enough to wrap to multiple lines.
+   */
+  public @java.lang.SuppressWarnings("all") void setBooleans2(final java.util.List<Boolean> booleans2) {
+    this.booleans2 = booleans2;
+  }
+}

--- a/test/transform/resource/before/JavadocMultiline.java
+++ b/test/transform/resource/before/JavadocMultiline.java
@@ -1,0 +1,22 @@
+@lombok.Getter
+@lombok.Setter
+class JavadocMultiline {
+    /**
+     * This is a list of booleans.
+     *
+     * @param booleans A list of booleans to set for this object. This is a Javadoc param that is
+     *        long enough to wrap to multiple lines.
+     * @return A list of booleans to set for this object. This is a Javadoc return that is long
+     *         enough to wrap to multiple lines.
+     */
+    private java.util.List<Boolean> booleans;
+    
+    
+    /**
+     * This is a list of booleans.
+     *
+     * @param booleans A list of booleans to set for this object. This is a Javadoc param that is
+     *        long enough to wrap to multiple lines.
+     */
+    private java.util.List<Boolean> booleans2;
+}


### PR DESCRIPTION
This PR fixes #2443.

I have a few general improvements for the javadoc handling in mind but it will take some time until I have implemented them.