### PR TITLE
Add end positions to all generated nodes

### DIFF
--- a/src/core/lombok/javac/handlers/HandleBuilderDefault.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderDefault.java
@@ -55,6 +55,7 @@ public class HandleBuilderDefault extends JavacAnnotationHandler<Builder.Default
 			JCFieldAccess jfa = (JCFieldAccess) ast.annotationType;
 			if (jfa.selected instanceof JCIdent && ((JCIdent) jfa.selected).name.contentEquals("Builder") && jfa.name.contentEquals("Default")) {
 				JCFieldAccess newJfaSel = annotationNode.getTreeMaker().Select(annotationNode.getTreeMaker().Ident(annotationNode.toName("lombok")), ((JCIdent) jfa.selected).name);
+				recursiveSetGeneratedBy(newJfaSel, annotationNode);
 				jfa.selected = newJfaSel;
 			}
 		}

--- a/src/core/lombok/javac/handlers/HandleCleanup.java
+++ b/src/core/lombok/javac/handlers/HandleCleanup.java
@@ -52,7 +52,6 @@ import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCTypeCast;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
-import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
@@ -129,10 +128,9 @@ public class HandleCleanup extends JavacAnnotationHandler<Cleanup> {
 		
 		JCIf ifNotNullCleanup = maker.If(isNull, maker.Block(0, cleanupCall), null);
 		
-		Context context = annotationNode.getContext();
-		JCBlock finalizer = recursiveSetGeneratedBy(maker.Block(0, List.<JCStatement>of(ifNotNullCleanup)), ast, context);
+		JCBlock finalizer = recursiveSetGeneratedBy(maker.Block(0, List.<JCStatement>of(ifNotNullCleanup)), annotationNode);
 		
-		newStatements.append(setGeneratedBy(maker.Try(setGeneratedBy(maker.Block(0, tryBlock.toList()), ast, context), List.<JCCatch>nil(), finalizer), ast, context));
+		newStatements.append(setGeneratedBy(maker.Try(setGeneratedBy(maker.Block(0, tryBlock.toList()), annotationNode), List.<JCCatch>nil(), finalizer), annotationNode));
 		
 		if (blockNode instanceof JCBlock) {
 			((JCBlock)blockNode).stats = newStatements.toList();

--- a/src/core/lombok/javac/handlers/HandleDelegate.java
+++ b/src/core/lombok/javac/handlers/HandleDelegate.java
@@ -349,7 +349,7 @@ public class HandleDelegate extends JavacAnnotationHandler<Delegate> {
 		JCStatement body = useReturn ? maker.Return(delegateCall) : maker.Exec(delegateCall);
 		JCBlock bodyBlock = maker.Block(0, com.sun.tools.javac.util.List.of(body));
 		
-		return recursiveSetGeneratedBy(maker.MethodDef(mods, sig.name, returnType, toList(typeParams), toList(params), toList(thrown), bodyBlock, null), annotation.get(), annotation.getContext());
+		return recursiveSetGeneratedBy(maker.MethodDef(mods, sig.name, returnType, toList(typeParams), toList(params), toList(thrown), bodyBlock, null), annotation);
 	}
 	
 	public static <T> com.sun.tools.javac.util.List<T> toList(ListBuffer<T> collection) {

--- a/src/core/lombok/javac/handlers/HandleExtensionMethod.java
+++ b/src/core/lombok/javac/handlers/HandleExtensionMethod.java
@@ -202,6 +202,7 @@ public class HandleExtensionMethod extends JavacAnnotationHandler<ExtensionMetho
 					if (!types.isAssignable(receiverType, firstArgType)) continue;
 					methodCall.args = methodCall.args.prepend(receiver);
 					methodCall.meth = chainDotsString(annotationNode, extensionProvider.toString() + "." + methodName);
+					recursiveSetGeneratedBy(methodCall.meth, methodCallNode);
 					return;
 				}
 			}

--- a/src/core/lombok/javac/handlers/HandleFieldNameConstants.java
+++ b/src/core/lombok/javac/handlers/HandleFieldNameConstants.java
@@ -78,7 +78,7 @@ public class HandleFieldNameConstants extends JavacAnnotationHandler<FieldNameCo
 		if (qualified.isEmpty()) {
 			errorNode.addWarning("No fields qualify for @FieldNameConstants, therefore this annotation does nothing");
 		} else {
-			createInnerTypeFieldNameConstants(typeNode, errorNode, errorNode.get(), level, qualified, asEnum, innerTypeName, uppercase);
+			createInnerTypeFieldNameConstants(typeNode, errorNode, level, qualified, asEnum, innerTypeName, uppercase);
 		}
 	}
 	
@@ -133,7 +133,7 @@ public class HandleFieldNameConstants extends JavacAnnotationHandler<FieldNameCo
 		generateFieldNameConstantsForType(node, annotationNode, level, asEnum, innerTypeName, annotationInstance.onlyExplicitlyIncluded(), uppercase);
 	}
 	
-	private void createInnerTypeFieldNameConstants(JavacNode typeNode, JavacNode errorNode, JCTree pos, AccessLevel level, java.util.List<JavacNode> fields, boolean asEnum, IdentifierName innerTypeName, boolean uppercase) {
+	private void createInnerTypeFieldNameConstants(JavacNode typeNode, JavacNode errorNode, AccessLevel level, java.util.List<JavacNode> fields, boolean asEnum, IdentifierName innerTypeName, boolean uppercase) {
 		if (fields.isEmpty()) return;
 		
 		JavacTreeMaker maker = typeNode.getTreeMaker();
@@ -146,7 +146,7 @@ public class HandleFieldNameConstants extends JavacAnnotationHandler<FieldNameCo
 		if (fieldsType == null) {
 			JCClassDecl innerType = maker.ClassDef(mods, fieldsName, List.<JCTypeParameter>nil(), null, List.<JCExpression>nil(), List.<JCTree>nil());
 			fieldsType = injectType(typeNode, innerType);
-			recursiveSetGeneratedBy(innerType, pos, typeNode.getContext());
+			recursiveSetGeneratedBy(innerType, errorNode);
 			genConstr = true;
 		} else {
 			JCClassDecl builderTypeDeclaration = (JCClassDecl) fieldsType.get();
@@ -166,7 +166,7 @@ public class HandleFieldNameConstants extends JavacAnnotationHandler<FieldNameCo
 			JCModifiers genConstrMods = maker.Modifiers(Flags.GENERATEDCONSTR | (asEnum ? 0L : Flags.PRIVATE));
 			JCBlock genConstrBody = maker.Block(0L, List.<JCStatement>of(maker.Exec(maker.Apply(List.<JCExpression>nil(), maker.Ident(typeNode.toName("super")), List.<JCExpression>nil()))));
 			JCMethodDecl c = maker.MethodDef(genConstrMods, typeNode.toName("<init>"), null, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), genConstrBody, null);
-			recursiveSetGeneratedBy(c, pos, typeNode.getContext());
+			recursiveSetGeneratedBy(c, errorNode);
 			injectMethod(fieldsType, c);
 		}
 		
@@ -187,9 +187,9 @@ public class HandleFieldNameConstants extends JavacAnnotationHandler<FieldNameCo
 			}
 			JCVariableDecl constantField = maker.VarDef(constantValueMods, fName, returnType, init);
 			injectField(fieldsType, constantField, false, true);
-			setGeneratedBy(constantField, pos, typeNode.getContext());
+			setGeneratedBy(constantField, errorNode);
 			generated.add(constantField);
 		}
-		for (JCVariableDecl cf : generated) recursiveSetGeneratedBy(cf, pos, typeNode.getContext());
+		for (JCVariableDecl cf : generated) recursiveSetGeneratedBy(cf, errorNode);
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleHelper.java
+++ b/src/core/lombok/javac/handlers/HandleHelper.java
@@ -71,7 +71,7 @@ public class HandleHelper extends JavacAnnotationHandler<Helper> {
 		else throw new IllegalArgumentException("Can't set statements on node type: " + tree.getClass());
 	}
 	
-	@Override public void handle(AnnotationValues<Helper> annotation, JCAnnotation ast, JavacNode annotationNode) {
+	@Override public void handle(AnnotationValues<Helper> annotation, JCAnnotation ast, final JavacNode annotationNode) {
 		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.HELPER_FLAG_USAGE, "@Helper");
 		
 		deleteAnnotationIfNeccessary(annotationNode, Helper.class);
@@ -120,6 +120,7 @@ public class HandleHelper extends JavacAnnotationHandler<Helper> {
 				JCIdent jci = (JCIdent) jcmi.meth;
 				if (Arrays.binarySearch(knownMethodNames_, jci.name.toString()) < 0) return;
 				jcmi.meth = maker.Select(maker.Ident(helperName), jci.name);
+				recursiveSetGeneratedBy(jcmi.meth, annotationNode);
 				helperUsed[0] = true;
 			}
 		};
@@ -144,6 +145,7 @@ public class HandleHelper extends JavacAnnotationHandler<Helper> {
 			JCExpression init = maker.NewClass(null, List.<JCExpression>nil(), maker.Ident(annotatedType_.name), List.<JCExpression>nil(), null);
 			JCExpression varType = maker.Ident(annotatedType_.name);
 			JCVariableDecl decl = maker.VarDef(maker.Modifiers(Flags.FINAL), helperName, varType, init);
+			recursiveSetGeneratedBy(decl, annotationNode);
 			newStatements.append(decl);
 		}
 		setStatementsOfJcNode(containingBlock.get(), newStatements.toList());

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -39,7 +39,6 @@ import lombok.javac.handlers.JavacHandlerUtil.MemberExistsResult;
 import org.mangosdk.spi.ProviderFor;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
@@ -90,7 +89,7 @@ public class HandleLog {
 			}
 			
 			JCFieldAccess loggingType = selfType(typeNode);
-			createField(framework, typeNode, loggingType, annotationNode.get(), logFieldName.getName(), useStatic, loggerTopic);
+			createField(framework, typeNode, loggingType, annotationNode, logFieldName.getName(), useStatic, loggerTopic);
 			break;
 		default:
 			annotationNode.addError("@Log is legal only on types.");
@@ -104,7 +103,7 @@ public class HandleLog {
 		return maker.Select(maker.Ident(name), typeNode.toName("class"));
 	}
 	
-	private static boolean createField(LoggingFramework framework, JavacNode typeNode, JCFieldAccess loggingType, JCTree source, String logFieldName, boolean useStatic, JCExpression loggerTopic) {
+	private static boolean createField(LoggingFramework framework, JavacNode typeNode, JCFieldAccess loggingType, JavacNode source, String logFieldName, boolean useStatic, JCExpression loggerTopic) {
 		JavacTreeMaker maker = typeNode.getTreeMaker();
 		
 		LogDeclaration logDeclaration = framework.getDeclaration();
@@ -118,7 +117,7 @@ public class HandleLog {
 		
 		JCVariableDecl fieldDecl = recursiveSetGeneratedBy(maker.VarDef(
 			maker.Modifiers(Flags.PRIVATE | Flags.FINAL | (useStatic ? Flags.STATIC : 0)),
-			typeNode.toName(logFieldName), loggerType, factoryMethodCall), source, typeNode.getContext());
+			typeNode.toName(logFieldName), loggerType, factoryMethodCall), source);
 		
 		injectFieldAndMarkGenerated(typeNode, fieldDecl);
 		return true;

--- a/src/core/lombok/javac/handlers/HandleNonNull.java
+++ b/src/core/lombok/javac/handlers/HandleNonNull.java
@@ -111,7 +111,7 @@ public class HandleNonNull extends JavacAnnotationHandler<NonNull> {
 		// and if they exist, create a new method in the class: 'private static <T> T lombok$nullCheck(T expr, String msg) {if (expr == null) throw NPE; return expr;}' and
 		// wrap all references to it in the super/this to a call to this method.
 		
-		JCStatement nullCheck = recursiveSetGeneratedBy(generateNullCheck(annotationNode.getTreeMaker(), paramNode, annotationNode), ast, annotationNode.getContext());
+		JCStatement nullCheck = recursiveSetGeneratedBy(generateNullCheck(annotationNode.getTreeMaker(), paramNode, annotationNode), annotationNode);
 		
 		if (nullCheck == null) {
 			// @NonNull applied to a primitive. Kinda pointless. Let's generate a warning.

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -220,7 +220,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			List<JCAnnotation> annotations = d.mods.annotations;
 			if (annotations == null) annotations = List.nil();
 			JCAnnotation anno = treeMaker.Annotation(genTypeRef(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
-			recursiveSetGeneratedBy(anno, source.get(), field.getContext());
+			recursiveSetGeneratedBy(anno, source);
 			d.mods.annotations = annotations.prepend(anno);
 		}
 		return d;
@@ -239,7 +239,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			List<JCAnnotation> annotations = d.mods.annotations;
 			if (annotations == null) annotations = List.nil();
 			JCAnnotation anno = treeMaker.Annotation(genTypeRef(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
-			recursiveSetGeneratedBy(anno, source.get(), field.getContext());
+			recursiveSetGeneratedBy(anno, source);
 			d.mods.annotations = annotations.prepend(anno);
 		}
 		return d;
@@ -265,7 +265,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		List<JCAnnotation> annsOnParam = copyAnnotations(onParam).appendList(copyableAnnotations);
 		
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, field.getContext());
-		JCExpression pType = cloneType(treeMaker, fieldDecl.vartype, source.get(), source.getContext());
+		JCExpression pType = cloneType(treeMaker, fieldDecl.vartype, source);
 		JCVariableDecl param = treeMaker.VarDef(treeMaker.Modifiers(flags, annsOnParam), paramName, pType, null);
 		
 		if (!hasNonNullAnnotations(field) && !hasNonNullAnnotations(field, onParam)) {
@@ -309,7 +309,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 				methodGenericParams, parameters, throwsClauses, methodBody, annotationMethodDefaultValue);
 		}
 		if (returnStatement != null) createRelevantNonNullAnnotation(source, methodDef);
-		JCMethodDecl decl = recursiveSetGeneratedBy(methodDef, source.get(), field.getContext());
+		JCMethodDecl decl = recursiveSetGeneratedBy(methodDef, source);
 		copyJavadoc(field, decl, CopyJavadoc.SETTER, returnStatement != null);
 		return decl;
 	}

--- a/src/core/lombok/javac/handlers/HandleSynchronized.java
+++ b/src/core/lombok/javac/handlers/HandleSynchronized.java
@@ -46,7 +46,6 @@ import com.sun.tools.javac.tree.JCTree.JCNewArray;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
-import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 
 /**
@@ -87,7 +86,6 @@ public class HandleSynchronized extends JavacAnnotationHandler<Synchronized> {
 		}
 		
 		JavacTreeMaker maker = methodNode.getTreeMaker().at(ast.pos);
-		Context context = methodNode.getContext();
 		
 		JavacNode typeNode = upToTypeNode(annotationNode);
 		
@@ -120,7 +118,7 @@ public class HandleSynchronized extends JavacAnnotationHandler<Synchronized> {
 				List.<JCExpression>of(maker.Literal(CTC_INT, 0)), null);
 			JCVariableDecl fieldDecl = recursiveSetGeneratedBy(maker.VarDef(
 				maker.Modifiers(Flags.PRIVATE | Flags.FINAL | (isStatic[0] ? Flags.STATIC : 0)),
-				methodNode.toName(lockName), objectType, newObjectArray), ast, context);
+				methodNode.toName(lockName), objectType, newObjectArray), annotationNode);
 			injectFieldAndMarkGenerated(methodNode.up(), fieldDecl);
 		}
 		
@@ -133,8 +131,8 @@ public class HandleSynchronized extends JavacAnnotationHandler<Synchronized> {
 			lockNode = maker.Select(maker.Ident(methodNode.toName("this")), methodNode.toName(lockName));
 		}
 		
-		recursiveSetGeneratedBy(lockNode, ast, context);
-		method.body = setGeneratedBy(maker.Block(0, List.<JCStatement>of(setGeneratedBy(maker.Synchronized(lockNode, method.body), ast, context))), ast, context);
+		recursiveSetGeneratedBy(lockNode, annotationNode);
+		method.body = setGeneratedBy(maker.Block(0, List.<JCStatement>of(setGeneratedBy(maker.Synchronized(lockNode, method.body), annotationNode))), annotationNode);
 		
 		methodNode.rebuild();
 	}

--- a/src/core/lombok/javac/handlers/HandleToString.java
+++ b/src/core/lombok/javac/handlers/HandleToString.java
@@ -42,7 +42,6 @@ import lombok.javac.JavacTreeMaker;
 import org.mangosdk.spi.ProviderFor;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCArrayTypeTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
@@ -141,7 +140,7 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 					}
 				}
 			}
-			JCMethodDecl method = createToString(typeNode, members, includeFieldNames, callSuper, fieldAccess, source.get());
+			JCMethodDecl method = createToString(typeNode, members, includeFieldNames, callSuper, fieldAccess, source);
 			injectMethod(typeNode, method);
 			break;
 		case EXISTS_BY_LOMBOK:
@@ -156,7 +155,7 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 	}
 	
 	static JCMethodDecl createToString(JavacNode typeNode, Collection<Included<JavacNode, ToString.Include>> members,
-		boolean includeNames, boolean callSuper, FieldAccess fieldAccess, JCTree source) {
+		boolean includeNames, boolean callSuper, FieldAccess fieldAccess, JavacNode source) {
 		
 		JavacTreeMaker maker = typeNode.getTreeMaker();
 		
@@ -256,7 +255,7 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 		JCMethodDecl methodDef = maker.MethodDef(mods, typeNode.toName("toString"), returnType,
 			List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
 		createRelevantNonNullAnnotation(typeNode, methodDef);
-		return recursiveSetGeneratedBy(methodDef, source, typeNode.getContext());
+		return recursiveSetGeneratedBy(methodDef, source);
 	}
 	
 	public static String getTypeName(JavacNode typeNode) {

--- a/src/core/lombok/javac/handlers/HandleUtilityClass.java
+++ b/src/core/lombok/javac/handlers/HandleUtilityClass.java
@@ -146,7 +146,7 @@ public class HandleUtilityClass extends JavacAnnotationHandler<UtilityClass> {
 		Name name = typeNode.toName("<init>");
 		JCBlock block = maker.Block(0L, createThrowStatement(typeNode, maker));
 		JCMethodDecl methodDef = maker.MethodDef(mods, name, null, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), block, null);
-		JCMethodDecl constructor = recursiveSetGeneratedBy(methodDef, typeNode.get(), typeNode.getContext());
+		JCMethodDecl constructor = recursiveSetGeneratedBy(methodDef, typeNode);
 		JavacHandlerUtil.injectMethod(typeNode, constructor, List.<Type>nil(), Javac.createVoidType(typeNode.getSymbolTable(), CTC_VOID));
 	}
 	

--- a/src/core/lombok/javac/handlers/HandleVal.java
+++ b/src/core/lombok/javac/handlers/HandleVal.java
@@ -63,6 +63,7 @@ public class HandleVal extends JavacASTAdapter {
 		JCTree typeTree = local.vartype;
 		if (typeTree == null) return;
 		String typeTreeToString = typeTree.toString();
+		JavacNode typeNode = localNode.getNodeFor(typeTree);
 		
 		if (!(eq(typeTreeToString, "val") || eq(typeTreeToString, "var"))) return;
 		boolean isVal = typeMatches(val.class, localNode, typeTree);
@@ -111,7 +112,7 @@ public class HandleVal extends JavacASTAdapter {
 		if (isVal) local.mods.flags |= Flags.FINAL;
 		
 		if (!localNode.shouldDeleteLombokAnnotations()) {
-			JCAnnotation valAnnotation = recursiveSetGeneratedBy(localNode.getTreeMaker().Annotation(local.vartype, List.<JCExpression>nil()), typeTree, localNode.getContext());
+			JCAnnotation valAnnotation = recursiveSetGeneratedBy(localNode.getTreeMaker().Annotation(local.vartype, List.<JCExpression>nil()), typeNode);
 			local.mods.annotations = local.mods.annotations == null ? List.of(valAnnotation) : local.mods.annotations.append(valAnnotation);
 		}
 		
@@ -182,7 +183,7 @@ public class HandleVal extends JavacASTAdapter {
 			local.vartype = JavacResolution.createJavaLangObject(localNode.getAst());
 			throw e;
 		} finally {
-			recursiveSetGeneratedBy(local.vartype, typeTree, localNode.getContext());
+			recursiveSetGeneratedBy(local.vartype, typeNode);
 		}
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleValue.java
+++ b/src/core/lombok/javac/handlers/HandleValue.java
@@ -72,7 +72,6 @@ public class HandleValue extends JavacAnnotationHandler<Value> {
 			JCModifiers jcm = ((JCClassDecl) typeNode.get()).mods;
 			if ((jcm.flags & Flags.FINAL) == 0) {
 				jcm.flags |= Flags.FINAL;
-				typeNode.rebuild();
 			}
 		}
 		handleFieldDefaults.generateFieldDefaultsForType(typeNode, annotationNode, AccessLevel.PRIVATE, true, true);

--- a/src/core/lombok/javac/handlers/HandleWith.java
+++ b/src/core/lombok/javac/handlers/HandleWith.java
@@ -215,6 +215,7 @@ public class HandleWith extends JavacAnnotationHandler<With> {
 		ClassSymbol sym = ((JCClassDecl) fieldNode.up().get()).sym;
 		Type returnType = sym == null ? null : sym.type;
 		
+		recursiveSetGeneratedBy(createdWith, source);
 		injectMethod(typeNode, createdWith, List.<Type>of(getMirrorForFieldType(fieldNode)), returnType);
 	}
 	
@@ -234,7 +235,7 @@ public class HandleWith extends JavacAnnotationHandler<With> {
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, field.getContext());
 		List<JCAnnotation> annsOnParam = copyAnnotations(onParam).appendList(copyableAnnotations);
 		
-		JCExpression pType = cloneType(maker, fieldDecl.vartype, source.get(), source.getContext());
+		JCExpression pType = cloneType(maker, fieldDecl.vartype, source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags, annsOnParam), fieldDecl.name, pType, null);
 		
 		if (!makeAbstract) {
@@ -289,7 +290,7 @@ public class HandleWith extends JavacAnnotationHandler<With> {
 		
 		if (makeAbstract) access = access | Flags.ABSTRACT;
 		JCMethodDecl decl = recursiveSetGeneratedBy(maker.MethodDef(maker.Modifiers(access, annsOnMethod), methodName, returnType,
-			methodGenericParams, parameters, throwsClauses, methodBody, annotationMethodDefaultValue), source.get(), field.getContext());
+			methodGenericParams, parameters, throwsClauses, methodBody, annotationMethodDefaultValue), source);
 		copyJavadoc(field, decl, CopyJavadoc.WITH);
 		return decl;
 	}

--- a/src/core/lombok/javac/handlers/HandleWithBy.java
+++ b/src/core/lombok/javac/handlers/HandleWithBy.java
@@ -209,6 +209,7 @@ public class HandleWithBy extends JavacAnnotationHandler<WithBy> {
 		ClassSymbol sym = ((JCClassDecl) fieldNode.up().get()).sym;
 		Type returnType = sym == null ? null : sym.type;
 		
+		recursiveSetGeneratedBy(createdWithBy, source);
 		injectMethod(typeNode, createdWithBy, List.<Type>of(getMirrorForFieldType(fieldNode)), returnType);
 	}
 	
@@ -265,7 +266,7 @@ public class HandleWithBy extends JavacAnnotationHandler<WithBy> {
 		}
 		if (functionalInterfaceName == null) {
 			functionalInterfaceName = NAME_JUF_FUNCTION;
-			parameterizer = cloneType(maker, fieldDecl.vartype, source.get(), field.getContext());
+			parameterizer = cloneType(maker, fieldDecl.vartype, source);
 		}
 		if (functionalInterfaceName == NAME_JUF_INTOP) applyMethodName = "applyAsInt";
 		if (functionalInterfaceName == NAME_JUF_LONGOP) applyMethodName = "applyAsLong";
@@ -274,7 +275,7 @@ public class HandleWithBy extends JavacAnnotationHandler<WithBy> {
 		JCExpression varType = chainDots(field, functionalInterfaceName);
 		if (parameterizer != null && superExtendsStyle) {
 			JCExpression parameterizer1 = parameterizer;
-			JCExpression parameterizer2 = cloneType(maker, parameterizer, source.get(), field.getContext());
+			JCExpression parameterizer2 = cloneType(maker, parameterizer, source);
 			// TODO: Apply copyable annotations to 'parameterizer' and 'parameterizer2'.
 			JCExpression arg1 = maker.Wildcard(maker.TypeBoundKind(BoundKind.SUPER), parameterizer1);
 			JCExpression arg2 = maker.Wildcard(maker.TypeBoundKind(BoundKind.EXTENDS), parameterizer2);
@@ -334,7 +335,7 @@ public class HandleWithBy extends JavacAnnotationHandler<WithBy> {
 		if (makeAbstract) access = access | Flags.ABSTRACT;
 		createRelevantNonNullAnnotation(source, param);
 		JCMethodDecl decl = recursiveSetGeneratedBy(maker.MethodDef(maker.Modifiers(access, annsOnMethod), methodName, returnType,
-			methodGenericParams, parameters, throwsClauses, methodBody, annotationMethodDefaultValue), source.get(), field.getContext());
+			methodGenericParams, parameters, throwsClauses, methodBody, annotationMethodDefaultValue), source);
 		copyJavadoc(field, decl, CopyJavadoc.WITH_BY);
 		createRelevantNonNullAnnotation(source, decl);
 		return decl;

--- a/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacGuavaSingularizer.java
@@ -39,7 +39,6 @@ import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
@@ -62,7 +61,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		return "builder";
 	}
 	
-	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JCTree source) {
+	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JavacNode source) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		String simpleTypeName = getSimpleTargetTypeName(data);
 		JCExpression type = JavacHandlerUtil.chainDots(builderType, "com", "google", "common", "collect", simpleTypeName, "Builder");
@@ -72,7 +71,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(CheckerFrameworkVersion cfv, SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker, AccessLevel access) {
+	@Override public void generateMethods(CheckerFrameworkVersion cfv, SingularData data, boolean deprecate, JavacNode builderType, JavacNode source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker, AccessLevel access) {
 		doGenerateMethods(cfv, data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker, access);
 	}
 	
@@ -83,7 +82,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 	
 	@Override
-	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		Name[] names = generateSingularMethodParameterNames(data, builderType);
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		for (int i = 0; i < names.length; i++) {
@@ -93,7 +92,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 	
 	@Override
-	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		Name[] names = generateSingularMethodParameterNames(data, builderType);
 		
 		JCExpression thisDotFieldDotAdd = chainDots(builderType, "this", data.getPluralName().toString(), getAddMethodName());
@@ -124,7 +123,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 		return genTypeRef(builderType, getAddAllTypeName());
 	}
 	
-	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
+	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JavacNode source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		List<JCExpression> jceBlank = List.nil();
 		
@@ -156,7 +155,7 @@ abstract class JavacGuavaSingularizer extends JavacSingularizer {
 	}
 
 	@Override
-	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		List<JCExpression> jceBlank = List.nil();
 		
 		JCExpression thisDotField = maker.Select(maker.Ident(builderType.toName("this")), data.getPluralName());

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSetSingularizer.java
@@ -37,7 +37,6 @@ import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
@@ -58,7 +57,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		return super.listMethodsToBeGenerated(data, builderType);
 	}
 	
-	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JCTree source) {
+	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JavacNode source) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		JCExpression type = JavacHandlerUtil.chainDots(builderType, "java", "util", "ArrayList");
 		type = addTypeArgs(1, false, builderType, type, data.getTypeArgs(), source);
@@ -67,7 +66,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 		return Collections.singletonList(injectFieldAndMarkGenerated(builderType, buildField));
 	}
 	
-	@Override public void generateMethods(CheckerFrameworkVersion cfv, SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker, AccessLevel access) {
+	@Override public void generateMethods(CheckerFrameworkVersion cfv, SingularData data, boolean deprecate, JavacNode builderType, JavacNode source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker, AccessLevel access) {
 		doGenerateMethods(cfv, data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker, access);
 	}
 	
@@ -84,13 +83,13 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 	
 	@Override
-	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		return new ListBuffer<JCStatement>()
 			.append(generateSingularMethodAddStatement(maker, builderType, data.getSingularName(), data.getPluralName().toString()));
 	}
 	
 	@Override
-	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		JCVariableDecl param = generateSingularMethodParameter(0, maker, data, builderType, source, data.getSingularName());
 		return List.of(param);
 	}
@@ -101,7 +100,7 @@ abstract class JavacJavaUtilListSetSingularizer extends JavacJavaUtilSingularize
 	}
 	
 	@Override
-	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		return createConstructBuilderVarIfNeeded(maker, data, builderType, false, source);
 	}
 	

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSingularizer.java
@@ -32,7 +32,6 @@ import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
@@ -50,7 +49,7 @@ public class JavacJavaUtilListSingularizer extends JavacJavaUtilListSetSingulari
 		return "java.util.Collections.emptyList";
 	}
 	
-	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
+	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JavacNode source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCCase> cases = new ListBuffer<JCCase>();
@@ -94,7 +93,7 @@ public class JavacJavaUtilListSingularizer extends JavacJavaUtilListSetSingulari
 		statements.append(switchStat);
 	}
 	
-	private List<JCStatement> createListCopy(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source, String builderVariable) {
+	private List<JCStatement> createListCopy(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source, String builderVariable) {
 		List<JCExpression> jceBlank = List.nil();
 		Name thisName = builderType.toName(builderVariable);
 		

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -40,7 +40,6 @@ import lombok.javac.handlers.JavacSingularsRecipes.StatementMaker;
 import org.mangosdk.spi.ProviderFor;
 
 import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
@@ -74,7 +73,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return super.listMethodsToBeGenerated(data, builderType);
 	}
 	
-	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JCTree source) {
+	@Override public java.util.List<JavacNode> generateFields(SingularData data, JavacNode builderType, JavacNode source) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		
 		JCVariableDecl buildKeyField; {
@@ -98,7 +97,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		return Arrays.asList(keyFieldNode, valueFieldNode);
 	}
 	
-	@Override public void generateMethods(CheckerFrameworkVersion cfv, SingularData data, boolean deprecate, JavacNode builderType, JCTree source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker, AccessLevel access) {
+	@Override public void generateMethods(CheckerFrameworkVersion cfv, SingularData data, boolean deprecate, JavacNode builderType, JavacNode source, boolean fluent, ExpressionMaker returnTypeMaker, StatementMaker returnStatementMaker, AccessLevel access) {
 		doGenerateMethods(cfv, data, deprecate, builderType, source, fluent, returnTypeMaker, returnStatementMaker, access);
 	}
 	
@@ -117,7 +116,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 	
 	@Override
-	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected ListBuffer<JCStatement> generateSingularMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 		
@@ -130,7 +129,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 	
 	@Override
-	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected List<JCVariableDecl> generateSingularMethodParameters(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		Name keyName = builderType.toName(data.getSingularName().toString() + "Key");
 		Name valueName = builderType.toName(data.getSingularName().toString() + "Value");
 		JCVariableDecl paramKey = generateSingularMethodParameter(0, maker, data, builderType, source, keyName);
@@ -139,7 +138,7 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 	
 	@Override
-	protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected ListBuffer<JCStatement> generatePluralMethodStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		long baseFlags = JavacHandlerUtil.addFinalIfNeeded(0, builderType.getContext());
@@ -164,11 +163,11 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	}
 	
 	@Override
-	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JCTree source) {
+	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, JavacNode source) {
 		return createConstructBuilderVarIfNeeded(maker, data, builderType, true, source);
 	}
 	
-	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
+	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JavacNode source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		
 		if (data.getTargetFqn().equals("java.util.Map")) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSetSingularizer.java
@@ -29,7 +29,6 @@ import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
@@ -46,7 +45,7 @@ public class JavacJavaUtilSetSingularizer extends JavacJavaUtilListSetSingulariz
 		return "java.util.Collections.emptySet";
 	}
 	
-	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JCTree source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
+	@Override public void appendBuildCode(SingularData data, JavacNode builderType, JavacNode source, ListBuffer<JCStatement> statements, Name targetVariableName, String builderVariable) {
 		JavacTreeMaker maker = builderType.getTreeMaker();
 		
 		if (data.getTargetFqn().equals("java.util.Set")) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSingularizer.java
@@ -24,7 +24,6 @@ package lombok.javac.handlers.singulars;
 import static lombok.javac.Javac.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
@@ -38,7 +37,7 @@ import lombok.javac.handlers.JavacSingularsRecipes.JavacSingularizer;
 import lombok.javac.handlers.JavacSingularsRecipes.SingularData;
 
 abstract class JavacJavaUtilSingularizer extends JavacSingularizer {
-	protected List<JCStatement> createJavaUtilSetMapInitialCapacitySwitchStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, String emptyCollectionMethod, String singletonCollectionMethod, String targetType, JCTree source, String builderVariable) {
+	protected List<JCStatement> createJavaUtilSetMapInitialCapacitySwitchStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, String emptyCollectionMethod, String singletonCollectionMethod, String targetType, JavacNode source, String builderVariable) {
 		List<JCExpression> jceBlank = List.nil();
 		ListBuffer<JCCase> cases = new ListBuffer<JCCase>();
 		
@@ -88,7 +87,7 @@ abstract class JavacJavaUtilSingularizer extends JavacSingularizer {
 		return List.of(varDefStat, switchStat);
 	}
 	
-	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, JCTree source) {
+	protected JCStatement createConstructBuilderVarIfNeeded(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, JavacNode source) {
 		List<JCExpression> jceBlank = List.nil();
 
 		Name v1Name = mapMode ? builderType.toName(data.getPluralName() + "$key") : data.getPluralName();
@@ -117,7 +116,7 @@ abstract class JavacJavaUtilSingularizer extends JavacSingularizer {
 		return maker.If(cond, thenPart, null);
 	}
 	
-	protected List<JCStatement> createJavaUtilSimpleCreationAndFillStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, boolean defineVar, boolean addInitialCapacityArg, boolean nullGuard, String targetType, JCTree source, String builderVariable) {
+	protected List<JCStatement> createJavaUtilSimpleCreationAndFillStatements(JavacTreeMaker maker, SingularData data, JavacNode builderType, boolean mapMode, boolean defineVar, boolean addInitialCapacityArg, boolean nullGuard, String targetType, JavacNode source, String builderVariable) {
 		List<JCExpression> jceBlank = List.nil();
 		Name thisName = builderType.toName(builderVariable);
 		

--- a/test/core/src/lombok/RunTestsViaDelombok.java
+++ b/test/core/src/lombok/RunTestsViaDelombok.java
@@ -21,17 +21,42 @@
  */
 package lombok;
 
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeScanner;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCAssign;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCModifiers;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 
 import lombok.delombok.Delombok;
 import lombok.javac.CapturingDiagnosticListener;
+import lombok.javac.Javac;
 import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
 
 public class RunTestsViaDelombok extends AbstractRunTests {
@@ -48,6 +73,8 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 		
 		delombok.setDiagnosticsListener(new CapturingDiagnosticListener(file, messages));
 		
+		delombok.addAdditionalAnnotationProcessor(new ValidatePositionProcessor());
+		
 		delombok.addFile(file.getAbsoluteFile().getParentFile(), file.getName());
 		delombok.setSourcepath(file.getAbsoluteFile().getParent());
 		String bcp = System.getProperty("delombok.bootclasspath");
@@ -63,6 +90,92 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 		}
 	}
 	
+	public static class ValidatePositionProcessor extends TreeProcessor {
+		@Override void processCompilationUnit(final JCCompilationUnit unit) {
+			unit.accept(new TreeScanner() {
+				@Override public void scan(JCTree tree) {
+					if (tree == null) return;
+					if (tree instanceof JCMethodDecl && (((JCMethodDecl) tree).mods.flags & Flags.GENERATEDCONSTR) != 0) return;
+					try {
+						if (tree instanceof JCModifiers) return;
+						
+						if (tree.pos == -1) {
+							fail("Start position of " + tree + " not set");
+						}
+						if (Javac.getEndPosition(tree, unit) == -1) {
+							fail("End position of " + tree + " not set");
+						}
+					} finally {
+						super.scan(tree);
+					}
+				}
+				
+				@Override public void visitMethodDef(JCMethodDecl tree) {
+					super.visitMethodDef(tree);
+				}
+				
+				@Override public void visitVarDef(JCVariableDecl tree) {
+					if ((tree.mods.flags & Flags.ENUM) != 0) return;
+					super.visitVarDef(tree);
+				}
+				
+				@Override public void visitAnnotation(JCAnnotation tree) {
+					scan(tree.annotationType);
+					// Javac parser maps @Annotation("val") to @Annotation(value = "val") but does not add an end position for the new JCIdent...
+					if (tree.args.length() == 1 && tree.args.head instanceof JCAssign && ((JCIdent)((JCAssign) tree.args.head).lhs).name.toString().equals("value")) {
+						scan(((JCAssign) tree.args.head).rhs);
+					} else {
+						scan(tree.args);
+					}
+				}
+			});
+		}
+	}
+	
+	public static abstract class TreeProcessor extends AbstractProcessor {
+		private Trees trees;
+		@Override public synchronized void init(ProcessingEnvironment processingEnv) {
+			super.init(processingEnv);
+			trees = Trees.instance(processingEnv);
+		}
+		
+		@Override public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+			for (Element element : roundEnv.getRootElements()) {
+				JCCompilationUnit unit = toUnit(element);
+				if (unit != null) {
+					processCompilationUnit(unit);
+				}
+			}
+			return false;
+		}
+		
+		abstract void processCompilationUnit(JCCompilationUnit unit);
+		
+		@Override public Set<String> getSupportedAnnotationTypes() {
+			return Collections.singleton("*");
+		}
+		
+		@Override public SourceVersion getSupportedSourceVersion() {
+			return SourceVersion.latest();
+		}
+		
+		private JCCompilationUnit toUnit(Element element) {
+			TreePath path = null;
+			if (trees != null) {
+				try {
+					path = trees.getPath(element);
+				} catch (NullPointerException ignore) {
+					// Happens if a package-info.java dowsn't conatin a package declaration.
+					// https://github.com/rzwitserloot/lombok/issues/2184
+					// We can safely ignore those, since they do not need any processing
+				}
+			}
+			if (path == null) return null;
+			
+			return (JCCompilationUnit) path.getCompilationUnit();
+		}
+	}
+
 	static class ChangedChecker {
 		private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 		private final PrintStream feedback;


### PR DESCRIPTION
This PR fixes #2691

`setGeneratedBy` and `recursiveSetGeneratedBy` now accept a `JavacNode` instead of `JCTree` and `Context`. Lombok can use this node to find the compilation unit and its end position table to add the generated node there. 

To validate that all nodes have positions I added an annotation processor that scans the ast and performs that check. I also tested this successful in NetBeans and with error-prone.