### PR TITLE
Save problem handler state for postponed error handling

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -55,6 +55,7 @@ import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.SuperReference;
 import org.eclipse.jdt.internal.compiler.ast.ThisReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
@@ -143,14 +144,17 @@ public class PatchExtensionMethod {
 		private final ProblemReporter problemReporter;
 		private ASTNode location;
 		private MethodBinding method;
+		private ReferenceContext referenceContext;
 		
 		PostponedNonStaticAccessToStaticMethodError(ProblemReporter problemReporter, ASTNode location, MethodBinding method) {
 			this.problemReporter = problemReporter;
 			this.location = location;
 			this.method = method;
+			this.referenceContext = problemReporter.referenceContext;
 		}
 
 		public void fire() {
+			problemReporter.referenceContext = this.referenceContext;
 			problemReporter.nonStaticAccessToStaticMethod(location, method);
 		}
 	}

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -83,6 +83,8 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		warnings.put(CompilerOptions.OPTION_ReportUnusedLabel, "ignore");
 		warnings.put(CompilerOptions.OPTION_ReportUnusedImport, "ignore");
 		warnings.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, "ignore");
+		warnings.put(CompilerOptions.OPTION_ReportIndirectStaticAccess, "warning");
+		warnings.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, "warning");
 		int ecjVersion = Eclipse.getEcjCompilerVersion();
 		warnings.put(CompilerOptions.OPTION_Source, (ecjVersion < 9 ? "1." : "") + ecjVersion);
 		options.set(warnings);

--- a/test/transform/resource/after-ecj/ExtensionMethodNonStaticAccess.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodNonStaticAccess.java
@@ -1,0 +1,22 @@
+class ExtensionMethodNonStaticAccess {
+  ExtensionMethodNonStaticAccess() {
+    super();
+  }
+  public void method() {
+    Derived derived = new Derived();
+    derived.staticMethod();
+  }
+}
+class Base {
+  Base() {
+    super();
+  }
+  static String staticMethod() {
+    return "";
+  }
+}
+class Derived extends Base {
+  Derived() {
+    super();
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodNonStaticAccess.java
+++ b/test/transform/resource/before/ExtensionMethodNonStaticAccess.java
@@ -1,0 +1,18 @@
+//issue #2752: this test triggers an indirect static access and a non static access warning for the same method call
+//platform ecj,eclipse
+class ExtensionMethodNonStaticAccess {
+  public void method(){
+      Derived derived = new Derived();
+      derived.staticMethod();
+  }
+}
+
+class Base {
+    static String staticMethod() {
+        return "";
+    }
+}
+
+class Derived extends Base {
+    
+}

--- a/test/transform/resource/messages-ecj/ExtensionMethodNonStaticAccess.java.messages
+++ b/test/transform/resource/messages-ecj/ExtensionMethodNonStaticAccess.java.messages
@@ -1,0 +1,2 @@
+6 The static method staticMethod() from the type Base should be accessed directly 
+6 The static method staticMethod() from the type Base should be accessed in a static way


### PR DESCRIPTION
This PR fixes #2752

The `ProblemReporter` has an internal `ReferenceContext` state which gets cleared if an error was handled. If there is more than one error for the same method call the state is `null` for postponed messages. Lombok now stores this value and restores it if required.