### PR TITLE
Print compact constructor after class name

### DIFF
--- a/src/delombok/lombok/delombok/PrettyPrinter.java
+++ b/src/delombok/lombok/delombok/PrettyPrinter.java
@@ -531,6 +531,9 @@ public class PrettyPrinter extends JCTree.Visitor {
 			print(tree.typarams, ", ");
 			print(">");
 		}
+		
+		if (isRecord) printRecordConstructor(tree.defs);
+		
 		JCTree extendsClause = getExtendsClause(tree);
 		if (extendsClause != null) {
 			print(" extends ");
@@ -541,8 +544,6 @@ public class PrettyPrinter extends JCTree.Visitor {
 			print(isInterface ? " extends " : " implements ");
 			print(tree.implementing, ", ");
 		}
-		
-		if (isRecord) printRecordConstructor(tree.defs);
 		
 		println(" {");
 		indent++;

--- a/test/pretty/resource/after/Record.java
+++ b/test/pretty/resource/after/Record.java
@@ -1,0 +1,3 @@
+public record Record<T>(T field) implements Cloneable {
+	
+}

--- a/test/pretty/resource/before/Record.java
+++ b/test/pretty/resource/before/Record.java
@@ -1,0 +1,4 @@
+// version 14:
+public record Record<T>(T field) implements Cloneable {
+	
+}


### PR DESCRIPTION
This PR fixes the wrong position of the compact constructor if the record implements an interface as mentioned in #2775