### PR TITLE
Only show super()-warning if lombok generates a method

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -168,30 +168,6 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 		
 		boolean isDirectDescendantOfObject = isDirectDescendantOfObject(typeNode);
 		
-		if (isDirectDescendantOfObject && callSuper) {
-			errorNode.addError("Generating equals/hashCode with a supercall to java.lang.Object is pointless.");
-			return;
-		}
-		
-		if (implicitCallSuper && !isDirectDescendantOfObject) {
-			CallSuperType cst = typeNode.getAst().readConfiguration(ConfigurationKeys.EQUALS_AND_HASH_CODE_CALL_SUPER);
-			if (cst == null) cst = CallSuperType.WARN;
-			
-			switch (cst) {
-			default:
-			case WARN:
-				errorNode.addWarning("Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.");
-				callSuper = false;
-				break;
-			case SKIP:
-				callSuper = false;
-				break;
-			case CALL:
-				callSuper = true;
-				break;
-			}
-		}
-		
 		boolean isFinal = (typeDecl.modifiers & ClassFileConstants.AccFinal) != 0;
 		boolean needsCanEqual = !isFinal || !isDirectDescendantOfObject;
 		MemberExistsResult equalsExists = methodExists("equals", typeNode, 1);
@@ -218,6 +194,30 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 		case NOT_EXISTS:
 		default:
 			//fallthrough
+		}
+		
+		if (isDirectDescendantOfObject && callSuper) {
+			errorNode.addError("Generating equals/hashCode with a supercall to java.lang.Object is pointless.");
+			return;
+		}
+		
+		if (implicitCallSuper && !isDirectDescendantOfObject) {
+			CallSuperType cst = typeNode.getAst().readConfiguration(ConfigurationKeys.EQUALS_AND_HASH_CODE_CALL_SUPER);
+			if (cst == null) cst = CallSuperType.WARN;
+			
+			switch (cst) {
+			default:
+			case WARN:
+				errorNode.addWarning("Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.");
+				callSuper = false;
+				break;
+			case SKIP:
+				callSuper = false;
+				break;
+			case CALL:
+				callSuper = true;
+				break;
+			}
 		}
 		
 		MethodDeclaration equalsMethod = createEquals(typeNode, members, callSuper, errorNode.get(), fieldAccess, needsCanEqual, onParam);

--- a/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
@@ -141,30 +141,6 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 		
 		boolean isDirectDescendantOfObject = isDirectDescendantOfObject(typeNode);
 		
-		if (isDirectDescendantOfObject && callSuper) {
-			source.addError("Generating equals/hashCode with a supercall to java.lang.Object is pointless.");
-			return;
-		}
-		
-		if (implicitCallSuper && !isDirectDescendantOfObject) {
-			CallSuperType cst = typeNode.getAst().readConfiguration(ConfigurationKeys.EQUALS_AND_HASH_CODE_CALL_SUPER);
-			if (cst == null) cst = CallSuperType.WARN;
-			
-			switch (cst) {
-			default:
-			case WARN:
-				source.addWarning("Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.");
-				callSuper = false;
-				break;
-			case SKIP:
-				callSuper = false;
-				break;
-			case CALL:
-				callSuper = true;
-				break;
-			}
-		}
-		
 		boolean isFinal = (((JCClassDecl) typeNode.get()).mods.flags & Flags.FINAL) != 0;
 		boolean needsCanEqual = !isFinal || !isDirectDescendantOfObject;
 		MemberExistsResult equalsExists = methodExists("equals", typeNode, 1);
@@ -191,6 +167,30 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 		case NOT_EXISTS:
 		default:
 			//fallthrough
+		}
+		
+		if (isDirectDescendantOfObject && callSuper) {
+			source.addError("Generating equals/hashCode with a supercall to java.lang.Object is pointless.");
+			return;
+		}
+		
+		if (implicitCallSuper && !isDirectDescendantOfObject) {
+			CallSuperType cst = typeNode.getAst().readConfiguration(ConfigurationKeys.EQUALS_AND_HASH_CODE_CALL_SUPER);
+			if (cst == null) cst = CallSuperType.WARN;
+			
+			switch (cst) {
+			default:
+			case WARN:
+				source.addWarning("Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.");
+				callSuper = false;
+				break;
+			case SKIP:
+				callSuper = false;
+				break;
+			case CALL:
+				callSuper = true;
+				break;
+			}
 		}
 		
 		JCMethodDecl equalsMethod = createEquals(typeNode, members, callSuper, fieldAccess, needsCanEqual, source, onParam);

--- a/test/transform/resource/after-delombok/DataWithOverrideEqualsAndHashCode.java
+++ b/test/transform/resource/after-delombok/DataWithOverrideEqualsAndHashCode.java
@@ -1,0 +1,25 @@
+class DataWithOverrideEqualsAndHashCode {
+
+	class Data1 {
+	}
+
+	class Data2 extends Data1 {
+		public int hashCode() {
+			return 42;
+		}
+
+		public boolean equals(Object other) {
+			return false;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public Data2() {
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "DataWithOverrideEqualsAndHashCode.Data2()";
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/DataWithOverrideEqualsAndHashCode.java
+++ b/test/transform/resource/after-ecj/DataWithOverrideEqualsAndHashCode.java
@@ -1,0 +1,25 @@
+import lombok.Data;
+class DataWithOverrideEqualsAndHashCode {
+  class Data1 {
+    Data1() {
+      super();
+    }
+  }
+  @Data class Data2 extends Data1 {
+    public int hashCode() {
+      return 42;
+    }
+    public boolean equals(Object other) {
+      return false;
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return "DataWithOverrideEqualsAndHashCode.Data2()";
+    }
+    public @java.lang.SuppressWarnings("all") Data2() {
+      super();
+    }
+  }
+  DataWithOverrideEqualsAndHashCode() {
+    super();
+  }
+}

--- a/test/transform/resource/before/DataWithOverrideEqualsAndHashCode.java
+++ b/test/transform/resource/before/DataWithOverrideEqualsAndHashCode.java
@@ -1,0 +1,18 @@
+import lombok.Data;
+
+class DataWithOverrideEqualsAndHashCode {
+	class Data1 {
+		
+	}
+	
+	@Data
+	class Data2 extends Data1 {
+		public int hashCode() {
+			return 42;
+		}
+		
+		public boolean equals(Object other) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #1064

The code that adds the warning for the missing super call now runs after the check for existing methods so it will only print it if lombok generates a method.