### PR TITLE
Avoid reading file from disk by reusing the parser source

### DIFF
--- a/src/core/lombok/eclipse/EclipseAST.java
+++ b/src/core/lombok/eclipse/EclipseAST.java
@@ -232,6 +232,14 @@ public class EclipseAST extends AST<EclipseAST, EclipseNode, ASTNode> {
 		}
 	}
 	
+	public void setSource(char[] source) {
+		this.source = source;
+	}
+	
+	public char[] getSource() {
+		return source;
+	}
+	
 	/**
 	 * Eclipse starts off with a 'diet' parse which leaves method bodies blank, amongst other shortcuts.
 	 * 
@@ -309,6 +317,7 @@ public class EclipseAST extends AST<EclipseAST, EclipseNode, ASTNode> {
 	}
 	
 	private final CompilationUnitDeclaration compilationUnitDeclaration;
+	private char[] source;
 	private boolean completeParse;
 	
 	private static String toFileName(CompilationUnitDeclaration ast) {

--- a/src/core/lombok/eclipse/TransformEclipseAST.java
+++ b/src/core/lombok/eclipse/TransformEclipseAST.java
@@ -182,6 +182,7 @@ public class TransformEclipseAST {
 			DebugSnapshotStore.INSTANCE.snapshot(ast, "transform entry");
 			long histoToken = lombokTracker == null ? 0L : lombokTracker.start();
 			EclipseAST existing = getAST(ast, false);
+			existing.setSource(parser.scanner.getSource());
 			new TransformEclipseAST(existing).go();
 			if (lombokTracker != null) lombokTracker.end(histoToken);
 			DebugSnapshotStore.INSTANCE.snapshot(ast, "transform exit");

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -1057,7 +1057,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 	private void copyJavadocFromParam(EclipseNode from, MethodDeclaration to, TypeDeclaration type, String param) {
 		try {
 			CompilationUnitDeclaration cud = (CompilationUnitDeclaration) from.top().get();
-			String methodComment = getDocComment(cud, from.get());
+			String methodComment = getDocComment(from);
 			String newJavadoc = addReturnsThisIfNeeded(getParamJavadoc(methodComment, param));
 			setDocComment(cud, type, to, newJavadoc);
 		} catch (Exception ignore) {}


### PR DESCRIPTION
It seems like `compilationUnit.getContents()` is not always cached and can trigger some file system operations. By reusing the data that is already loaded by the parser we can avoid that.