### PR TITLE
Add more Jackson annotations to the copy-to-setter list

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -325,7 +325,9 @@ public class HandlerUtil {
 			"com.fasterxml.jackson.annotation.JsonTypeInfo",
 			"com.fasterxml.jackson.annotation.JsonView",
 			"com.fasterxml.jackson.databind.annotation.JsonDeserialize",
+			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
+			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText",
 		}));
 		COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonAnySetter",


### PR DESCRIPTION
Also copy `@JacksonXmlElementWrapper` and `@JacksonXmlText` to setter methods, as discussed in #2654.