### PR TITLE
[fixes #2704] SuperBuilder: avoid NPE on existing constructors

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -1206,7 +1206,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 					if ((def.bits & ASTNode.IsDefaultConstructor) != 0) continue;
 					if (!def.isConstructor()) continue;
 					if (isTolerate(type, def)) continue;
-					if (def.arguments.length != 1) continue;
+					if (def.arguments == null || def.arguments.length != 1) continue;
 					
 					// Cannot use typeMatches() here, because the parameter could be fully-qualified, partially-qualified, or not qualified.
 					// A string-compare of the last part should work. If it's a false-positive, users could still @Tolerate it.

--- a/test/transform/resource/after-delombok/SuperBuilderWithExistingConstuctor.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithExistingConstuctor.java
@@ -1,0 +1,39 @@
+public class SuperBuilderWithExistingConstuctor {
+	public SuperBuilderWithExistingConstuctor() {
+	}
+	@java.lang.SuppressWarnings("all")
+	public static abstract class SuperBuilderWithExistingConstuctorBuilder<C extends SuperBuilderWithExistingConstuctor, B extends SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<C, B>> {
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder()";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	private static final class SuperBuilderWithExistingConstuctorBuilderImpl extends SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<SuperBuilderWithExistingConstuctor, SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilderImpl> {
+		@java.lang.SuppressWarnings("all")
+		private SuperBuilderWithExistingConstuctorBuilderImpl() {
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		protected SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilderImpl self() {
+			return this;
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public SuperBuilderWithExistingConstuctor build() {
+			return new SuperBuilderWithExistingConstuctor(this);
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	protected SuperBuilderWithExistingConstuctor(final SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<?, ?> b) {
+	}
+	@java.lang.SuppressWarnings("all")
+	public static SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<?, ?> builder() {
+		return new SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilderImpl();
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithExistingConstuctor.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithExistingConstuctor.java
@@ -1,0 +1,32 @@
+public @lombok.experimental.SuperBuilder class SuperBuilderWithExistingConstuctor {
+  public static abstract @java.lang.SuppressWarnings("all") class SuperBuilderWithExistingConstuctorBuilder<C extends SuperBuilderWithExistingConstuctor, B extends SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<C, B>> {
+    public SuperBuilderWithExistingConstuctorBuilder() {
+      super();
+    }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return "SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder()";
+    }
+  }
+  private static final @java.lang.SuppressWarnings("all") class SuperBuilderWithExistingConstuctorBuilderImpl extends SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<SuperBuilderWithExistingConstuctor, SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilderImpl> {
+    private SuperBuilderWithExistingConstuctorBuilderImpl() {
+      super();
+    }
+    protected @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilderImpl self() {
+      return this;
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithExistingConstuctor build() {
+      return new SuperBuilderWithExistingConstuctor(this);
+    }
+  }
+  public SuperBuilderWithExistingConstuctor() {
+    super();
+  }
+  protected @java.lang.SuppressWarnings("all") SuperBuilderWithExistingConstuctor(final SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<?, ?> b) {
+    super();
+  }
+  public static @java.lang.SuppressWarnings("all") SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilder<?, ?> builder() {
+    return new SuperBuilderWithExistingConstuctor.SuperBuilderWithExistingConstuctorBuilderImpl();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderWithExistingConstuctor.java
+++ b/test/transform/resource/before/SuperBuilderWithExistingConstuctor.java
@@ -1,0 +1,5 @@
+@lombok.experimental.SuperBuilder
+public class SuperBuilderWithExistingConstuctor {
+	public SuperBuilderWithExistingConstuctor() {
+	}
+}


### PR DESCRIPTION
Add `null` check to avoid NPE in Eclipse's `HandleSuperBuilder`.
Fixes #2704.