### PR TITLE
Add missing checker annotations in SuperBuilder

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -606,6 +606,9 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		}
 		
 		constructor.statements = statements.isEmpty() ? null : statements.toArray(new Statement[0]);
+		if (job.checkerFramework.generateSideEffectFree()) {
+			constructor.annotations = new Annotation[] {generateNamedAnnotation(job.source, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE)};
+		}
 		
 		constructor.traverse(new SetGeneratedByVisitor(job.source), typeDeclaration.scope);
 		
@@ -635,6 +638,9 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		AllocationExpression invoke = new AllocationExpression();
 		invoke.type = namePlusTypeParamsToTypeReference(job.parentType, job.builderImplClassNameArr, false, job.typeParams, p);
 		out.statements = new Statement[] {new ReturnStatement(invoke, pS, pE)};
+		if (job.checkerFramework.generateSideEffectFree()) {
+			out.annotations = new Annotation[] {generateNamedAnnotation(job.source, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE)};
+		}
 		
 		createRelevantNonNullAnnotation(job.parentType, out);
 		out.traverse(new SetGeneratedByVisitor(job.source), ((TypeDeclaration) job.parentType.get()).scope);
@@ -673,6 +679,9 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		invokeFillMethod.selector = FILL_VALUES_METHOD_NAME;
 		invokeFillMethod.arguments = new Expression[] {new ThisReference(0, 0)};
 		out.statements = new Statement[] {new ReturnStatement(invokeFillMethod, pS, pE)};
+		if (job.checkerFramework.generateSideEffectFree()) {
+			out.annotations = new Annotation[] {generateNamedAnnotation(job.source, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE)};
+		}
 		
 		createRelevantNonNullAnnotation(job.parentType, out);
 		out.traverse(new SetGeneratedByVisitor(job.source), ((TypeDeclaration) job.parentType.get()).scope);

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -556,7 +556,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			}
 		}
 		
-		List<JCAnnotation> annsOnMethod = job.checkerFramework.generateUnique() ? List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil())) : List.<JCAnnotation>nil();
+		List<JCAnnotation> annsOnMethod = job.checkerFramework.generateSideEffectFree() ? List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil())) : List.<JCAnnotation>nil();
 		JCModifiers mods = maker.Modifiers(toJavacModifier(level), annsOnMethod);
 		
 		// Create a constructor that has just the builder as parameter.
@@ -608,9 +608,12 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		JCWildcard wildcard = maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
 		typeParameterNames.add(wildcard);
 		typeParameterNames.add(wildcard);
-		JCTypeApply returnType = maker.TypeApply(namePlusTypeParamsToTypeReference(maker, job.parentType, job.toName(job.builderAbstractClassName), false, List.<JCTypeParameter>nil()), typeParameterNames.toList());
+		// And return type annotations.
+		List<JCAnnotation> annsOnParamType = List.nil();
+		if (job.checkerFramework.generateUnique()) annsOnParamType = List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__UNIQUE), List.<JCExpression>nil()));
+		JCTypeApply returnType = maker.TypeApply(namePlusTypeParamsToTypeReference(maker, job.parentType, job.toName(job.builderAbstractClassName), false, List.<JCTypeParameter>nil(), annsOnParamType), typeParameterNames.toList());
 		
-		List<JCAnnotation> annsOnMethod = job.checkerFramework.generateUnique() ? List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil())) : List.<JCAnnotation>nil();
+		List<JCAnnotation> annsOnMethod = job.checkerFramework.generateSideEffectFree() ? List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil())) : List.<JCAnnotation>nil();
 		JCMethodDecl methodDef = maker.MethodDef(maker.Modifiers(modifiers, annsOnMethod), job.toName(job.builderMethodName), returnType, copyTypeParams(job.sourceNode, job.typeParams), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
 		createRelevantNonNullAnnotation(job.parentType, methodDef);
 		return methodDef;
@@ -647,7 +650,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		typeParameterNames.add(wildcard);
 		JCTypeApply returnType = maker.TypeApply(namePlusTypeParamsToTypeReference(maker, job.parentType, job.toName(job.builderAbstractClassName), false, List.<JCTypeParameter>nil()), typeParameterNames.toList());
 		
-		List<JCAnnotation> annsOnMethod = job.checkerFramework.generateUnique() ? List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil())) : List.<JCAnnotation>nil();
+		List<JCAnnotation> annsOnMethod = job.checkerFramework.generateSideEffectFree() ? List.of(maker.Annotation(genTypeRef(job.parentType, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil())) : List.<JCAnnotation>nil();
 		JCMethodDecl methodDef = maker.MethodDef(maker.Modifiers(modifiers, annsOnMethod), job.toName(TO_BUILDER_METHOD_NAME), returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), body, null);
 		createRelevantNonNullAnnotation(job.parentType, methodDef);
 		return methodDef;

--- a/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
@@ -1,4 +1,3 @@
-// skip-idempotent
 import java.util.List;
 class CheckerFrameworkSuperBuilder {
 	public static class Parent {
@@ -128,7 +127,7 @@ class CheckerFrameworkSuperBuilder {
 		}
 		@org.checkerframework.dataflow.qual.SideEffectFree
 		@java.lang.SuppressWarnings("all")
-		public static CheckerFrameworkSuperBuilder.Parent.ParentBuilder<?, ?> builder() {
+		public static CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.common.aliasing.qual.Unique ParentBuilder<?, ?> builder() {
 			return new CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl();
 		}
 	}
@@ -211,7 +210,7 @@ class CheckerFrameworkSuperBuilder {
 		}
 		@org.checkerframework.dataflow.qual.SideEffectFree
 		@java.lang.SuppressWarnings("all")
-		public static CheckerFrameworkSuperBuilder.ZChild.ZChildBuilder<?, ?> builder() {
+		public static CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.common.aliasing.qual.Unique ZChildBuilder<?, ?> builder() {
 			return new CheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl();
 		}
 	}

--- a/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
@@ -78,7 +78,7 @@ class CheckerFrameworkSuperBuilder {
     private static @java.lang.SuppressWarnings("all") int $default$x() {
       return 5;
     }
-    protected @java.lang.SuppressWarnings("all") Parent(final CheckerFrameworkSuperBuilder.Parent.ParentBuilder<?, ?> b) {
+    protected @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") Parent(final CheckerFrameworkSuperBuilder.Parent.ParentBuilder<?, ?> b) {
       super();
       if (b.x$set)
           this.x = b.x$value;
@@ -99,7 +99,7 @@ class CheckerFrameworkSuperBuilder {
       }
       this.names = names;
     }
-    public static @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.common.aliasing.qual.Unique ParentBuilder<?, ?> builder() {
+    public static @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.common.aliasing.qual.Unique ParentBuilder<?, ?> builder() {
       return new CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl();
     }
   }
@@ -148,7 +148,7 @@ class CheckerFrameworkSuperBuilder {
     private static @java.lang.SuppressWarnings("all") int $default$a() {
       return 1;
     }
-    protected @java.lang.SuppressWarnings("all") ZChild(final CheckerFrameworkSuperBuilder.ZChild.ZChildBuilder<?, ?> b) {
+    protected @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") ZChild(final CheckerFrameworkSuperBuilder.ZChild.ZChildBuilder<?, ?> b) {
       super(b);
       if (b.a$set)
           this.a = b.a$value;
@@ -156,7 +156,7 @@ class CheckerFrameworkSuperBuilder {
           this.a = CheckerFrameworkSuperBuilder.ZChild.$default$a();
       this.b = b.b;
     }
-    public static @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.common.aliasing.qual.Unique ZChildBuilder<?, ?> builder() {
+    public static @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.common.aliasing.qual.Unique ZChildBuilder<?, ?> builder() {
       return new CheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl();
     }
   }

--- a/test/transform/resource/after-ecj/NullAnnotatedCheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/NullAnnotatedCheckerFrameworkSuperBuilder.java
@@ -11,12 +11,12 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       public ParentBuilder() {
         super();
       }
-      protected abstract @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
-      public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(NullAnnotatedCheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B x(NullAnnotatedCheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("x") ParentBuilder<C, B> this, final int x) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B x(final int x) {
         this.x$value = x;
         x$set = true;
         return self();
@@ -24,24 +24,24 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B y(NullAnnotatedCheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("y") ParentBuilder<C, B> this, final int y) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B y(final int y) {
         this.y = y;
         return self();
       }
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B z(NullAnnotatedCheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("z") ParentBuilder<C, B> this, final int z) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B z(final int z) {
         this.z = z;
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B name(final String name) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B name(final String name) {
         if ((this.names == null))
             this.names = new java.util.ArrayList<String>();
         this.names.add(name);
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B names(final java.util.Collection<? extends String> names) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B names(final java.util. @org.checkerframework.checker.nullness.qual.NonNull Collection<? extends String> names) {
         if ((names == null))
             {
               throw new java.lang.NullPointerException("names cannot be null");
@@ -51,12 +51,12 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
         this.names.addAll(names);
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B clearNames() {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B clearNames() {
         if ((this.names != null))
             this.names.clear();
         return self();
       }
-      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.@org.checkerframework.checker.nullness.qual.NonNull String toString() {
         return (((((((("NullAnnotatedCheckerFrameworkSuperBuilder.Parent.ParentBuilder(x$value=" + this.x$value) + ", y=") + this.y) + ", z=") + this.z) + ", names=") + this.names) + ")");
       }
     }
@@ -64,10 +64,10 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       private ParentBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl self() {
         return this;
       }
-      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.Parent build(NullAnnotatedCheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilderImpl this) {
+      public @java.lang.Override @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.@org.checkerframework.checker.nullness.qual.NonNull Parent build() {
         return new NullAnnotatedCheckerFrameworkSuperBuilder.Parent(this);
       }
     }
@@ -99,7 +99,7 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       }
       this.names = names;
     }
-    public static @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.Parent. @org.checkerframework.common.aliasing.qual.Unique ParentBuilder<?, ?> builder() {
+    public static @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.nullness.qual.NonNull ParentBuilder<?, ?> builder() {
       return new NullAnnotatedCheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl();
     }
   }
@@ -111,12 +111,12 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       public ZChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(NullAnnotatedCheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B a(NullAnnotatedCheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("a") ZChildBuilder<C, B> this, final int a) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B a(final int a) {
         this.a$value = a;
         a$set = true;
         return self();
@@ -124,11 +124,11 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B b(NullAnnotatedCheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.NotCalledMethods("b") ZChildBuilder<C, B> this, final int b) {
+      public @org.checkerframework.checker.nullness.qual.NonNull @java.lang.SuppressWarnings("all") B b(final int b) {
         this.b = b;
         return self();
       }
-      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.@org.checkerframework.checker.nullness.qual.NonNull String toString() {
         return (((((("NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.ZChildBuilder(super=" + super.toString()) + ", a$value=") + this.a$value) + ", b=") + this.b) + ")");
       }
     }
@@ -136,10 +136,10 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       private ZChildBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl self() {
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl self() {
         return this;
       }
-      public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.ZChild build(NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilderImpl this) {
+      public @java.lang.Override @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.@org.checkerframework.checker.nullness.qual.NonNull ZChild build() {
         return new NullAnnotatedCheckerFrameworkSuperBuilder.ZChild(this);
       }
     }
@@ -156,7 +156,7 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
           this.a = NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.$default$a();
       this.b = b.b;
     }
-    public static @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.common.aliasing.qual.Unique ZChildBuilder<?, ?> builder() {
+    public static @java.lang.SuppressWarnings("all") NullAnnotatedCheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.nullness.qual.NonNull ZChildBuilder<?, ?> builder() {
       return new NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl();
     }
   }


### PR DESCRIPTION
This PR fixes #2692

Lombok now adds `@SideEffectFree` in eclipse and `@Unique` for the `builder()` method in `javac`. I also fixed the `NullAnnotatedCheckerFrameworkSuperBuilder` test case.