### PR TITLE
add @ToString.Format(foramtter = <? extends ToStringFormatter>.class)

### DIFF
--- a/src/core/lombok/ToString.java
+++ b/src/core/lombok/ToString.java
@@ -90,7 +90,7 @@ public @interface ToString {
 	
 	/**
 	 * Configure the behavior of how this member is rendered in the
-	 * {@code toString}; you should implement the {@code ToStringFormatter};
+	 * {@code toString}; You should implement the {@code ToStringFormatter};
 	 * interface then override the format method.
 	 */
 	@Target(ElementType.FIELD)

--- a/src/core/lombok/ToString.java
+++ b/src/core/lombok/ToString.java
@@ -89,6 +89,17 @@ public @interface ToString {
 	boolean onlyExplicitlyIncluded() default false;
 	
 	/**
+	 * Configure the behavior of how this member is rendered in the
+	 * {@code toString}; you should implement the {@code ToStringFormatter};
+	 * interface then override the format method.
+	 */
+	@Target(ElementType.FIELD)
+	@Retention(RetentionPolicy.SOURCE)
+	public @interface Format {
+		Class<? extends ToStringFormatter> formatter();
+	}
+	
+	/**
 	 * If present, do not include this field in the generated {@code toString}.
 	 */
 	@Target(ElementType.FIELD)

--- a/src/core/lombok/ToStringFormatter.java
+++ b/src/core/lombok/ToStringFormatter.java
@@ -1,0 +1,5 @@
+package lombok;
+
+public interface ToStringFormatter {
+	<T> String format(T field);
+}

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -1545,6 +1545,42 @@ public class EclipseHandlerUtil {
 		return call;
 	}
 	
+	/**
+	 * Creates an expression that calls a method on an external object whose
+	 * argument reads the field(Will either be {@code this.field} or
+	 * {@code this.getField()} depending on whether or not there's a getter).
+	 */
+	static Expression createFieldAccessor(EclipseNode field, FieldAccess fieldAccess, ASTNode source, String className, char[] methodName) {
+		
+		int pS = source == null ? 0 : source.sourceStart, pE = source == null ? 0 : source.sourceEnd;
+		long p = (long) pS << 32 | pE;
+		
+		className = className.substring(0, className.length() - 6);
+		String[] classNames = className.split("\\.");
+		long[] poss = {p};
+		char[][] tokens = new char[classNames.length][];
+		for (int i = 0; i < classNames.length; i++) {
+			tokens[i] = classNames[i].toCharArray();
+		}
+		
+		QualifiedTypeReference qtr = new QualifiedTypeReference(tokens, poss);
+		
+		AllocationExpression allocationExpression = new AllocationExpression();
+		allocationExpression.type = qtr;
+		
+		Expression[] arguments = {createFieldAccessor(field, fieldAccess, source)};
+		
+		MessageSend call = new MessageSend();
+		setGeneratedBy(call, source);
+		call.sourceStart = pS;
+		call.statementEnd = call.sourceEnd = pE;
+		call.receiver = allocationExpression;
+		setGeneratedBy(call.receiver, source);
+		call.selector = methodName;
+		call.arguments = arguments;
+		return call;
+	}
+	
 	static Expression createFieldAccessor(EclipseNode field, FieldAccess fieldAccess, ASTNode source, char[] receiver) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long)pS << 32 | pE;

--- a/src/core/lombok/eclipse/handlers/HandleToString.java
+++ b/src/core/lombok/eclipse/handlers/HandleToString.java
@@ -231,7 +231,13 @@ public class HandleToString extends EclipseAnnotationHandler<ToString> {
 			if (memberNode.getKind() == Kind.METHOD) {
 				memberAccessor = createMethodAccessor(memberNode, source);
 			} else {
-				memberAccessor = createFieldAccessor(memberNode, fieldAccess, source);
+				if (memberNode.hasAnnotation(ToString.Format.class)) {
+					AnnotationValues<ToString.Format> annot = memberNode.findAnnotation(ToString.Format.class);
+					String className = annot.getRawExpression("formatter").toString();
+					memberAccessor = createFieldAccessor(memberNode, fieldAccess, source, className, "format".toCharArray());
+				} else {
+					memberAccessor = createFieldAccessor(memberNode, fieldAccess, source);
+				}
 			}
 			
 			// The distinction between primitive and object will be useful if we ever add a 'hideNulls' option.

--- a/src/core/lombok/javac/handlers/HandleToString.java
+++ b/src/core/lombok/javac/handlers/HandleToString.java
@@ -206,7 +206,13 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 			if (memberNode.getKind() == Kind.METHOD) {
 				memberAccessor = createMethodAccessor(maker, memberNode);
 			} else {
-				memberAccessor = createFieldAccessor(maker, memberNode, fieldAccess);
+				if (memberNode.hasAnnotation(ToString.Format.class)) {
+					AnnotationValues<ToString.Format> annot = memberNode.findAnnotation(ToString.Format.class);
+					String className = annot.getRawExpression("formatter").toString();
+					memberAccessor = createFieldAccessor(maker, memberNode, fieldAccess, className, typeNode.toName("format"));
+				} else {
+					memberAccessor = createFieldAccessor(maker, memberNode, fieldAccess);
+				}
 			}
 			
 			JCExpression memberType = getFieldType(memberNode, fieldAccess);

--- a/test/transform/resource/after-delombok/ToStringFormatterStyle.java
+++ b/test/transform/resource/after-delombok/ToStringFormatterStyle.java
@@ -1,0 +1,33 @@
+import lombok.ToStringFormatter;
+
+public class ToStringFormatterStyle {
+
+	class PasswordFormat implements ToStringFormatter {
+		@Override
+		public <T> String format(T field) {
+			return "formatted : " + field;
+		}
+	}
+
+	private String password;
+
+
+	class CardNumberForamt implements ToStringFormatter {
+		@Override
+		public <T> String format(T field) {
+			return "formatted : " + field;
+		}
+	}
+
+	private long cardNumber;
+
+	public long getCardNumber() {
+		return this.cardNumber;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public java.lang.String toString() {
+		return "ToStringFormatterStyle(password=" + new PasswordFormat().format(this.password) + ", cardNumber=" + new CardNumberForamt().format(this.getCardNumber()) + ")";
+	}
+}

--- a/test/transform/resource/after-delombok/ToStringFormatterStyle.java
+++ b/test/transform/resource/after-delombok/ToStringFormatterStyle.java
@@ -1,15 +1,14 @@
 import lombok.ToStringFormatter;
 
 public class ToStringFormatterStyle {
-
-	class PasswordFormat implements ToStringFormatter {
-		@Override
-		public <T> String format(T field) {
-			return "formatted : " + field;
-		}
-	}
-
+	private String name;
 	private String password;
+	private int age;
+	private long cardNumber;
+
+	public long getCardNumber() {
+		return this.cardNumber;
+	}
 
 
 	class CardNumberForamt implements ToStringFormatter {
@@ -19,15 +18,17 @@ public class ToStringFormatterStyle {
 		}
 	}
 
-	private long cardNumber;
 
-	public long getCardNumber() {
-		return this.cardNumber;
+	class PasswordFormat implements ToStringFormatter {
+		@Override
+		public <T> String format(T field) {
+			return "formatted : " + field;
+		}
 	}
 
 	@java.lang.Override
 	@java.lang.SuppressWarnings("all")
 	public java.lang.String toString() {
-		return "ToStringFormatterStyle(password=" + new PasswordFormat().format(this.password) + ", cardNumber=" + new CardNumberForamt().format(this.getCardNumber()) + ")";
+		return "ToStringFormatterStyle(name=" + this.name + ", password=" + new PasswordFormat().format(this.password) + ", age=" + this.age + ", cardNumber=" + new CardNumberForamt().format(this.getCardNumber()) + ")";
 	}
 }

--- a/test/transform/resource/after-ecj/ToStringFormatterStyle.java
+++ b/test/transform/resource/after-ecj/ToStringFormatterStyle.java
@@ -1,14 +1,6 @@
 import lombok.ToStringFormatter;
 import lombok.ToString;
 public @ToString class ToStringFormatterStyle {
-  class PasswordFormat implements ToStringFormatter {
-    PasswordFormat() {
-      super();
-    }
-    public @Override <T>String format(T field) {
-      return ("formatted : " + field);
-    }
-  }
   class CardNumberForamt implements ToStringFormatter {
     CardNumberForamt() {
       super();
@@ -17,7 +9,17 @@ public @ToString class ToStringFormatterStyle {
       return ("formatted : " + field);
     }
   }
+  class PasswordFormat implements ToStringFormatter {
+    PasswordFormat() {
+      super();
+    }
+    public @Override <T>String format(T field) {
+      return ("formatted : " + field);
+    }
+  }
+  private String name;
   private @ToString.Format(formatter = PasswordFormat.class) String password;
+  private int age;
   private @ToString.Format(formatter = CardNumberForamt.class) long cardNumber;
   public ToStringFormatterStyle() {
     super();
@@ -26,6 +28,6 @@ public @ToString class ToStringFormatterStyle {
     return this.cardNumber;
   }
   public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
-    return (((("ToStringFormatterStyle(password=" + new PasswordFormat().format(this.password)) + ", cardNumber=") + new CardNumberForamt().format(this.getCardNumber())) + ")");
+    return (((((((("ToStringFormatterStyle(name=" + this.name) + ", password=") + new PasswordFormat().format(this.password)) + ", age=") + this.age) + ", cardNumber=") + new CardNumberForamt().format(this.getCardNumber())) + ")");
   }
 }

--- a/test/transform/resource/after-ecj/ToStringFormatterStyle.java
+++ b/test/transform/resource/after-ecj/ToStringFormatterStyle.java
@@ -1,0 +1,31 @@
+import lombok.ToStringFormatter;
+import lombok.ToString;
+public @ToString class ToStringFormatterStyle {
+  class PasswordFormat implements ToStringFormatter {
+    PasswordFormat() {
+      super();
+    }
+    public @Override <T>String format(T field) {
+      return ("formatted : " + field);
+    }
+  }
+  class CardNumberForamt implements ToStringFormatter {
+    CardNumberForamt() {
+      super();
+    }
+    public @Override <T>String format(T field) {
+      return ("formatted : " + field);
+    }
+  }
+  private @ToString.Format(formatter = PasswordFormat.class) String password;
+  private @ToString.Format(formatter = CardNumberForamt.class) long cardNumber;
+  public ToStringFormatterStyle() {
+    super();
+  }
+  public long getCardNumber() {
+    return this.cardNumber;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+    return (((("ToStringFormatterStyle(password=" + new PasswordFormat().format(this.password)) + ", cardNumber=") + new CardNumberForamt().format(this.getCardNumber())) + ")");
+  }
+}

--- a/test/transform/resource/before/ToStringFormatterStyle.java
+++ b/test/transform/resource/before/ToStringFormatterStyle.java
@@ -2,14 +2,15 @@ import lombok.ToStringFormatter;
 import lombok.ToString;
 
 public @ToString class ToStringFormatterStyle {
-	class PasswordFormat implements ToStringFormatter {
-		
-		@Override public <T> String format(T field) {
-			return "formatted : " + field;
-		}
-	}
 	
+	private String name;
 	@ToString.Format(formatter = PasswordFormat.class) private String password;
+	private int age;
+	@ToString.Format(formatter = CardNumberForamt.class) private long cardNumber;
+	
+	public long getCardNumber() {
+		return this.cardNumber;
+	}
 	
 	class CardNumberForamt implements ToStringFormatter {
 		
@@ -18,9 +19,10 @@ public @ToString class ToStringFormatterStyle {
 		}
 	}
 	
-	@ToString.Format(formatter = CardNumberForamt.class) private long cardNumber;
-	
-	public long getCardNumber() {
-		return this.cardNumber;
+	class PasswordFormat implements ToStringFormatter {
+		
+		@Override public <T> String format(T field) {
+			return "formatted : " + field;
+		}
 	}
 }

--- a/test/transform/resource/before/ToStringFormatterStyle.java
+++ b/test/transform/resource/before/ToStringFormatterStyle.java
@@ -1,0 +1,26 @@
+import lombok.ToStringFormatter;
+import lombok.ToString;
+
+public @ToString class ToStringFormatterStyle {
+	class PasswordFormat implements ToStringFormatter {
+		
+		@Override public <T> String format(T field) {
+			return "formatted : " + field;
+		}
+	}
+	
+	@ToString.Format(formatter = PasswordFormat.class) private String password;
+	
+	class CardNumberForamt implements ToStringFormatter {
+		
+		@Override public <T> String format(T field) {
+			return "formatted : " + field;
+		}
+	}
+	
+	@ToString.Format(formatter = CardNumberForamt.class) private long cardNumber;
+	
+	public long getCardNumber() {
+		return this.cardNumber;
+	}
+}


### PR DESCRIPTION
Add **@ToString.Format** to Configure the behavior of how this member is rendered in the toString method.
You should implement the **ToStringFormatter** interface then override the format method.
**This solution is compile time and does not depend on runtime, because we give the qualified name of the class to the formatter.**
for example : 
```
public class PasswordFormatter implements ToStringFormatter {
    @Override
    public <T> String format(T t) {
        return "formatted field : " + t;
    }
}
```
```
@Data
public class User {
    @ToString.Format(formatter = PasswordFormatter.class) // give the formatter the qualified name of the class.
    public long password;
}
```
thanks.
