### PR TITLE
[fixes #2724] Increase priority of Builder annotation removal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Maarten Mulders <mthmulders@users.noreply.github.com>
 Mark Haynes <markhaynes.work@gmail.com>
 Mart Hagenaars <marthagenaars@gmail.com>
 Mateusz Matela <mateusz.matela@gmail.com>
+Michael Dardis <git@md-5.net>
 Michael Ernst <mernst@alum.mit.edu>
 Michiel Verheul <cheelio@gmail.com>
 Pascal Bihler <pascal@qfs.de>
@@ -49,4 +50,4 @@ Till Brychcy <till.brychcy@mercateo.com>
 Victor Williams Stafusa da Silva <victorwssilva@gmail.com>
 Yun Zhi Lin <yun@yunspace.com>
 
-By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok, and you certify that you have the right to do so for all commits you add to Project Lombok.
+By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok in relation to all commits you add to Project Lombok, and you certify that you have the right to do so.

--- a/src/core/lombok/javac/handlers/HandleBuilderDefaultRemove.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderDefaultRemove.java
@@ -35,7 +35,7 @@ import lombok.javac.JavacNode;
 import lombok.spi.Provides;
 
 @Provides
-@HandlerPriority(65536)
+@HandlerPriority(32768)
 @AlreadyHandledAnnotations
 public class HandleBuilderDefaultRemove extends JavacAnnotationHandler<Builder.Default> {
 	@Override public void handle(AnnotationValues<Default> annotation, JCAnnotation ast, JavacNode annotationNode) {

--- a/src/core/lombok/javac/handlers/HandleBuilderRemove.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderRemove.java
@@ -34,7 +34,7 @@ import lombok.javac.JavacNode;
 import lombok.spi.Provides;
 
 @Provides
-@HandlerPriority(65536)
+@HandlerPriority(32768)
 @AlreadyHandledAnnotations
 public class HandleBuilderRemove extends JavacAnnotationHandler<Builder> {
 	@Override public void handle(AnnotationValues<Builder> annotation, JCAnnotation ast, JavacNode annotationNode) {

--- a/src/core/lombok/javac/handlers/HandleSuperBuilderRemove.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilderRemove.java
@@ -34,7 +34,7 @@ import lombok.javac.JavacNode;
 import lombok.spi.Provides;
 
 @Provides
-@HandlerPriority(65536)
+@HandlerPriority(32768)
 @AlreadyHandledAnnotations
 public class HandleSuperBuilderRemove extends JavacAnnotationHandler<SuperBuilder> {
 	@Override public void handle(AnnotationValues<SuperBuilder> annotation, JCAnnotation ast, JavacNode annotationNode) {

--- a/test/transform/resource/after-delombok/BuilderAccessWithGetter.java
+++ b/test/transform/resource/after-delombok/BuilderAccessWithGetter.java
@@ -1,0 +1,49 @@
+public final class BuilderAccessWithGetter {
+    private final String string;
+
+    @java.lang.SuppressWarnings("all")
+    BuilderAccessWithGetter(final String string) {
+        this.string = string;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    private static class BuilderAccessWithGetterBuilder {
+        @java.lang.SuppressWarnings("all")
+        private String string;
+
+        @java.lang.SuppressWarnings("all")
+        BuilderAccessWithGetterBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        private BuilderAccessWithGetter.BuilderAccessWithGetterBuilder string(final String string) {
+            this.string = string;
+            return this;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        private BuilderAccessWithGetter build() {
+            return new BuilderAccessWithGetter(this.string);
+        }
+
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        public java.lang.String toString() {
+            return "BuilderAccessWithGetter.BuilderAccessWithGetterBuilder(string=" + this.string + ")";
+        }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    private static BuilderAccessWithGetter.BuilderAccessWithGetterBuilder builder() {
+        return new BuilderAccessWithGetter.BuilderAccessWithGetterBuilder();
+    }
+
+    @java.lang.SuppressWarnings("all")
+    public String getString() {
+        return this.string;
+    }
+}

--- a/test/transform/resource/after-delombok/BuilderDefaultsWarnings.java
+++ b/test/transform/resource/after-delombok/BuilderDefaultsWarnings.java
@@ -1,6 +1,4 @@
 //skip-idempotent
-import lombok.Builder;
-@Builder
 public class BuilderDefaultsWarnings {
 	long x = System.currentTimeMillis();
 	final int y = 5;
@@ -87,7 +85,6 @@ public class BuilderDefaultsWarnings {
 }
 class NoBuilderButHasDefaults {
 	private final long z = 5;
-	@Builder
 	public NoBuilderButHasDefaults() {
 	}
 	@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/BuilderSingularNoAuto.java
+++ b/test/transform/resource/after-delombok/BuilderSingularNoAuto.java
@@ -1,6 +1,5 @@
 //skip-idempotent
 import java.util.List;
-@lombok.Builder
 class BuilderSingularNoAuto {
 	private List<String> things;
 	private List<String> widgets;

--- a/test/transform/resource/after-delombok/BuilderSingularNoAutoWithSetterPrefix.java
+++ b/test/transform/resource/after-delombok/BuilderSingularNoAutoWithSetterPrefix.java
@@ -1,6 +1,5 @@
 //skip-idempotent
 import java.util.List;
-@lombok.Builder(setterPrefix = "with")
 class BuilderSingularNoAutoWithSetterPrefix {
 	private List<String> things;
 	private List<String> widgets;

--- a/test/transform/resource/after-delombok/JacksonizedSuperBuilderWithJsonDeserialize.java
+++ b/test/transform/resource/after-delombok/JacksonizedSuperBuilderWithJsonDeserialize.java
@@ -1,5 +1,4 @@
 //skip-idempotent
-@lombok.experimental.SuperBuilder
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize
 public class JacksonizedSuperBuilderWithJsonDeserialize {
 	int field1;

--- a/test/transform/resource/after-ecj/BuilderAccessWithGetter.java
+++ b/test/transform/resource/after-ecj/BuilderAccessWithGetter.java
@@ -1,0 +1,35 @@
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+public final @Builder(access = AccessLevel.PRIVATE) class BuilderAccessWithGetter {
+  private static @java.lang.SuppressWarnings("all") class BuilderAccessWithGetterBuilder {
+    private @java.lang.SuppressWarnings("all") String string;
+    @java.lang.SuppressWarnings("all") BuilderAccessWithGetterBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    private @java.lang.SuppressWarnings("all") BuilderAccessWithGetter.BuilderAccessWithGetterBuilder string(final String string) {
+      this.string = string;
+      return this;
+    }
+    private @java.lang.SuppressWarnings("all") BuilderAccessWithGetter build() {
+      return new BuilderAccessWithGetter(this.string);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("BuilderAccessWithGetter.BuilderAccessWithGetterBuilder(string=" + this.string) + ")");
+    }
+  }
+  private final @Getter String string;
+  @java.lang.SuppressWarnings("all") BuilderAccessWithGetter(final String string) {
+    super();
+    this.string = string;
+  }
+  private static @java.lang.SuppressWarnings("all") BuilderAccessWithGetter.BuilderAccessWithGetterBuilder builder() {
+    return new BuilderAccessWithGetter.BuilderAccessWithGetterBuilder();
+  }
+  public @java.lang.SuppressWarnings("all") String getString() {
+    return this.string;
+  }
+}

--- a/test/transform/resource/before/BuilderAccessWithGetter.java
+++ b/test/transform/resource/before/BuilderAccessWithGetter.java
@@ -1,0 +1,10 @@
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder(access = AccessLevel.PRIVATE)
+public final class BuilderAccessWithGetter {
+
+    @Getter
+    private final String string;
+}


### PR DESCRIPTION
Otherwise they may run after `HandleDelegate`. This is problematic as
`HandleDelegate` parses the compulation unit and `@Builder` may contain imports
(eg `AccessLevel`) that were already removed by other processors, eg `@Getter`.

fixes #2724